### PR TITLE
Alias for QUICKBOOKS_QUERY_ENTITY & changed var_export to print_r

### DIFF
--- a/QuickBooks.php
+++ b/QuickBooks.php
@@ -490,6 +490,8 @@ define('QUICKBOOKS_MOD_EMPLOYEE', 'EmployeeMod');
 define('QUICKBOOKS_QUERY_EMPLOYEE', 'EmployeeQuery');
 define('QUICKBOOKS_IMPORT_EMPLOYEE', 'EmployeeImport');
 
+define('QUICKBOOKS_QUERY_ENTITY', 'EntityQuery');
+
 define('QUICKBOOKS_OBJECT_ESTIMATE', 'Estimate');
 define('QUICKBOOKS_ADD_ESTIMATE', 'EstimateAdd');
 define('QUICKBOOKS_MOD_ESTIMATE', 'EstimateMod');

--- a/QuickBooks/WebConnector/Handlers.php
+++ b/QuickBooks/WebConnector/Handlers.php
@@ -277,8 +277,8 @@ class QuickBooks_WebConnector_Handlers
 		
 		$this->_callback_config = $callback_config;
 		
-		//$this->_driver->log('Handler is starting up...: ' . var_export($this->_config, true), '', QUICKBOOKS_LOG_DEBUG);
-		$this->_log('Handler is starting up...: ' . var_export($this->_config, true), '', QUICKBOOKS_LOG_DEBUG);
+		//$this->_driver->log('Handler is starting up...: ' . print_r($this->_config, true), '', QUICKBOOKS_LOG_DEBUG);
+		$this->_log('Handler is starting up...: ' . print_r($this->_config, true), '', QUICKBOOKS_LOG_DEBUG);
 	}
 	
 	/**


### PR DESCRIPTION
1. Added alias for QUICKBOOKS_QUERY_ENTITY
2. Changed var_export to print_r => var_export does not handle circular references