### PR TITLE
Add support for invoice PDF route

### DIFF
--- a/QuickBooks/IPP.php
+++ b/QuickBooks/IPP.php
@@ -1055,6 +1055,11 @@ class QuickBooks_IPP
 			$url = $this->baseURL() . '/company/' . $realm . '/' . strtolower($resource) . $qs;
 			$xml = $xml_or_query;
 		}
+		else if ($optype == QuickBooks_IPP_IDS::OPTYPE_PDF)
+		{
+			$post = false;
+			$url = $this->baseURL() . '/company/' . $realm . '/' . strtolower($resource) . '/' . $ID . '/pdf';
+		}
 
 		$response = $this->_request($Context, QuickBooks_IPP::REQUEST_IDS, $url, $optype, $xml, $post);
 

--- a/QuickBooks/IPP/IDS.php
+++ b/QuickBooks/IPP/IDS.php
@@ -36,6 +36,8 @@ class QuickBooks_IPP_IDS
 
 	const OPTYPE_VOID = 'Void';
 
+	const OPTYPE_PDF = 'PDF';
+
 	const OPTYPE_QUERY = 'Query';
 
 	const OPTYPE_CDC = 'ChangeDataCapture';

--- a/QuickBooks/IPP/Service.php
+++ b/QuickBooks/IPP/Service.php
@@ -638,6 +638,15 @@ abstract class QuickBooks_IPP_Service
 		return false;
 	}
 
+	protected function _pdf($Context, $realmID, $resource, $ID)
+	{
+		// v3 only
+		$IPP = $Context->IPP();
+		$IPP->useIDSParser(false); // We want raw pdf output
+
+		return $IPP->IDS($Context, $realmID, $resource, QuickBooks_IPP_IDS::OPTYPE_PDF, null, $ID);
+	}
+
 	/**
 	 * @deprecated 			Use _update() instead
 	 */

--- a/QuickBooks/IPP/Service/Invoice.php
+++ b/QuickBooks/IPP/Service/Invoice.php
@@ -45,4 +45,9 @@ class QuickBooks_IPP_Service_Invoice extends QuickBooks_IPP_Service
 	{
 		return parent::_void($Context, $realmID, QuickBooks_IPP_IDS::RESOURCE_INVOICE, $IDType);
 	}
+
+	public function pdf($Context, $realmID, $IDType)
+	{
+		return parent::_pdf($Context, $realmID, QuickBooks_IPP_IDS::RESOURCE_INVOICE, $IDType);
+	}
 }


### PR DESCRIPTION
I was able to test this via 

```php
<?php

require_once dirname(__FILE__) . '/config.php';

$InvoiceService = new QuickBooks_IPP_Service_Invoice();

header('Content-type: application/pdf');
echo $InvoiceService->pdf($Context, $realm, 42);
```

If this is accepted, I'll create a second PR for adding this example to the docs. 