### PR TITLE
Fixing the "undefined constant QUICKBOOKS_OBJECT_XML_DROP" in the SalesOrder Object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,11 @@ local.properties
 # PDT-specific
 .buildpath
 
+#################
+## PHPStorm
+#################
+
+.idea
 
 #################
 ## Visual Studio

--- a/QuickBooks/QBXML/Object/SalesOrder.php
+++ b/QuickBooks/QBXML/Object/SalesOrder.php
@@ -796,7 +796,7 @@ class QuickBooks_QBXML_Object_SalesOrder extends QuickBooks_QBXML_Object
 	 * @param string $root
 	 * @return string
 	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null, $parent = null)
+	public function asQBXML($request, $todo_for_empty_elements = QuickBooks_QBXML_Object::XML_DROP, $indent = "\t", $root = null, $parent = null)
 	{
 		$this->_cleanup();
 		


### PR DESCRIPTION
This is the fix for the "undefined constant QUICKBOOKS_OBJECT_XML_DROP" in the SalesOrder Object.  I can change the other objects after I verify this fix is correct.

I also ignored the project folder that PHPStorm IDE creates (since there were other IDE ignores in there already).
