### PR TITLE
Fixed issue with mysqli adapter not passing port

### DIFF
--- a/QuickBooks/Driver/Sql/Mysqli.php
+++ b/QuickBooks/Driver/Sql/Mysqli.php
@@ -308,7 +308,7 @@ class QuickBooks_Driver_SQL_Mysqli extends QuickBooks_Driver_Sql
 	{
 		if ($port)
 		{
-			$this->_conn = new mysqli($host, $user, $pass, $db) or die('host: ' . $host . ', user: ' . $user . ', pass: ' . $pass . ' mysqli_error(): ' . mysqli_connect_error());
+			$this->_conn = new mysqli($host, $user, $pass, $db, $port) or die('host: ' . $host . ', user: ' . $user . ', pass: ' . $pass . ' mysqli_error(): ' . mysqli_connect_error());
 		}
 		else
 		{


### PR DESCRIPTION
When passing a port in the database DSN, it does not get passed to the mysqli instance. This patch fixes this issue.