### PR TITLE
Authentication failure is now recorded in "QuickBooks_IPP_IntuitAnywhere::test" method

### DIFF
--- a/QuickBooks/IPP/IntuitAnywhere.php
+++ b/QuickBooks/IPP/IntuitAnywhere.php
@@ -174,6 +174,12 @@ class QuickBooks_IPP_IntuitAnywhere
 					$CustomerService = new QuickBooks_IPP_Service_Customer();
 					$customers = $CustomerService->query($Context, $creds['qb_realm'], "SELECT * FROM Customer MAXRESULTS 1");
 
+					if ( !$customers ) {
+						$this->_last_request = $CustomerService->lastRequest();
+						$this->_last_response = $CustomerService->lastResponse();
+						$this->_setError($CustomerService->errorCode(), $CustomerService->errorMessage());
+					}
+
 					$IPP->version($cur_version);		// Revert back to whatever they set 
 
 					//$IPP->baseURL($IPP->getBaseURL($Context, $creds['qb_realm']));


### PR DESCRIPTION
Before this PR, when user attempts to login with expired authentication token, then:

* he/she isn't getting any error back
* the "QuickBooks_IPP_IntuitAnywhere::test" method return `true`
* next executed command fails, because user isn't authenticated

After this PR, when user attempts to login with expired authentication token, then:

* both error code and error message of `CustomersService` is recorded and user is able to get them back
* the "QuickBooks_IPP_IntuitAnywhere::test" method return `false`
* any code using above method will properly react to the error and won't send any new commands to the server