### PR TITLE
Update QuickBooks_IPP_Service_CreditMemo class

### DIFF
--- a/QuickBooks/IPP/Service/CreditMemo.php
+++ b/QuickBooks/IPP/Service/CreditMemo.php
@@ -26,4 +26,20 @@ class QuickBooks_IPP_Service_CreditMemo extends QuickBooks_IPP_Service
 		$xml = null;
 		return parent::_findAll($Context, $realmID, QuickBooks_IPP_IDS::RESOURCE_CREDITMEMO, $xml);
 	}
+	
+	public function add($Context, $realmID, $Object)
+	{
+		return parent::_add($Context, $realmID, QuickBooks_IPP_IDS::RESOURCE_CREDITMEMO, $Object);
+	}	
+
+	public function query($Context, $realm, $query)
+	{
+		return parent::_query($Context, $realm, $query);
+	}
+
+	public function findById($Context, $realmID, $ID, $domain = null)
+	{
+		$xml = null;
+		return parent::_findById($Context, $realmID, QuickBooks_IPP_IDS::RESOURCE_CREDITMEMO, $ID, $domain, $xml);
+	}
 }


### PR DESCRIPTION
IPP v3 now supports adding credit memos.  I've added the required methods to the credit memo service class to make this possible as well as the other standard methods found in other QuickBooks_IPP_Service child classes.
