### PR TITLE
Allow grabbing of XML attributes onto QuickBooks_IPP_Object_* objects

### DIFF
--- a/QuickBooks/IPP/Parser.php
+++ b/QuickBooks/IPP/Parser.php
@@ -553,5 +553,14 @@ class QuickBooks_IPP_Parser
 				}
 			}*/		
 		}
+		
+		if ($Node->hasAttributes())
+		{
+			//Don't make a new object, just put it as a property of the same one
+			foreach ($Node->attributes() as $attr_name => $attr_value)
+			{
+				$Object->{'add' . $name . '_' . $attr_name}($attr_value);
+			}
+		}
 	}
 }


### PR DESCRIPTION
If a node has attributes (e.g. name), then add those as $name_{$attr_name} with the value of $attr_value.

The basic premise is that now you can get basic information (e.g. a name) from referenced entities.

Example: An Invoice Query (SELECT * FROM Invoice) has several <Line> items. Each item has, potentially, a <SalesItemLineDetail>. In there, an <ItemRef> tag has the item's actual ID, but in an XML Attribute called "name", it as the item's name. If we do not return that attribute, we would have to make a whole other round-trip call to retrieve the name of the item in question (SELECT * FROM Item WHERE id = '{ItemRef}').

This works similarly with customers, currency, etc.