### PR TITLE
Fix redefinition of parameters fatal error for PHP7 compatibility

### DIFF
--- a/QuickBooks/Callbacks.php
+++ b/QuickBooks/Callbacks.php
@@ -1,50 +1,50 @@
 <?php
 
 /**
- * Centralized static QuickBooks callback methods 
+ * Centralized static QuickBooks callback methods
  *
  * Copyright (c) 2010 Keith Palmer / ConsoliBYTE, LLC.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.opensource.org/licenses/eclipse-1.0.php
- * 
+ *
  * As or release v1.5.3 all callback calling is being re-factored and
  * re-located to this file to ease maintainance of callbacks. Callbacks are now
  * supported as:
  * 	- functions
  * 	- static class methods
  * 	- object instance methods
- * 
+ *
  * @author Keith Palmer <keith@consolibyte.com>
  * @license LICENSE.txt
- * 
+ *
  * @package QuickBooks
  * @subpackage Callbacks
  */
 
 /**
- * 
+ *
  */
 define('QUICKBOOKS_CALLBACKS_TYPE_NONE', 'none');
 
 /**
- * 
+ *
  */
 define('QUICKBOOKS_CALLBACKS_TYPE_FUNCTION', 'function');
 
 /**
- * 
+ *
  */
 define('QUICKBOOKS_CALLBACKS_TYPE_STATIC_METHOD', 'static-method');
 
 /**
- * 
+ *
  */
 define('QUICKBOOKS_CALLBACKS_TYPE_OBJECT_METHOD', 'object-method');
 
 /**
- * 
+ *
  */
 define('QUICKBOOKS_CALLBACKS_TYPE_HOOK_INSTANCE', 'instanceof-hook');
 
@@ -60,55 +60,55 @@ class QuickBooks_Callbacks
 	const TYPE_STATIC_METHOD = 'static-method';
 
 	const TYPE_OBJECT_METHOD = 'object-method';
-	
+
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 */
 	static public function callAuthenticate($Driver, $callback, $username, $password, &$customauth_company_file, &$customauth_wait_before_next_update, &$customauth_min_run_every_n_seconds)
 	{
 		$type = QuickBooks_Callbacks::_type($callback, $Driver);
-		
+
 		if ($Driver)
 		{
 			// Log the callback for debugging
 			$Driver->log('Calling auth callback [' . $type . ']: ' . print_r($callback, true), null, QUICKBOOKS_LOG_DEVELOP);
 		}
-		
+
 		// Backward compat
 		if (is_string($callback))
 		{
 			$callback = str_replace('function://', '', $callback);
 		}
-		
+
 		// Make sure we can pass back an error
 		$which = 5;
-		
+
 		$err = null;
 		$ret = null;
-		
+
 		$vars = array( $username, $password, &$customauth_company_file, &$customauth_wait_before_next_update, &$customauth_min_run_every_n_seconds, &$err );
 		if ($type == QuickBooks_Callbacks::TYPE_OBJECT_METHOD)			// Object instance method hook
 		{
 			$object = $callback[0];
 			$method = $callback[1];
-			
+
 			if ($Driver)
 			{
 				$Driver->log('Calling auth instance method: ' . get_class($callback[0]) . '->' . $callback[1], null, QUICKBOOKS_LOG_VERBOSE);
 			}
-			
+
 			$ret = QuickBooks_Callbacks::_callObjectMethod( array( $object, $method ), $vars, $err, $which);
 		}
 		else if ($type == QuickBooks_Callbacks::TYPE_FUNCTION)		// Function hook
 		{
 			$err = '';
-			
+
 			if ($Driver)
 			{
 				$Driver->log('Calling auth function: ' . $callback, null, QUICKBOOKS_LOG_VERBOSE);
 			}
-			
+
 			$ret = QuickBooks_Callbacks::_callFunction($callback, $vars, $err, $which);
 		}
 		else if ($type == QuickBooks_Callbacks::TYPE_STATIC_METHOD)		// Static method hook
@@ -117,11 +117,11 @@ class QuickBooks_Callbacks
 			{
 				$Driver->log('Calling auth static method: ' . $callback, null, QUICKBOOKS_LOG_VERBOSE);
 			}
-			
+
 			//$tmp = explode('::', $callback);
 			//$class = trim(current($tmp));
 			//$method = trim(end($tmp));
-			
+
 			$ret = QuickBooks_Callbacks::_callStaticMethod($callback, $vars, $err, $which);
 		}
 		else
@@ -131,16 +131,16 @@ class QuickBooks_Callbacks
 				$Driver->log('Unsupported callback type for callback: ' . print_r($callback, true), null, QUICKBOOKS_LOG_VERBOSE);
 			}
 		}
-		
-		if ($err and 
+
+		if ($err and
 			$Driver)
 		{
 			$Driver->log('Auth callback error: ' . $err, null, QUICKBOOKS_LOG_VERBOSE);
 		}
-		
+
 		return $ret;
 	}
-	
+
 	static public function callSAMLCallback($Driver, $callback, $auth_id, $ticket, $target_url, $realm_id_pseudonym, $config, &$err)
 	{
 		/****  */
@@ -151,7 +151,7 @@ class QuickBooks_Callbacks
 
 		// Determine the type of hook
 		$type = QuickBooks_Callbacks::_type($callback, $Driver, $ticket);
-		
+
 		if ($Driver)
 		{
 			// Log the callback for debugging
@@ -160,31 +160,31 @@ class QuickBooks_Callbacks
 
 		// The 6th (start at 0: 0, 1, 2, 3, 4, 5) param is the error handler
 		$which = 5;
-		
+
 		//             0         1        2            3                    4        5
 		$vars = array( $auth_id, $ticket, $target_url, $realm_id_pseudonym, $config, &$err );
 		if ($type == QUICKBOOKS_CALLBACKS_TYPE_OBJECT_METHOD)			// Object instance method hook
 		{
 			$object = $callback[0];
 			$method = $callback[1];
-			
+
 			if ($Driver)
 			{
 				$Driver->log('Calling hook instance method: ' . get_class($callback[0]) . '->' . $callback[1], $ticket, QUICKBOOKS_LOG_VERBOSE);
 			}
-			
+
 			$ret = QuickBooks_Callbacks::_callObjectMethod( array( $object, $method ), $vars, $err, $which);
 			//$ret = call_user_func_array( array( $object, $method ), array( $requestID, $user, $hook, &$err, $hook_data, $callback_config) );
 		}
 		else if ($type == QUICKBOOKS_CALLBACKS_TYPE_FUNCTION)		// Function hook
 		{
 			$err = '';
-			
+
 			if ($Driver)
 			{
 				$Driver->log('Calling hook function: ' . $callback, $ticket, QUICKBOOKS_LOG_VERBOSE);
 			}
-			
+
 			$ret = QuickBooks_Callbacks::_callFunction($callback, $vars, $err, $which);
 			//$ret = $callback($requestID, $user, $hook, $err, $hook_data, $callback_config);
 			// 			$requestID, $user, $action, $ident, $extra, $err, $xml, $qb_identifier
@@ -195,11 +195,11 @@ class QuickBooks_Callbacks
 			{
 				$Driver->log('Calling hook static method: ' . $callback, $ticket, QUICKBOOKS_LOG_VERBOSE);
 			}
-			
+
 			//$tmp = explode('::', $callback);
 			//$class = trim(current($tmp));
 			//$method = trim(end($tmp));
-			
+
 			$ret = QuickBooks_Callbacks::_callStaticMethod($callback, $vars, $err, $which);
 			//$ret = call_user_func_array( array( $class, $method ), array( $requestID, $user, $hook, &$err, $hook_data, $callback_config) );
 		}
@@ -208,20 +208,20 @@ class QuickBooks_Callbacks
 			$err = 'Unsupported callback type for callback: ' . print_r($callback, true);
 			return false;
 		}
-		
+
 		//QuickBooks_Callbacks::_callFunction($function, &$vars, &$err, $which = null)
 		//QuickBooks_Callbacks::_callStaticMethod();
 		//QuickBooks_Callbacks::_callObjectMethod();
-		
+
 		// Pass on any error messages
 		$err = $vars[$which];
-		
+
 		return $ret;
 	}
-	
+
 	/**
 	 * Call a callback function
-	 * 
+	 *
 	 * @param string $function		A valid function name
 	 * @param array $vars			An array of arguments to the function
 	 * @param string $err			An error message will be passed back to this if an error occurs
@@ -235,17 +235,17 @@ class QuickBooks_Callbacks
 			$err = 'Callback does not exist: [function] ' . $function . '(...)';
 			return false;
 		}
-		
+
 		$ret = call_user_func_array($function, $vars);
-		
+
 		if (!is_null($which))
 		{
 			$err = $vars[$which];
 		}
-		
+
 		return $ret;
 	}
-	
+
 	/**
 	 * Call an object method callback (object instance method)
 	 *
@@ -259,23 +259,23 @@ class QuickBooks_Callbacks
 	{
 		$object = current($object_and_method);
 		$method = next($object_and_method);
-		
+
 		if (is_callable(array( $object, $method)))
 		{
 			$ret = call_user_func_array( array( $object, $method ), $vars);
-			
+
 			if (!is_null($which))
 			{
 				$err = $vars[$which];
 			}
-			
+
 			return $ret;
 		}
-		
-		$err = 'Object method does not exist: instance of ' . get_class($object) . '->' . $method . '(...)'; 
+
+		$err = 'Object method does not exist: instance of ' . get_class($object) . '->' . $method . '(...)';
 		return false;
 	}
-	
+
 	/**
 	 * Call a static method of a class and return the result
 	 *
@@ -290,34 +290,34 @@ class QuickBooks_Callbacks
 		$tmp = explode('::', $class_and_method);
 		$class = current($tmp);
 		$method = next($tmp);
-		
+
 		if (is_callable(array( $class, $method)))
 		{
 			$ret = call_user_func_array(array( $class, $method ), $vars);
-			
+
 			if (!is_null($which))
 			{
 				// *** WARNING *** This is a hack for just this _callStaticMethod routine, because the offset doesn't seem to be working correctly for static methods...
 				//$which = $which - 1;
-				
+
 				$err = $vars[$which];
 			}
-			
+
 			return $ret;
 		}
-		
+
 		$err = 'Static method does not exist: ' . $class . '::' . $method . '(...)';
 		return false;
 	}
-	
+
 	/**
 	 * Tell what type of callback this is (a function, an object instance method, a static method, etc.)
-	 * 
-	 * 
+	 *
+	 *
 	 */
 	static protected function _type(&$callback, $Driver = null, $ticket = null)
 	{
-		// This first section turns things like this:   array( 'MyClassName', 'myStaticMethod' )    into this:   'MyClassName::myStaticMethod' 
+		// This first section turns things like this:   array( 'MyClassName', 'myStaticMethod' )    into this:   'MyClassName::myStaticMethod'
 		if (is_array($callback))
 		{
 			if (isset($callback[0]) and
@@ -329,7 +329,7 @@ class QuickBooks_Callbacks
 			}
 			else if (isset($callback[0]) and
 					 isset($callback[1]) and
-					 is_object($callback[0]) and 
+					 is_object($callback[0]) and
 					 is_string($callback[1]))
 			{
 				; // Do nothing
@@ -340,12 +340,12 @@ class QuickBooks_Callbacks
 				{
 					$Driver->log('Invalid callback format: ' . print_r($callback, true), $ticket, QUICKBOOKS_LOG_NORMAL);
 				}
-				
+
 				return false;
 			}
 		}
-		
-		// This section actually determines the callback type 
+
+		// This section actually determines the callback type
 		if (!$callback)
 		{
 			return QUICKBOOKS_CALLBACKS_TYPE_NONE;
@@ -366,27 +366,27 @@ class QuickBooks_Callbacks
 		{
 			return QUICKBOOKS_CALLBACKS_TYPE_HOOK_INSTANCE;
 		}
-		
+
 		if ($Driver)
 		{
-			// Log this... 
+			// Log this...
 			$Driver->log('Could not determine callback type for: ' . print_r($callback, true), $ticket, QUICKBOOKS_LOG_NORMAL);
 		}
-		
+
 		return false;
 	}
-	
+
 	/**
-	 * 
-	 * 
-	 * 
+	 *
+	 *
+	 *
 	 */
-	
+
 	static public function callAPICallback($Driver, $ticket, $callback, $method, $action, $ID, &$err, $qbxml, $qbobject, $qbres)
 	{
 		// Determine the type of hook
 		$type = QuickBooks_Callbacks::_type($callback, $Driver, $ticket);
-		
+
 		if ($Driver)
 		{
 			// Log the callback for debugging
@@ -402,12 +402,12 @@ class QuickBooks_Callbacks
 		{
 			$object = $callback[0];
 			$method = $callback[1];
-			
+
 			if ($Driver)
 			{
 				$Driver->log('Calling hook instance method: ' . get_class($callback[0]) . '->' . $callback[1], $ticket, QUICKBOOKS_LOG_VERBOSE);
 			}
-			
+
 			$ret = QuickBooks_Callbacks::_callObjectMethod( array( $object, $method ), $vars, $err, $which);
 			//$ret = call_user_func_array( array( $object, $method ), array( $requestID, $user, $hook, &$err, $hook_data, $callback_config) );
 		}
@@ -417,7 +417,7 @@ class QuickBooks_Callbacks
 			{
 				$Driver->log('Calling hook function: ' . $callback, $ticket, QUICKBOOKS_LOG_VERBOSE);
 			}
-			
+
 			$ret = QuickBooks_Callbacks::_callFunction($callback, $vars, $err, $which);
 			//$ret = $callback($requestID, $user, $hook, $err, $hook_data, $callback_config);
 			// 			$requestID, $user, $action, $ident, $extra, $err, $xml, $qb_identifier
@@ -428,11 +428,11 @@ class QuickBooks_Callbacks
 			{
 				$Driver->log('Calling hook static method: ' . $callback, $ticket, QUICKBOOKS_LOG_VERBOSE);
 			}
-			
+
 			//$tmp = explode('::', $callback);
 			//$class = trim(current($tmp));
 			//$method = trim(end($tmp));
-			
+
 			$ret = QuickBooks_Callbacks::_callStaticMethod($callback, $vars, $err, $which);
 			//$ret = call_user_func_array( array( $class, $method ), array( $requestID, $user, $hook, &$err, $hook_data, $callback_config) );
 		}
@@ -441,21 +441,21 @@ class QuickBooks_Callbacks
 			$err = 'Unsupported callback type for callback: ' . print_r($callback, true);
 			return false;
 		}
-		
+
 		//QuickBooks_Callbacks::_callFunction($function, &$vars, &$err, $which = null)
 		//QuickBooks_Callbacks::_callStaticMethod();
 		//QuickBooks_Callbacks::_callObjectMethod();
-		
+
 		// Pass on any error messages
 		$err = $vars[$which];
-		
+
 		return $ret;
 	}
-	
-	
+
+
 	/**
 	 * Call a hook function / object method / static method
-	 * 
+	 *
 	 * @param QuickBooks_Driver $Driver		QuickBooks_Driver instance for logging
 	 * @param array $hooks					An array of arrays of hooks
 	 * @param string $hook					The hook to call
@@ -469,12 +469,12 @@ class QuickBooks_Callbacks
 	 */
 	static public function callHook($Driver, &$hooks, $hook, $requestID, $user, $ticket, &$err, $hook_data, $callback_config = array())
 	{
-		// There's a bug somewhere that passes a null value to this function... ? 
+		// There's a bug somewhere that passes a null value to this function... ?
 		if (!is_array($hooks))
 		{
 			$hooks = array();
 		}
-		
+
 		// First, clean up the hooks array
 		foreach ($hooks as $key => $value)
 		{
@@ -483,7 +483,7 @@ class QuickBooks_Callbacks
 				$hooks[$key] = array( $value );
 			}
 		}
-		
+
 		// Clean up the hook data
 		foreach (array( 'requestID' => $requestID, 'user' => $user, 'ticket' => $ticket ) as $key => $value)
 		{
@@ -491,40 +491,40 @@ class QuickBooks_Callbacks
 			{
 				$hook_data[$key] = $value;
 			}
-		}		
-		
+		}
+
 		// Check if the hook is set, if so, call it!
 		if (isset($hooks[$hook]))
 		{
-			// Drop a message in the log 
+			// Drop a message in the log
 			if ($Driver)
 			{
 				$Driver->log('Calling hooks for: ' . $hook, $ticket, QUICKBOOKS_LOG_VERBOSE);
 			}
-			
+
 			// Loop through the hooks
 			foreach ($hooks[$hook] as $callback)
 			{
 				// Determine the type of hook
 				$type = QuickBooks_Callbacks::_type($callback, $Driver, $ticket);
-				
+
 				if ($Driver)
 				{
 					// Log the callback for debugging
 					$Driver->log('Calling callback [' . $type . ']: ' . print_r($callback, true), $ticket, QUICKBOOKS_LOG_DEVELOP);
 				}
-				
+
 				$vars = array( $requestID, $user, $hook, &$err, $hook_data, $callback_config );
 				if ($type == QUICKBOOKS_CALLBACKS_TYPE_OBJECT_METHOD)			// Object instance method hook
 				{
 					$object = $callback[0];
 					$method = $callback[1];
-					
+
 					if ($Driver)
 					{
 						$Driver->log('Calling hook instance method: ' . get_class($callback[0]) . '->' . $callback[1], $ticket, QUICKBOOKS_LOG_VERBOSE);
 					}
-					
+
 					$ret = QuickBooks_Callbacks::_callObjectMethod( array( $object, $method ), $vars, $err);
 					//$ret = call_user_func_array( array( $object, $method ), array( $requestID, $user, $hook, &$err, $hook_data, $callback_config) );
 				}
@@ -534,7 +534,7 @@ class QuickBooks_Callbacks
 					{
 						$Driver->log('Calling hook function: ' . $callback, $ticket, QUICKBOOKS_LOG_VERBOSE);
 					}
-					
+
 					$ret = QuickBooks_Callbacks::_callFunction($callback, $vars, $err);
 					//$ret = $callback($requestID, $user, $hook, $err, $hook_data, $callback_config);
 					// 			$requestID, $user, $action, $ident, $extra, $err, $xml, $qb_identifier
@@ -545,30 +545,30 @@ class QuickBooks_Callbacks
 					{
 						$Driver->log('Calling hook static method: ' . $callback, $ticket, QUICKBOOKS_LOG_VERBOSE);
 					}
-					
+
 					//$tmp = explode('::', $callback);
 					//$class = trim(current($tmp));
 					//$method = trim(end($tmp));
-					
+
 					$ret = QuickBooks_Callbacks::_callStaticMethod($callback, $vars, $err);
 					//$ret = call_user_func_array( array( $class, $method ), array( $requestID, $user, $hook, &$err, $hook_data, $callback_config) );
 				}
 				else if ($type == QUICKBOOKS_CALLBACKS_TYPE_HOOK_INSTANCE)
 				{
-					// Just call the ->hook() method 
-					
+					// Just call the ->hook() method
+
 					if ($Driver)
 					{
 						$Driver->log('Calling hook instance: ' . get_class($callback), $ticket, QUICKBOOKS_LOG_VERBOSE);
 					}
-					
+
 					$ret = QuickBooks_Callbacks::_callObjectMethod( array( $callback, 'hook' ), $vars, $err);
 				}
 				else
 				{
 					return false;
 				}
-				
+
 				// If the hook returns FALSE, then *do not* run all of the other hooks, just return FALSE here
 				if ($ret == false)
 				{
@@ -576,39 +576,39 @@ class QuickBooks_Callbacks
 				}
 			}
 		}
-			
+
 		return true;
 	}
-	
+
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 */
-	static public function callRequestHandler($Driver, &$map, $requestID, $action, $user, $action, $ident, $extra, &$err, $last_action_time, $last_actionident_time, $version = '', $locale = array(), $callback_config = array(), $qbxml = null)
+	static public function callRequestHandler($Driver, &$map, $requestID, $action, $user, $ident, $extra, &$err, $last_action_time, $last_actionident_time, $version = '', $locale = array(), $callback_config = array(), $qbxml = null)
 	{
-		return QuickBooks_Callbacks::_callRequestOrResponseHandler($Driver, $map, $requestID, $action, 0, $user, $action, $ident, $extra, $err, $last_action_time, $last_actionident_time, $version, $locale, $callback_config, $qbxml);
+		return QuickBooks_Callbacks::_callRequestOrResponseHandler($Driver, $map, $requestID, $action, 0, $user, $ident, $extra, $err, $last_action_time, $last_actionident_time, $version, $locale, $callback_config, $qbxml);
 	}
-	
+
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 */
-	static public function callResponseHandler($Driver, &$map, $requestID, $action, $user, $action, $ident, $extra, &$err, $last_action_time, $last_actionident_time, $xml = '', $qb_identifiers = array(), $callback_config = array(), $qbxml = null)
+	static public function callResponseHandler($Driver, &$map, $requestID, $action, $user, $ident, $extra, &$err, $last_action_time, $last_actionident_time, $xml = '', $qb_identifiers = array(), $callback_config = array(), $qbxml = null)
 	{
-		return QuickBooks_Callbacks::_callRequestOrResponseHandler($Driver, $map, $requestID, $action, 1, $user, $action, $ident, $extra, $err, $last_action_time, $last_actionident_time, $xml, $qb_identifiers, $callback_config, $qbxml);
+		return QuickBooks_Callbacks::_callRequestOrResponseHandler($Driver, $map, $requestID, $action, 1, $user, $ident, $extra, $err, $last_action_time, $last_actionident_time, $xml, $qb_identifiers, $callback_config, $qbxml);
 	}
-	
+
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 * @todo Support for object instance callbacks
 	 */
-	static protected function _callRequestOrResponseHandler($Driver, &$map, $requestID, $action, $which, $user, $action, $ident, $extra, &$err, $last_action_time, $last_actionident_time, $xml_or_version = '', $qb_identifier_or_locale = array(), $callback_config = array(), $qbxml = null)
+	static protected function _callRequestOrResponseHandler($Driver, &$map, $requestID, $action, $which, $user, $ident, $extra, &$err, $last_action_time, $last_actionident_time, $xml_or_version = '', $qb_identifier_or_locale = array(), $callback_config = array(), $qbxml = null)
 	{
 		//print_r($map);
 		//print('action: ' . $action . "\n");
 		//print('which: ' . $which . "\n");
-		
+
 		if (isset($map[$action]))
 		{
 			$tmp =& $map[$action];
@@ -621,8 +621,8 @@ class QuickBooks_Callbacks
 		{
 			$tmp = null;
 		}
-		
-		// Call the appropriate callback function 
+
+		// Call the appropriate callback function
 		if (is_array($tmp))
 		{
 			if (isset($tmp[$which]))
@@ -630,30 +630,30 @@ class QuickBooks_Callbacks
 				$callback = $tmp[$which];
 				//$class = '';
 				//$method = '';
-				
+
 				/*if (false !== strpos($func, '::'))
 				{
 					$tmp = explode('::', $func);
 					$class = current($tmp);
 					$method = end($tmp);
 				}*/
-				
+
 				$type = QuickBooks_Callbacks::_type($callback, $Driver, null);
-				
+
 				//$requestID = QuickBooks_Utilities::constructRequestID($action, $ident);
 				$vars = array( $requestID, $user, $action, $ident, $extra, &$err, $last_action_time, $last_actionident_time, $xml_or_version, $qb_identifier_or_locale, $callback_config, $qbxml );
-				
+
 				// $class and $method and method_exists($class, $method))
 				if ($type == QUICKBOOKS_CALLBACKS_TYPE_OBJECT_METHOD)
 				{
 					$xml = QuickBooks_Callbacks::_callObjectMethod($callback, $vars, $err);
-					
+
 					return $xml;
 				}
 				else if ($type == QUICKBOOKS_CALLBACKS_TYPE_STATIC_METHOD)
 				{
 					$err = '';
-					
+
 					//if (version_compare(PHP_VERSION, '5.3.0', '>='))
 					//{
 					//	$xml = $class::$method($requestID, $user, $action, $ident, $extra, $err, $xml, $qb_identifier);
@@ -663,16 +663,16 @@ class QuickBooks_Callbacks
 						$xml = QuickBooks_Callbacks::_callStaticMethod($callback, $vars, $err);
 						//$xml = call_user_func(array( $class, $method ), $requestID, $user, $action, $ident, $extra, $err, $last_action_time, $last_actionident_time, $xml_or_version, $qb_identifier_or_locale, $callback_config, $qbxml);
 					//}
-					
+
 					return $xml;
 				}
 				else if ($type == QUICKBOOKS_CALLBACKS_TYPE_FUNCTION)
 				{
 					$err = '';
-					
+
 					$xml = QuickBooks_Callbacks::_callFunction($callback, $vars, $err);
 					//$xml = $func($requestID, $user, $action, $ident, $extra, $err, $last_action_time, $last_actionident_time, $xml_or_version, $qb_identifier_or_locale, $callback_config, $qbxml);
-					
+
 					return $xml;
 				}
 				else
@@ -680,7 +680,7 @@ class QuickBooks_Callbacks
 					// A function was registered, but the function doesn't exist
 					$err = 'Unknown callback type for: ' . $tmp[$which];
 				}
-				
+
 				if ($err)
 				{
 					$Driver->log('A request handler returned an error: ' . $err);
@@ -697,36 +697,36 @@ class QuickBooks_Callbacks
 			// There are *no* functions registered for that action
 			$err = 'No registered functions for action: ' . $action;
 		}
-		
-		return '';		
+
+		return '';
 	}
-	
+
 	static public function callAuth($Driver, $callback, $username, $password, &$qb_company_file, &$wait_before_next_update, &$min_run_every_n_seconds, &$err)
 	{
-		
+
 	}
-	
+
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 * @todo Support for object instance error handlers
-	 * 
+	 *
 	 */
 	static public function callErrorHandler($Driver, $errmap, $errnum, $errmsg, $user, $requestID, $action, $ident, $extra, &$errerr, $xml, $callback_config)
 	{
 		// $Driver, &$map, $action, $which, $user, $action, $ident, $extra, &$err, $last_action_time, $last_actionident_time, $xml_or_version = '', $qb_identifier_or_locale = array(), $callback_config = array(), $qbxml = null
-		
+
 		// Build the requestID
 		//$requestID = QuickBooks_Utilities::constructRequestID($action, $ident);
-		
+
 		$callback = '';
-		/*if (is_object($this->_instance_onerror) and 
+		/*if (is_object($this->_instance_onerror) and
 			method_exists($this->_instance_onerror, 'e' . $errnum))
 		{
 			$func = get_class($this->_instance_onerror) . '->e' . $errnum;
 		}*/
-		//else 
-		
+		//else
+
 		if (isset($errmap[$errnum]))	//  and function_exists($this->_onerror[$errnum])
 		{
 			$callback = $errmap[$errnum];
@@ -743,20 +743,20 @@ class QuickBooks_Callbacks
 		{
 			$callback = $errmap['*'];
 		}
-		
+
 		// Determine the type of hook
 		$type = QuickBooks_Callbacks::_type($callback, $Driver, null);
-		
+
 		$vars = array( $requestID, $user, $action, $ident, $extra, &$errerr, $xml, $errnum, $errmsg, $callback_config );
-		
+
 		$errerr = '';
 		if ($type == QUICKBOOKS_CALLBACKS_TYPE_OBJECT_METHOD)			// Object instance method hook
 		{
 			$Driver->log('Object method error handler: ' . get_class($callback[0]) . '->' . $callback[1], null, QUICKBOOKS_LOG_VERBOSE);
-			
+
 			$errerr = '';
 			$continue = QuickBooks_Callbacks::_callObjectMethod($callback, $vars, $errerr, 5);
-			
+
 			if ($errerr)
 			{
 				$Driver->log('Error handler returned an error: ' . $errerr, null, QUICKBOOKS_LOG_NORMAL);
@@ -766,13 +766,13 @@ class QuickBooks_Callbacks
 		else if ($type == QUICKBOOKS_CALLBACKS_TYPE_FUNCTION)		// Function hook
 		{
 			// It's a callback FUNCTION
-			
+
 			$Driver->log('Function error handler: ' . $callback, null, QUICKBOOKS_LOG_VERBOSE);
-				
+
 			$errerr = '';	// This is an error message *returned by* the error handler function
 			$continue = QuickBooks_Callbacks::_callFunction($callback, $vars, $errerr, 5);
 			//$continue = $func($requestID, $user, $action, $ident, $extra, $errerr, $xml, $errnum, $errmsg, $callback_config);
-			
+
 			if ($errerr)
 			{
 				$Driver->log('Error handler returned an error: ' . $errerr, null, QUICKBOOKS_LOG_NORMAL);
@@ -782,16 +782,16 @@ class QuickBooks_Callbacks
 		else if ($type == QUICKBOOKS_CALLBACKS_TYPE_STATIC_METHOD)		// Static method hook
 		{
 			// It's a callback STATIC METHOD
-			
+
 			//$tmp = explode('::', $func);
 			//$class = trim(current($tmp));
 			//$method = trim(end($tmp));
-			
+
 			$Driver->log('Static method error handler: ' . $callback, null, QUICKBOOKS_LOG_VERBOSE);
-			
+
 			$errerr = '';
 			$continue = QuickBooks_Callbacks::_callStaticMethod($callback, $vars, $errerr, 5);
-			
+
 			if ($errerr)
 			{
 				$Driver->log('Error handler returned an error: ' . $errerr, null, QUICKBOOKS_LOG_NORMAL);
@@ -802,7 +802,7 @@ class QuickBooks_Callbacks
 		{
 			return false;
 		}
-		
+
 		return $continue;
 	}
 }

--- a/QuickBooks/WebConnector/Handlers.php
+++ b/QuickBooks/WebConnector/Handlers.php
@@ -8,19 +8,19 @@
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.opensource.org/licenses/eclipse-1.0.php
- * 
- * The QuickBooks Web Connector requires that your SOAP server be able to 
- * handle six basic methods. Each of the six methods are implemented in this 
- * class and called by the QuickBooks_Server class instance. 
- * 
- * These methods in turn will call the action handlers you register with the 
- * SOAP server, and also log quite a bit of debugging information to the 
- * database so that you can see what's happening during the QBWC exchange with 
- * your SOAP server. 
- * 
+ *
+ * The QuickBooks Web Connector requires that your SOAP server be able to
+ * handle six basic methods. Each of the six methods are implemented in this
+ * class and called by the QuickBooks_Server class instance.
+ *
+ * These methods in turn will call the action handlers you register with the
+ * SOAP server, and also log quite a bit of debugging information to the
+ * database so that you can see what's happening during the QBWC exchange with
+ * your SOAP server.
+ *
  * @author Keith Palmer <keith@consolibyte.com>
  * @license LICENSE.txt
- * 
+ *
  * @package QuickBooks
  * @subpackage Server
  */
@@ -100,45 +100,45 @@ define('QUICKBOOKS_HANDLERS_HOOK_CLOSECONNECTION', 'QuickBooks_Handlers::closeCo
 define('QUICKBOOKS_HANDLERS_HOOK_CONNECTIONERROR', 'QuickBooks_Handlers::connectionError');
 
 /**
- * 
+ *
  */
 define('QUICKBOOKS_HANDLERS_HOOK_GETINTERACTIVEURL', 'QuickBooks_Handlers::getInteractiveURL');
 
 /**
- * 
+ *
  */
 define('QUICKBOOKS_HANDLERS_HOOK_GETLASTERROR', 'QuickBooks_Handlers::getLastError');
 
 /**
- * 
- * 
+ *
+ *
  */
 define('QUICKBOOKS_HANDLERS_HOOK_INTERACTIVEDONE', 'QuickBooks_Handlers::interactiveDone');
 
 /**
- * 
- * 
+ *
+ *
  */
 define('QUICKBOOKS_HANDLERS_HOOK_INTERACTIVEREJECTED', 'QuickBooks_Handlers::interactiveRejected');
 
 /**
- * 
- * 
+ *
+ *
  */
 define('QUICKBOOKS_HANDLERS_HOOK_RECEIVERESPONSEXML', 'QuickBooks_HandlersS::receiveResponseXML');
 
 /**
- * 
+ *
  */
 define('QUICKBOOKS_HANDLERS_HOOK_SENDREQUESTXML', 'QuickBooks_Handlers::sendRequestXML');
 
 /**
- * 
+ *
  */
 define('QUICKBOOKS_HANDLERS_HOOK_SERVERVERSION', 'QuickBooks_Handlers::serverVersion');
 
 /**
- * 
+ *
  */
 define('QUICKBOOKS_HANDLERS_HOOK_LOGINSUCCESS', 'QuickBooks_Handlers::login-success');
 
@@ -173,70 +173,70 @@ class QuickBooks_WebConnector_Handlers
 {
 	const HOOK_AUTHENTICATE = QUICKBOOKS_HANDLERS_HOOK_AUTHENTICATE;
 	const HOOK_LOGINSUCCESS = QUICKBOOKS_HANDLERS_HOOK_LOGINSUCCESS;
-	
+
 	/**
 	 * Driver object instance for backend of SOAP server
 	 * @var QuickBooks_Driver
 	 */
 	protected $_driver;
-	
+
 	/**
 	 * Raw XML input
 	 * @var string
 	 */
 	protected $_input;
-	
+
 	/**
 	 * Map of queued actions to function handlers
-	 * @var array 
+	 * @var array
 	 */
 	protected $_map;
-	
+
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 */
 	protected $_instance_map;
-	
+
 	/**
 	 * Map of error codes to function handler
-	 * @var array 
+	 * @var array
 	 */
 	protected $_onerror;
-	
+
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 */
 	protected $_instance_onerror;
-	
+
 	/**
 	 * Map of hook names to function handlers
-	 * @var array 
+	 * @var array
 	 */
 	protected $_hooks;
-	
+
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 */
-	protected $_instance_hooks;	
-	
+	protected $_instance_hooks;
+
 	/**
 	 * Configuration parameters
 	 * @var array
 	 */
 	protected $_config;
-	
+
 	/**
 	 * Callback configuration parameters
 	 * @var array
 	 */
 	protected $_callback_config;
-	
+
 	/**
 	 * Create the server handler instance
-	 * 
+	 *
 	 * Optional configuration items should be passed as an associative array with any of these keys:
 	 * 	- qb_company_file				The full filesystem path to a specific QuickBooks company file (by default, it will use the currently open company file)
 	 * 	- qbwc_min_version				Minimum version of the Web Connector that must be used to connect (by default, any version may connect)
@@ -246,7 +246,7 @@ class QuickBooks_WebConnector_Handlers
 	 * 	- server_version				Server version string
 	 * 	- authenticate_handler			If you want to use some custom authentication method, put the function name of your custom authentication function here
 	 * 	- autoadd_missing_requestid		This defaults to TRUE, if TRUE and you forget to embed a requestID="..." attribute, it will try to automatically add that attribute for you
-	 * 
+	 *
 	 * @param mixed $dsn_or_conn		DSN connection string for QuickBooks queue
 	 * @param array $map				A map of QuickBooks API calls to callback functions/methods
 	 * @param array $onerror			A map of QuickBooks error codes to callback functions/methods
@@ -261,7 +261,7 @@ class QuickBooks_WebConnector_Handlers
 		$this->_input = $input;
 		$this->_map = $map;
 		$this->_onerror = $onerror;
-		
+
 		$this->_hooks = array();
 		foreach ($hooks as $hook => $funcs)
 		{
@@ -269,23 +269,23 @@ class QuickBooks_WebConnector_Handlers
 			{
 				$funcs = array( $funcs );
 			}
-			
+
 			$this->_hooks[$hook] = $funcs;
 		}
-		
+
 		$this->_config = $this->_defaults($handler_config);
-		
+
 		$this->_callback_config = $callback_config;
-		
+
 		//$this->_driver->log('Handler is starting up...: ' . print_r($this->_config, true), '', QUICKBOOKS_LOG_DEBUG);
 		$this->_log('Handler is starting up...: ' . print_r($this->_config, true), '', QUICKBOOKS_LOG_DEBUG);
 	}
-	
+
 	/**
 	 * Massage any optional configuration flags
-	 * 
+	 *
 	 * @param array $config
-	 * @return array 
+	 * @return array
 	 */
 	protected function _defaults($config)
 	{
@@ -294,65 +294,65 @@ class QuickBooks_WebConnector_Handlers
 		{
 			$url = $_SERVER['REQUEST_URI'];
 		}
-		
+
 		$defaults = array(
-			'qb_company_file' => null,					// To force a specific company file to be used		
+			'qb_company_file' => null,					// To force a specific company file to be used
 			'qbwc_min_version' => null, 				// Minimum version of the QBWC that must be used to connect
 			'qbwc_wait_before_next_update' => null, 	// Tell the QBWC to wait this number of seconds before doing another update
 			'qbwc_min_run_every_n_seconds' => null,		// Tell the QBWC to run every n seconds (overrides whatever was in the .QWC web connector configuration file)
-			'qbwc_version_warning_message' => null,		// Not implemented... 
+			'qbwc_version_warning_message' => null,		// Not implemented...
 			'qbwc_version_error_message' => null,  		// Not implemented...
 			'qbwc_interactive_url' => null, 			// Provide the URL for an interactive session to the QuickBooks Web Connector
-			'autoadd_missing_requestid' => true,  
-			'check_valid_requestid' => true, 
+			'autoadd_missing_requestid' => true,
+			'check_valid_requestid' => true,
 			'server_version' => 'PHP QuickBooks SOAP Server v' . QUICKBOOKS_PACKAGE_VERSION . ' at ' . $url,	// Server version string
 			'authenticate' => null, 					// If you want to use some custom authentication scheme (and not the quickbooks_user MySQL table) you can specify your own function here
 			'authenticate_dsn' => null, 				//		(backward compat. for 'authenticate')
 			'map_application_identifiers' => true, 		// Try to map web application IDs to QuickBooks ListIDs/TxnIDs
-			'allow_remote_addr' => array(), 
-			'deny_remote_addr' => array(), 
-			'convert_unix_newlines' => true, 
-			
-			'deny_concurrent_logins' => true, 
-			'deny_concurrent_timeout' => 60, 
-			
-			'deny_reallyfast_logins' => true, 
-			'deny_reallyfast_timeout' => 600, 
-			
-			'masking' => true, 
+			'allow_remote_addr' => array(),
+			'deny_remote_addr' => array(),
+			'convert_unix_newlines' => true,
+
+			'deny_concurrent_logins' => true,
+			'deny_concurrent_timeout' => 60,
+
+			'deny_reallyfast_logins' => true,
+			'deny_reallyfast_timeout' => 600,
+
+			'masking' => true,
 			);
-			
+
 		$config = array_merge($defaults, $config);
-		
+
 		// Make sure this is an *array* of addresses to allow
 		if (!is_array($config['allow_remote_addr']))
 		{
 			$config['allow_remote_addr'] = array( $config['allow_remote_addr'] );
 		}
-		
+
 		// Make sure this is an *array* of addresses to deny
 		if (!is_array($config['deny_remote_addr']))
 		{
 			$config['deny_remote_addr'] = array( $config['deny_remote_addr'] );
 		}
-		
+
 		$config['autoadd_missing_requestid'] = (boolean) $config['autoadd_missing_requestid'];
 		$config['check_valid_requestid'] = (boolean) $config['check_valid_requestid'];
 		$config['map_application_identifiers'] = (boolean) $config['map_application_identifiers'];
 		$config['convert_unix_newlines'] = (boolean) $config['convert_unix_newlines'];
-		
+
 		$config['deny_concurrent_logins'] = (boolean) $config['deny_concurrent_logins'];
 		$config['deny_concurrent_timeout'] = (int) max(1, $config['deny_concurrent_timeout']);
-		
+
 		$config['deny_reallyfast_logins'] = (boolean) $config['deny_reallyfast_logins'];
 		$config['deny_reallyfast_timeout'] = (int) max(1, $config['deny_reallyfast_timeout']);
-		
+
 		return $config;
 	}
-		
+
 	/**
 	 * Check if a given remote address (IP address) is allowed based on allow and deny arrays
-	 * 
+	 *
 	 * @param string $remoteaddr
 	 * @param array $allow
 	 * @param array $deny
@@ -362,7 +362,7 @@ class QuickBooks_WebConnector_Handlers
 	{
 		return QuickBooks_Utilities::checkRemoteAddress($remoteaddr, $arr_allow, $arr_deny);
 	}
-	
+
 	/**
 	 * Log a message to the error/debug log
 	 *
@@ -374,25 +374,25 @@ class QuickBooks_WebConnector_Handlers
 	protected function _log($msg, $ticket, $level = QUICKBOOKS_LOG_NORMAL)
 	{
 		$Driver = $this->_driver;
-		
+
 		if ($this->_config['masking'])
 		{
 			$msg = QuickBooks_Utilities::mask($msg);
 		}
-		
+
 		if ($Driver)
 		{
 			return $Driver->log($msg, $ticket, $level);
 		}
-		
+
 		return false;
 	}
-	
+
 	/**
 	 * Queue up recurring events that are overdue to be run
-	 * 
+	 *
 	 * @param string $ticket
-	 * @return boolean 
+	 * @return boolean
 	 */
 	protected function _handleRecurringEvents($ticket)
 	{
@@ -402,62 +402,62 @@ class QuickBooks_WebConnector_Handlers
 			{
 				//$this->_driver->log('Dequeued a recurring event, enqueuing!', $ticket, QUICKBOOKS_LOG_VERBOSE);
 				$this->_log('Dequeued a recurring event, enqueuing!', $ticket, QUICKBOOKS_LOG_VERBOSE);
-				
+
 				$extra = null;
 				if ($next['extra'])
 				{
 					$extra = unserialize($next['extra']);
 				}
-				
+
 				//print_r($next);
-				
+
 				$hookerr = '';
-				$this->_callHook($ticket, 
-					QUICKBOOKS_HANDLERS_HOOK_RECURRING, 
-					null, 					//$this->_constructRequestID($next['qb_action'], $next['ident']), 
-					$next['qb_action'], 
-					$next['ident'], 
-					$extra, 
+				$this->_callHook($ticket,
+					QUICKBOOKS_HANDLERS_HOOK_RECURRING,
+					null, 					//$this->_constructRequestID($next['qb_action'], $next['ident']),
+					$next['qb_action'],
+					$next['ident'],
+					$extra,
 					$hookerr);
 				// $ticket, $hook, $requestID, $action, $ident, $extra, &$err, $xml = '', $qb_identifiers = array()
-				
+
 				//print_r($next);
 				//exit;
-				
+
 				// (boolean) $next['replace']
 				// 							$user, $action, $ident, $replace = true, $priority = 0, $extra = null, $qbxml = null
 				$this->_driver->queueEnqueue($user, $next['qb_action'], $next['ident'], true, (int) $next['priority'], $extra, $next['qbxml']);
 			}
-			
+
 			return true;
 		}
-		
-		return false;		
+
+		return false;
 	}
-	
+
 	/**
 	 * Authenticate method for the QuickBooks Web Connector SOAP service
-	 * 
-	 * The authenticate method is called when the Web Connector establishes a 
-	 * connection with the SOAP server in order to ensure that there is work to 
-	 * do and that the Web Connector is allowed to connect/that it actually is 
+	 *
+	 * The authenticate method is called when the Web Connector establishes a
+	 * connection with the SOAP server in order to ensure that there is work to
+	 * do and that the Web Connector is allowed to connect/that it actually is
 	 * the Web Connector that is connecting and sending us messages.
-	 * 
-	 * The stdClass object that is received as a parameter will have two 
+	 *
+	 * The stdClass object that is received as a parameter will have two
 	 * members:
 	 * 	- strUserName	The username provided in the QWC file to the Web Connector
 	 * 	- strPassword 	The password the end-user enters into the QuickBooks Web Connector application
-	 * 
-	 * The return object should be an array with two elements. The first 
-	 * element is a generated login ticket (or an empty string if the login 
-	 * failed) and the second string is either "none" (for successful log-ins 
-	 * with nothing to do in the queue) or "nvu" if the login failed. 
-	 * 
+	 *
+	 * The return object should be an array with two elements. The first
+	 * element is a generated login ticket (or an empty string if the login
+	 * failed) and the second string is either "none" (for successful log-ins
+	 * with nothing to do in the queue) or "nvu" if the login failed.
+	 *
 	 * The following user-defined hooks are invoked:
 	 * 	- QUICKBOOKS_HANDLERS_HOOK_AUTHENTICATE
 	 * 	- QUICKBOOKS_HANDLERS_HOOK_LOGINSUCCESS
 	 * 	- QUICKBOOKS_HANDLERS_HOOK_LOGINFAILURE
-	 * 
+	 *
 	 * @param stdClass $obj						The SOAP object that gets sent by the Web Connector
 	 * @return QuickBooks_Result_Authenticate	A container object to send back to the Web Connector
 	 */
@@ -465,97 +465,97 @@ class QuickBooks_WebConnector_Handlers
 	{
 		//$this->_driver->log('authenticate()', '', QUICKBOOKS_LOG_VERBOSE);
 		$this->_log('authenticate()', '', QUICKBOOKS_LOG_VERBOSE);
-		
+
 		$ticket = '';
 		$status = '';
-		
+
 		// Authenticate login hook
 		$hookdata = array(
-			'username' => $obj->strUserName, 
+			'username' => $obj->strUserName,
 			'password' => $obj->strPassword,
 			);
 		$hookerr = '';
 		$this->_callHook($ticket, QUICKBOOKS_HANDLERS_HOOK_AUTHENTICATE, null, null, null, null, $hookerr, null, array(), $hookdata);
-		
+
 		// Remote address allow/deny
 		if (false == $this->_checkRemote($_SERVER['REMOTE_ADDR'], $this->_config['allow_remote_addr'], $this->_config['deny_remote_addr']))
 		{
 			//$this->_driver->log('Connection from remote address rejected: ' . $_SERVER['REMOTE_ADDR'], null, QUICKBOOKS_LOG_VERBOSE);
 			$this->_log('Connection from remote address rejected: ' . $_SERVER['REMOTE_ADDR'], null, QUICKBOOKS_LOG_VERBOSE);
-			
+
 			return new QuickBooks_WebConnector_Result_Authenticate('', 'nvu', null, null);
 		}
-		
-		// If we do either concurrent login checks, or rate-limiting, we need to grab the date/time 
+
+		// If we do either concurrent login checks, or rate-limiting, we need to grab the date/time
 		//	of the last connection.
 		$authLast = null;
 		if ($this->_config['deny_concurrent_logins'] or $this->_config['deny_reallyfast_logins'])
 		{
 			$authlast = $this->_driver->authLast($obj->strUserName);
 		}
-		
+
 		// Check for concurrent logins
 		if ($this->_config['deny_concurrent_logins'])
 		{
-			if ($authlast and 
+			if ($authlast and
 				time() - strtotime($authlast[1]) < $this->_config['deny_concurrent_timeout'])
 			{
 				$this->_log('Denied concurrent login from: ' . $obj->strUserName, null, QUICKBOOKS_LOG_VERBOSE);
-			
+
 				return new QuickBooks_WebConnector_Result_Authenticate('CONC1234', 'none', null, null);
 			}
 		}
-		
+
 		// Rate-limiting
 		if ($this->_config['deny_reallyfast_logins'])
 		{
-			if ($authlast and 
+			if ($authlast and
 				time() - strtotime($authlast[1]) < $this->_config['deny_reallyfast_timeout'])
 			{
 				$this->_log('Denied really fast login from: ' . $obj->strUserName . ' (last login: ' . $authlast[1] . ')', null, QUICKBOOKS_LOG_VERBOSE);
-			
+
 				return new QuickBooks_WebConnector_Result_Authenticate('FAST1234', 'none', null, null);
 			}
 		}
-		
+
 		// Custom authentication backends
 		$override_dsn = $this->_config['authenticate'];
-		
+
 		if (!empty($this->_config['authenticate_dsn']))
 		{
 			// Backwards compat.
 			$override_dsn = $this->_config['authenticate_dsn'];
 		}
-		
+
 		$auth = null;
-		
+
 		/*
 		if (strlen($override_dsn))
 		{
 			$override_dsn = str_replace('function://', '', $override_dsn);
 		}
 		*/
-		
+
 		$company_file = null;
 		$wait_before_next_update = null;
 		$min_run_every_n_seconds = null;
-		
+
 		$customauth_company_file = null;
 		$customauth_wait_before_next_update = null;
 		$customauth_min_run_every_n_seconds = null;
-		
+
 		if (is_array($override_dsn) or strlen($override_dsn)) 	// Custom autj
 		{
-			//if ($auth->authenticate($obj->strUserName, $obj->strPassword, $customauth_company_file, $customauth_wait_before_next_update, $customauth_min_run_every_n_seconds) and 
-			
-			//if ($override_dsn($obj->strUserName, $obj->strPassword, $customauth_company_file, $customauth_wait_before_next_update, $customauth_min_run_every_n_seconds) and 
-			
-			if (QuickBooks_Callbacks::callAuthenticate($this->_driver, $override_dsn, $obj->strUserName, $obj->strPassword, $customauth_company_file, $customauth_wait_before_next_update, $customauth_min_run_every_n_seconds) and 
+			//if ($auth->authenticate($obj->strUserName, $obj->strPassword, $customauth_company_file, $customauth_wait_before_next_update, $customauth_min_run_every_n_seconds) and
+
+			//if ($override_dsn($obj->strUserName, $obj->strPassword, $customauth_company_file, $customauth_wait_before_next_update, $customauth_min_run_every_n_seconds) and
+
+			if (QuickBooks_Callbacks::callAuthenticate($this->_driver, $override_dsn, $obj->strUserName, $obj->strPassword, $customauth_company_file, $customauth_wait_before_next_update, $customauth_min_run_every_n_seconds) and
 				$ticket = $this->_driver->authLogin($obj->strUserName, $obj->strPassword, $company_file, $wait_before_next_update, $min_run_every_n_seconds, true))
 			{
 				//$this->_driver->log('Login (' . $parse['scheme'] . '): ' . $obj->strUserName, $ticket, QUICKBOOKS_LOG_DEBUG);
 				$this->_log('Login via ' . print_r($override_dsn, true) . ': ' . $obj->strUserName, $ticket, QUICKBOOKS_LOG_DEBUG);
-				
+
 				if ($customauth_company_file)
 				{
 					$status = $customauth_company_file;
@@ -568,7 +568,7 @@ class QuickBooks_WebConnector_Handlers
 				{
 					$status = $this->_config['qb_company_file'];
 				}
-				
+
 				if ((int) $customauth_wait_before_next_update)
 				{
 					$wait_before_next_update = (int) $customauth_wait_before_next_update;
@@ -581,69 +581,69 @@ class QuickBooks_WebConnector_Handlers
 				{
 					$wait_before_next_update = (int) $this->_config['qbwc_wait_before_next_update'];
 				}
-				
+
 				if ((int) $customauth_min_run_every_n_seconds)
 				{
 					$min_run_every_n_seconds = (int) $customauth_min_run_every_n_seconds;
 				}
 				else if ((int) $min_run_every_n_seconds)
 				{
-					; 
+					;
 				}
 				else if ((int) $this->_config['qbwc_min_run_every_n_seconds'])
 				{
 					$min_run_every_n_seconds = (int) $this->_config['qbwc_min_run_every_n_seconds'];
 				}
-				
+
 				// Call login hook
 				$hookdata = array(
-					'authenticate_dsn' => $override_dsn,  
-					'username' => $obj->strUserName, 
-					'password' => $obj->strPassword, 
-					'ticket' => $ticket, 
-					'qb_company_file' => $status, 
-					'qbwc_wait_before_next_update' => $wait_before_next_update, 
-					'qbwc_min_run_every_n_seconds' => $min_run_every_n_seconds, 
+					'authenticate_dsn' => $override_dsn,
+					'username' => $obj->strUserName,
+					'password' => $obj->strPassword,
+					'ticket' => $ticket,
+					'qb_company_file' => $status,
+					'qbwc_wait_before_next_update' => $wait_before_next_update,
+					'qbwc_min_run_every_n_seconds' => $min_run_every_n_seconds,
 					);
 				$hookerr = '';
 				$this->_callHook($ticket, QuickBooks_WebConnector_Handlers::HOOK_LOGINSUCCESS, null, null, null, null, $hookerr, null, array(), $hookdata);
-				
+
 				// Move any recurring events that are due to the queue table
 				$this->_handleRecurringEvents($ticket);
-				
+
 				if (!$this->_driver->queueDequeue($obj->strUserName))
 				{
 					$status = 'none';
 				}
-				
+
 				// Login success (with a custom login handler)!
 			}
 			else
 			{
 				//$this->_driver->log('Login failed (' . $parse['scheme'] . '): ' . $obj->strUserName, '', QUICKBOOKS_LOG_DEBUG);
 				$this->_log('Login failed: ' . $obj->strUserName, '', QUICKBOOKS_LOG_DEBUG);
-				
+
 				$hookdata = array(
-					'authenticate_dsn' => $override_dsn, 
-					'username' => $obj->strUserName, 
-					'password' => $obj->strPassword, 
+					'authenticate_dsn' => $override_dsn,
+					'username' => $obj->strUserName,
+					'password' => $obj->strPassword,
 					);
 				$hookerr = '';
 				$this->_callHook(null, QUICKBOOKS_HANDLERS_HOOK_LOGINFAILURE, null, null, null, null, $hookerr, null, array(), $hookdata);
-				
+
 				$ticket = '';
 				$status = 'nvu'; // Invalid username/password
 			}
-			
+
 			return new QuickBooks_WebConnector_Result_Authenticate($ticket, $status, $wait_before_next_update, $min_run_every_n_seconds);
-		} 
+		}
 		else	// Standard authentication
 		{
 			if ($ticket = $this->_driver->authLogin($obj->strUserName, $obj->strPassword, $company_file, $wait_before_next_update, $min_run_every_n_seconds))
 			{
 				//$this->_driver->log('Login: ' . $obj->strUserName, $ticket, QUICKBOOKS_LOG_DEBUG);
 				$this->_log('Login: ' . $obj->strUserName, $ticket, QUICKBOOKS_LOG_DEBUG);
-				
+
 				if (!strlen($company_file) and $this->_config['qb_company_file'])
 				{
 					$status = $this->_config['qb_company_file'];
@@ -652,80 +652,80 @@ class QuickBooks_WebConnector_Handlers
 				{
 					$status = $company_file;
 				}
-				
+
 				if (! (int) $wait_before_next_update and (int) $this->_config['qbwc_wait_before_next_update'])
 				{
 					$wait_before_next_update = (int) $this->_config['qbwc_wait_before_next_update'];
 				}
-				
+
 				if (! (int) $min_run_every_n_seconds and (int) $this->_config['qbwc_min_run_every_n_seconds'])
 				{
 					$min_run_every_n_seconds = (int) $this->_config['qbwc_min_run_every_n_seconds'];
 				}
-				
+
 				$hookdata = array(
-					'username' => $obj->strUserName, 
-					'password' => $obj->strPassword, 
-					'ticket' => $ticket, 
-					'qb_company_file' => $status, 
-					'qbwc_wait_before_next_update' => $wait_before_next_update, 
-					'qbwc_min_run_every_n_seconds' => $min_run_every_n_seconds, 
+					'username' => $obj->strUserName,
+					'password' => $obj->strPassword,
+					'ticket' => $ticket,
+					'qb_company_file' => $status,
+					'qbwc_wait_before_next_update' => $wait_before_next_update,
+					'qbwc_min_run_every_n_seconds' => $min_run_every_n_seconds,
 					);
 				$hookerr = '';
 				$this->_callHook($ticket, QUICKBOOKS_HANDLERS_HOOK_LOGINSUCCESS, null, null, null, null, $hookerr, null, array(), $hookdata);
-				
+
 				$this->_handleRecurringEvents($ticket);
-				
+
 				if (!$this->_driver->queueDequeue($obj->strUserName))
 				{
 					$status = 'none'; // Good login, but there isn't anything in the queue
 				}
-				
+
 				// Login success!
 			}
 			else
 			{
 				//$this->_driver->log('Login failed: ' . $obj->strUserName, '', QUICKBOOKS_LOG_DEBUG);
 				$this->_log('Login failed: ' . $obj->strUserName, '', QUICKBOOKS_LOG_DEBUG);
-				
+
 				$hookdata = array(
-					'username' => $obj->strUserName, 
-					'password' => $obj->strPassword, 
+					'username' => $obj->strUserName,
+					'password' => $obj->strPassword,
 					);
 				$hookerr = '';
 				$this->_callHook(null, QUICKBOOKS_HANDLERS_HOOK_LOGINFAILURE, null, null, null, null, $hookerr, null, array(), $hookdata);
-				
+
 				$ticket = '';
 				$status = 'nvu'; // Invalid username/password
 			}
-			
+
 			return new QuickBooks_WebConnector_Result_Authenticate($ticket, $status, $wait_before_next_update, $min_run_every_n_seconds);
 		}
 	}
-	
+
 	/**
 	 * SendRequestXML method for the QuickBooks Web Connector SOAP server - Generate and send a request to QuickBooks
-	 * 
-	 * The QuickBooks Web Connector calls this method to ask for things to do. 
-	 * So, calling this method is the Web Connectors way of saying: "Please 
-	 * send me a command so that I can pass that command on to QuickBooks." 
-	 * After it passes the command to QuickBooks, it will pass the response 
-	 * back via a call to receiveResponseXML(). 
-	 * 
-	 * The stdClass object passed as a parameter should contain these members: 
+	 *
+	 * The QuickBooks Web Connector calls this method to ask for things to do.
+	 * So, calling this method is the Web Connectors way of saying: "Please
+	 * send me a command so that I can pass that command on to QuickBooks."
+	 * After it passes the command to QuickBooks, it will pass the response
+	 * back via a call to receiveResponseXML().
+	 *
+	 * The stdClass object passed as a parameter should contain these members:
 	 * 	- ticket				The login session ticket
-	 *  - strHCPResponse		
-	 * 	- strCompanyFileName	
+	 *  - strHCPResponse
+	 * 	- strCompanyFileName
 	 * 	- qbXMLCountry			The country code for whatever version of QuickBooks is sitting behind the Web Connector
 	 * 	- qbXMLMajorVers		The major version code of the QuickBooks web connector
 	 * 	- qbXMLMinorVers 		The minor version code of the QuickBooks web connector
-	 * 
-	 * You should return either an empty string "" to signal an error state, or 
-	 * a valid qbXML or qbposXML request. 
-	 * 
+	 *
+	 * You should return either an empty string "" to signal an error state, or
+	 * a valid qbXML or qbposXML request.
+	 *
 	 * The following user-defined hooks are invoked by this method:
 	 * 	- QUICKBOOKS_HANDLERS_HOOK_SENDREQUESTXML
-	 * 
+	 *
 	 * @param stdClass $obj
 	 * @return QuickBooks_Result_SendRequestXML
 	 */
@@ -733,91 +733,91 @@ class QuickBooks_WebConnector_Handlers
 	{
 		//$this->_driver->log('sendRequestXML()', $obj->ticket, QUICKBOOKS_LOG_VERBOSE);
 		$this->_log('sendRequestXML()', $obj->ticket, QUICKBOOKS_LOG_VERBOSE);
-		
-		if ($this->_driver->authCheck($obj->ticket)) 
+
+		if ($this->_driver->authCheck($obj->ticket))
 		{
 			$user = $this->_driver->authResolve($obj->ticket);
-			
+
 			$hookdata = array(
-				'username' => 			$user, 
-				'ticket' => 			$obj->ticket, 
-				'strHCPResponse' => 	$obj->strHCPResponse, 
+				'username' => 			$user,
+				'ticket' => 			$obj->ticket,
+				'strHCPResponse' => 	$obj->strHCPResponse,
 				'strCompanyFileName' => $obj->strCompanyFileName,
-				'qbXMLCountry' => 		$obj->qbXMLCountry, 
-				'qbXMLMajorVers' => 	$obj->qbXMLMajorVers, 
-				'qbXMLMinorVers' => 	$obj->qbXMLMinorVers, 
+				'qbXMLCountry' => 		$obj->qbXMLCountry,
+				'qbXMLMajorVers' => 	$obj->qbXMLMajorVers,
+				'qbXMLMinorVers' => 	$obj->qbXMLMinorVers,
 				);
 			$hookerr = '';
 			$this->_callHook($obj->ticket, QUICKBOOKS_HANDLERS_HOOK_SENDREQUESTXML, null, null, null, null, $hookerr, null, array(), $hookdata);
 			// _callHook($ticket, $hook, $requestID, $action, $ident, $extra, &$err, $xml = '', $qb_identifiers = array(), $hook_data = array())
-			
+
 			// Move recurring events which are due to run to the queue table
-			// 	We *CAN'T* re-register recurring events here, otherwise, we run 
-			//	the risk of re-adding an event which has occured, *before* the 
-			//	entire session has finishing running. Thus, we'd create an 
-			//	infinite loop of web connector that would never end. 
+			// 	We *CAN'T* re-register recurring events here, otherwise, we run
+			//	the risk of re-adding an event which has occured, *before* the
+			//	entire session has finishing running. Thus, we'd create an
+			//	infinite loop of web connector that would never end.
 			//$this->_handleRecurringEvents($obj->ticket);
-			
+
 			if ($next = $this->_driver->queueDequeue($user, true)) // Fetch the next action/command from the queue
 			{
 				//$this->_driver->log('Dequeued: ( ' . $next['qb_action'] . ', ' . $next['ident'] . ' ) ', $obj->ticket, QUICKBOOKS_LOG_DEBUG);
 				$this->_log('Dequeued: ( ' . $next['qb_action'] . ', ' . $next['ident'] . ' ) ', $obj->ticket, QUICKBOOKS_LOG_DEBUG);
 				//$this->_driver->queueStatus($obj->ticket, $next['qb_action'], $next['ident'], QUICKBOOKS_STATUS_PROCESSING);
 				$this->_driver->queueStatus($obj->ticket, $next['quickbooks_queue_id'], QUICKBOOKS_STATUS_PROCESSING);
-				
+
 				/*
 				// Here's a strange case, interactive mode handler
 				if ($next['qb_action'] == QUICKBOOKS_INTERACTIVE_MODE)
 				{
 					// Set the error to "Interactive mode"
 					$this->_driver->errorLog($obj->ticket, QUICKBOOKS_ERROR_OK, QUICKBOOKS_INTERACTIVE_MODE);
-					
+
 					// This will cause ->getLastError() to be called, and ->getLastError() will then return the string "Interactive mode" which will cause QuickBooks to call ->getInteractiveURL() and start an interactive session... I think...?
 					return new QuickBooks_Result_SendRequestXML('');
 				}
 				*/
-				
+
 				$extra = '';
 				if ($next['extra'])
 				{
 					$extra = unserialize($next['extra']);
 				}
-				
+
 				$err = '';
 				$xml = '';
-				
+
 				//$last_action_time = $this->_driver->queueActionLast($user, $next['qb_action']);
 				//$last_actionident_time = $this->_driver->queueActionIdentLast($user, $next['qb_action'], $next['ident']);
 				$last_action_time = null;
 				$last_actionident_time = null;
-				
+
 				// Call the mapped function that should generate an appropriate qbXML request
 				$xml = $this->_callMappedFunction(0, $user, $next['quickbooks_queue_id'], $next['qb_action'], $next['ident'], $extra, $err, $last_action_time, $last_actionident_time, $obj->qbXMLMajorVers . '.' . $obj->qbXMLMinorVers, $obj->qbXMLCountry, $next['qbxml']);
-				
+
 				// Make sure there's no whitespace around it
 				$xml = trim($xml);
-				
+
 				// NoOp can be returned to skip this current operation. This will cause getLastError
 				//	to be called, at which point NoOp should be returned to tell the Web
-				//	Connector to then pause for 5 seconds before asking for another request. 
+				//	Connector to then pause for 5 seconds before asking for another request.
 				if ($xml == QUICKBOOKS_NOOP)
 				{
 					$this->_driver->errorLog($obj->ticket, 0, QUICKBOOKS_NOOP);
-					
+
 					// Mark it as a NoOp to remove it from the queue
 					//$this->_driver->queueStatus($obj->ticket, $next['qb_action'], $next['ident'], QUICKBOOKS_STATUS_NOOP, 'Handler function returned: ' . QUICKBOOKS_NOOP);
 					$this->_driver->queueStatus($obj->ticket, $next['quickbooks_queue_id'], QUICKBOOKS_STATUS_NOOP, 'Handler function returned: ' . QUICKBOOKS_NOOP);
-					
+
 					return new QuickBooks_WebConnector_Result_SendRequestXML('');
 				}
-				
+
 				// If the requestID="..." attribute was not specified, we can try to automatically add it to the request
 				$requestID = null;
-				if (!($requestID = $this->_extractRequestID($xml)) and 
+				if (!($requestID = $this->_extractRequestID($xml)) and
 					$this->_config['autoadd_missing_requestid'])
 				{
 					// Find the <DoSomethingRq tag
-					
+
 					foreach (QuickBooks_Utilities::listActions() as $action)
 					{
 						$request = QuickBooks_Utilities::actionToRequest($action);
@@ -838,66 +838,66 @@ class QuickBooks_WebConnector_Handlers
 				else if ($this->_config['check_valid_requestid'])
 				{
 					// They embedded a requestID="..." attribute, let's make sure it's valid
-					
+
 					//$embedded_action = null;
 					//$embedded_ident = null;
 					//$this->_parseRequestID($requestID, $embedded_action, $embedded_ident);
-					
+
 					//if ($embedded_action != $next['qb_action'] or $embedded_ident != $next['ident'])
 					if ($next['quickbooks_queue_id'] != $requestID)
 					{
 						// They are sending this request with an INVALID requestID! Error this out and warn them!
-						
+
 						$err = 'This request contains an invalid embedded requestID="..." attribute; either embed the $requestID parameter, or leave out the requestID="..." attribute entirely, found [' . $requestID . ' vs. expected ' . $next['quickbooks_queue_id'] . ']!';
 					}
 				}
-				
+
 				/*
-				if ($this->_config['convert_unix_newlines'] and 
+				if ($this->_config['convert_unix_newlines'] and
 					false === strpos($xml, "\r") and 				// there are currently no Windows newlines...
 					false !== strpos($xml, "\n"))					// ... but there *are* Unix newlines!
 				{
 					; // (this is currently broken/unimplemented)
 				}
 				*/
-				
+
 				if ($err) // The function encountered an error when generating the qbXML request
 				{
 					//$this->_driver->errorLog($obj->ticket, QUICKBOOKS_ERROR_HANDLER, $err);
 					//$this->_driver->log('ERROR: ' . $err, $obj->ticket, QUICKBOOKS_LOG_NORMAL);
 					//$this->_driver->queueStatus($obj->ticket, $next['qb_action'], $next['ident'], QUICKBOOKS_STATUS_ERROR, 'Registered handler returned error: ' . $err);
-					
+
 					$errerr = '';
 					//$this->_handleError($obj->ticket, QUICKBOOKS_ERROR_HANDLER, $err, $this->_constructRequestID($next['qb_action'], $next['ident']), $next['qb_action'], $next['ident'], $extra, $errerr, $xml);
 					$this->_handleError($obj->ticket, QUICKBOOKS_ERROR_HANDLER, $err, $next['quickbooks_queue_id'], $next['qb_action'], $next['ident'], $extra, $errerr, $xml);
-					
+
 					return new QuickBooks_WebConnector_Result_SendRequestXML('');
 				}
 				else
 				{
 					//$this->_driver->log('Outgoing XML request: ' . $xml, $obj->ticket, QUICKBOOKS_LOG_DEBUG);
 					$this->_log('Outgoing XML request: ' . $xml, $obj->ticket, QUICKBOOKS_LOG_DEBUG);
-					
-					if (strlen($xml) and  // Returned XML AND 
+
+					if (strlen($xml) and  // Returned XML AND
 						!$this->_extractRequestID($xml)) // Does not have a requestID in the request
 					{
 						// Mark it as successful right now
 						//$this->_driver->queueStatus($obj->ticket, $next['qb_action'], $next['ident'], QUICKBOOKS_STATUS_SUCCESS, 'Unverified... no requestID attribute in XML stream.');
 						$this->_driver->queueStatus($obj->ticket, $next['quickbooks_queue_id'], QUICKBOOKS_STATUS_SUCCESS, 'Unverified... no requestID attribute in XML stream.');
 					}
-					
+
 					return new QuickBooks_WebConnector_Result_SendRequestXML($xml);
 				}
 			}
 		}
-		
+
 		// Reporting an error, this will cause the QBWC to call ->getLastError()
 		return new QuickBooks_WebConnector_Result_SendRequestXML('');
 	}
-	
+
 	/**
 	 * Extract the requestID attribute from an XML stream
-	 * 
+	 *
 	 * @param string $xml	The XML stream to look for a requestID attribute in
 	 * @return mixed		The request ID
 	 */
@@ -905,10 +905,10 @@ class QuickBooks_WebConnector_Handlers
 	{
 		return QuickBooks_Utilities::extractRequestID($xml);
 	}
-	
+
 	/**
 	 * Create a requestID string from action and ident parts
-	 * 
+	 *
 	 * @param string $action
 	 * @param mixed $ident
 	 * @return string
@@ -919,10 +919,10 @@ class QuickBooks_WebConnector_Handlers
 		return QuickBooks_Utilities::constructRequestID($action, $ident);
 	}
 	*/
-	
+
 	/**
 	 * Parse a requestID string into it's action and ident parts
-	 * 
+	 *
 	 * @param string $requestID
 	 * @param string $action
 	 * @param mixed $ident
@@ -934,169 +934,169 @@ class QuickBooks_WebConnector_Handlers
 		return QuickBooks_Utilities::parseRequestID($requestID, $action, $ident);
 	}
 	*/
-	
+
 	/**
 	 * Extract a unique record identifier from an XML response
-	 * 
-	 * Some (most?) records within QuickBooks have unique identifiers which are 
-	 * returned with the qbXML responses. This method will try to extract all  
-	 * identifiers it can find from a qbXML response and return them in an 
-	 * associative array. 
-	 * 
-	 * For example, Customers have unique ListIDs, Invoices have unique TxnIDs, 
-	 * etc. For an AddCustomer request, you'll get an array that looks like 
+	 *
+	 * Some (most?) records within QuickBooks have unique identifiers which are
+	 * returned with the qbXML responses. This method will try to extract all
+	 * identifiers it can find from a qbXML response and return them in an
+	 * associative array.
+	 *
+	 * For example, Customers have unique ListIDs, Invoices have unique TxnIDs,
+	 * etc. For an AddCustomer request, you'll get an array that looks like
 	 * this:
 	 * <code>
 	 * array(
 	 * 	'ListID' => '2C0000-1039887390'
 	 * )
 	 * </code>
-	 * 
-	 * Other transactions might have more than one identifier. For instance, a 
+	 *
+	 * Other transactions might have more than one identifier. For instance, a
 	 * call to AddInvoice returns both a ListID and a TxnID:
 	 * <code>
 	 * array(
-	 * 	'ListID' => '200000-1036881887', // This is actually part of the 'CustomerRef' entity in the Invoice XML response 
+	 * 	'ListID' => '200000-1036881887', // This is actually part of the 'CustomerRef' entity in the Invoice XML response
 	 * 	'TxnID' => '11C26-1196256987', // This is the actual transaction ID for the Invoice XML response
 	 * )
 	 * </code>
-	 * 
-	 * *** IMPORTANT *** If there are duplicate fields (i.e.: 3 different 
-	 * ListIDs returned) then only the first value encountered will appear in 
-	 * the associative array.  
-	 * 
+	 *
+	 * *** IMPORTANT *** If there are duplicate fields (i.e.: 3 different
+	 * ListIDs returned) then only the first value encountered will appear in
+	 * the associative array.
+	 *
 	 * The following elements/attributes are supported:
 	 * 	- ListID
 	 * 	- TxnID
 	 * 	- iteratorID
 	 * 	- OwnerID
 	 * 	- TxnLineID
-	 * 
+	 *
 	 * @param string $xml	The XML stream to look for an identifier in
 	 * @return array		An associative array mapping identifier fields to identifier values
 	 */
 	protected function _extractIdentifiers($xml)
 	{
 		$fetch_tagdata = array(
-			'ListID', 
-			'TxnID', 
-			'OwnerID', 
-			'TxnLineID', 
+			'ListID',
+			'TxnID',
+			'OwnerID',
+			'TxnLineID',
 			'EditSequence',
-			'FullName', 
-			'Name', 
-			'RefNumber', 
+			'FullName',
+			'Name',
+			'RefNumber',
 			);
-		
+
 		$fetch_attributes = array(
-			'requestID',			
+			'requestID',
 			'iteratorID',
 			'iteratorRemainingCount',
-			'metaData', 
-			'retCount', 
-			'statusCode', 
-			'statusSeverity', 
-			'statusMessage', 
-			'newMessageSetID', 
-			'messageSetStatusCode', 
+			'metaData',
+			'retCount',
+			'statusCode',
+			'statusSeverity',
+			'statusMessage',
+			'newMessageSetID',
+			'messageSetStatusCode',
 			);
-		
+
 		$list = array();
-		
+
 		foreach ($fetch_tagdata as $tag)
 		{
-			if (false !== ($start = strpos($xml, '<' . $tag . '>')) and 
+			if (false !== ($start = strpos($xml, '<' . $tag . '>')) and
 				false !== ($end = strpos($xml, '</' . $tag . '>')))
 			{
 				$list[$tag] = substr($xml, $start + 2 + strlen($tag), $end - $start - 2 - strlen($tag));
 			}
 		}
-		
+
 		foreach ($fetch_attributes as $attribute)
 		{
-			if (false !== ($start = strpos($xml, ' ' . $attribute . '="')) and 
+			if (false !== ($start = strpos($xml, ' ' . $attribute . '="')) and
 				false !== ($end = strpos($xml, '"', $start + strlen($attribute) + 3)))
 			{
 				$list[$attribute] = substr($xml, $start + strlen($attribute) + 3, $end - $start - strlen($attribute) - 3);
 			}
 		}
-		
+
 		return $list;
 	}
-	
+
 	/**
 	 * Extract the status code from an XML response
-	 * 
-	 * Each qbXML response should return a status code and a status message 
-	 * indicating whether or not an error occured. 
-	 * 
+	 *
+	 * Each qbXML response should return a status code and a status message
+	 * indicating whether or not an error occured.
+	 *
 	 * @param string $xml	The XML stream to look for a response status code in
 	 * @return integer		The response status code (0 if OK, another positive integer if an error occured)
 	 */
 	protected function _extractStatusCode($xml)
 	{
-		if (false !== ($start = strpos($xml, ' statusCode="')) and 
+		if (false !== ($start = strpos($xml, ' statusCode="')) and
 			false !== ($end = strpos($xml, '"', $start + 13)))
 		{
 			return substr($xml, $start + 13, $end - $start - 13);
 		}
-		
+
 		return QUICKBOOKS_ERROR_OK;
 	}
-	
+
 	/**
 	 * Extract the status message from an XML response
-	 * 
-	 * Each qbXML response should return a status code and a status message 
-	 * indicating whether or not an error occured. 
-	 * 
+	 *
+	 * Each qbXML response should return a status code and a status message
+	 * indicating whether or not an error occured.
+	 *
 	 * @param string $xml	The XML stream to look for a response status message in
 	 * @return string		The response status message
 	 */
 	protected function _extractStatusMessage($xml)
 	{
-		if (false !== ($start = strpos($xml, ' statusMessage="')) and 
+		if (false !== ($start = strpos($xml, ' statusMessage="')) and
 			false !== ($end = strpos($xml, '"', $start + 16)))
 		{
 			return substr($xml, $start + 16, $end - $start - 16);
 		}
-		
+
 		return '';
 	}
-	
+
 	/**
-	 * Call the mapped function for a given action 
-	 * 
+	 * Call the mapped function for a given action
+	 *
 	 * @param integer $which			Whether or call the request action handler (pass a 0) or the response action handler (pass a 1)
 	 * @param string $user				QuickBooks username of the user the request/response is for
-	 * @param string $action			
-	 * @param mixed $ident				
+	 * @param string $action
+	 * @param mixed $ident
 	 * @param mixed $extra
 	 * @param string $err				If the function returns an error message, the error message will be stored here
 	 * @param integer $last_action_time
 	 * @param integer $last_actionident_time
 	 * @param string $xml				A qbXML response (if you're calling the response handler)
-	 * @param array $qb_identifier		
+	 * @param array $qb_identifier
 	 * @return string
 	 */
 	protected function _callMappedFunction($which, $user, $requestID, $action, $ident, $extra, &$err, $last_action_time, $last_actionident_time, $xml_or_version = '', $qb_identifier_or_locale = array(), $qbxml = null)
 	{
 		if ($which == 0)
 		{
-			return QuickBooks_Callbacks::callRequestHandler($this->_driver, $this->_map, $requestID, $action, $user, $action, $ident, $extra, $err, $last_action_time, $last_actionident_time, $xml_or_version, $qb_identifier_or_locale, $this->_callback_config, $qbxml);
+			return QuickBooks_Callbacks::callRequestHandler($this->_driver, $this->_map, $requestID, $action, $user, $ident, $extra, $err, $last_action_time, $last_actionident_time, $xml_or_version, $qb_identifier_or_locale, $this->_callback_config, $qbxml);
 		}
 		else if ($which == 1)
 		{
-			return QuickBooks_Callbacks::callResponseHandler($this->_driver, $this->_map, $requestID, $action, $user, $action, $ident, $extra, $err, $last_action_time, $last_actionident_time, $xml_or_version, $qb_identifier_or_locale, $this->_callback_config, $qbxml);
+			return QuickBooks_Callbacks::callResponseHandler($this->_driver, $this->_map, $requestID, $action, $user, $ident, $extra, $err, $last_action_time, $last_actionident_time, $xml_or_version, $qb_identifier_or_locale, $this->_callback_config, $qbxml);
 		}
-		
+
 		$err = 'Request for a mapped function could not be fulfilled, invalid $which parameter.';
 		return false;
 	}
-	
+
 	/**
-	 * Call a user-defined hook 
-	 * 
+	 * Call a user-defined hook
+	 *
 	 * @param string $ticket
 	 * @param string $hook
 	 * @param string $requestID
@@ -1116,23 +1116,23 @@ class QuickBooks_WebConnector_Handlers
 		{
 			$user = $this->_driver->authResolve($ticket);
 		}
-		
-		// Call the hook 
+
+		// Call the hook
 		$ret = QuickBooks_Callbacks::callHook($this->_driver, $this->_hooks, $hook, $requestID, $user, $ticket, $err, $hook_data, $this->_callback_config, __FILE__, __LINE__);
-		
+
 		// If the hook reported an error, log the error
 		if ($err)
 		{
 			$errerr = '';
 			$this->_handleError($ticket, QUICKBOOKS_ERROR_HOOK, $err, $requestID, $action, $ident, $extra, $errerr, $xml, $qb_identifiers);
 		}
-		
+
 		return true;
 	}
-	
+
 	/**
 	 * Call an error-handler function and update the status of a request to ERROR
-	 * 
+	 *
 	 * @param string $ticket
 	 * @param integer $errnum		The error number from QuickBooks (see the QuickBooks SDK/IDN for a list of error codes)
 	 * @param string $errmsg		The error message from QuickBooks
@@ -1148,7 +1148,7 @@ class QuickBooks_WebConnector_Handlers
 	{
 		// , $requestID, $user, $action, $ident, $extra, &$err, $xml, $qb_identifier
 		// Call the error handler (if one is set)
-		
+
 		$errmsg = html_entity_decode($errmsg);
 
 		// First, set the status of the item to error
@@ -1162,50 +1162,50 @@ class QuickBooks_WebConnector_Handlers
 		{
 			$this->_driver->queueStatus($ticket, $requestID, QUICKBOOKS_STATUS_ERROR, $errnum . ': ' . $errmsg);
 		}
-		
+
 		// Log the last error (for the ticket)
 		$this->_driver->errorLog($ticket, $errnum, $errmsg);
 		//$this->_driver->log('Attempting to handle error: ' . $errnum . ', ' . $errmsg);
 		$this->_log('Attempting to handle error: ' . $errnum . ', ' . $errmsg, $ticket, QUICKBOOKS_LOG_NORMAL);
-		
+
 		// By default, we don't want to continue if the error is not handled
 		$continue = false;
-		
+
 		// Get username of user which experienced the error
 		$user = $this->_driver->authResolve($ticket);
-		
-		// CALL THE ERROR HANDLER 
+
+		// CALL THE ERROR HANDLER
 		$err = '';
 		$continue = QuickBooks_Callbacks::callErrorHandler($this->_driver, $this->_onerror, $errnum, $errmsg, $user, $requestID, $action, $ident, $extra, $err, $xml, $this->_callback_config);
 		//													$Driver, $errmap, $errnum, $errmsg, $user, $action, $ident, $extra, &$errerr, $xml, $callback_config
-		
+
 		if ($err)
 		{
-			// Log error messages returned by the error handler 
+			// Log error messages returned by the error handler
 			//$this->_driver->log('An error occured while handling error: ' . $errnum . ': ' . $errmsg . ': ' . $err, $ticket, QUICKBOOKS_LOG_NORMAL);
 			$this->_log('An error occured while handling error: ' . $errnum . ': ' . $errmsg . ': ' . $err, $ticket, QUICKBOOKS_LOG_NORMAL);
 			$this->_driver->errorLog($ticket, QUICKBOOKS_ERROR_HANDLER, $err);
 		}
-		
+
 		// Log the last error (for the log)
 		//$this->_driver->log('Handled error: ' . $errnum . ': ' . $errmsg . ' (handler returned: ' . $continue . ')', $ticket, QUICKBOOKS_LOG_NORMAL);
 		$this->_log('Handled error: ' . $errnum . ': ' . $errmsg . ' (handler returned: ' . $continue . ')', $ticket, QUICKBOOKS_LOG_NORMAL);
-		
+
 		// Update the queue status
 		//if ($action and $ident)
-		if ($requestID and 
+		if ($requestID and
 			$continue)
 		{
 			//$this->_driver->queueStatus($ticket, $action, $ident, QUICKBOOKS_STATUS_HANDLED, $errnum . ': ' . $errmsg);
 			$this->_driver->queueStatus($ticket, $requestID, QUICKBOOKS_STATUS_HANDLED, $errnum . ': ' . $errmsg);
 		}
-		
+
 		return $continue;
 	}
-	
+
 	/**
 	 * Calculate the current progress (what percentage done are we with this session?)
-	 * 
+	 *
 	 * @param string $ticket
 	 * @return integer
 	 */
@@ -1214,26 +1214,26 @@ class QuickBooks_WebConnector_Handlers
 		if ($this->_driver->authCheck($ticket)) // Check the ticket
 		{
 			$user = $this->_driver->authResolve($ticket);
-			
+
 			$current = $this->_driver->queueLeft($user);				// Number of items currently in the queue
 			$processed = $this->_driver->queueProcessed($ticket);	// Number of items we've processed during this session
-			
+
 			$percentage = 100;
 			if ($current)
 			{
 				$percentage = min(99, floor(100 * ($processed / ($processed + $current))));
 			}
-			
+
 			// Call the percentage done hook
 			$hookerr = null;
 			$hookdata = array(
-				'user' => $user, 
-				'percentage' => $percentage, 
-				'items_left' => $current, 
-				'items_processed' => $processed, 
+				'user' => $user,
+				'percentage' => $percentage,
+				'items_left' => $current,
+				'items_processed' => $processed,
 				);
 			$this->_callHook($ticket, QUICKBOOKS_HANDLERS_HOOK_PERCENT, null, null, null, null, $hookerr, null, array(), $hookdata);
-			
+
 			if ($current)
 			{
 				return $percentage;
@@ -1243,27 +1243,27 @@ class QuickBooks_WebConnector_Handlers
 				return 100;
 			}
 		}
-		
-		return -1;		
+
+		return -1;
 	}
-	
+
 	/**
-	 * ReceiveResponseXML() method for the QuickBooks Web Connector - Receive and handle a resonse form QuickBooks 
-	 * 
-	 * The stdClass object passed as a parameter will have the following members: 
+	 * ReceiveResponseXML() method for the QuickBooks Web Connector - Receive and handle a resonse form QuickBooks
+	 *
+	 * The stdClass object passed as a parameter will have the following members:
 	 * 	- ->ticket 		The QuickBooks Web Connector ticket
 	 * 	- ->response	An XML response message
 	 * 	- ->hresult		Error code
 	 * 	- ->message		Error message
-	 * 
-	 * The sole data member of the returned object should be an integer. 
+	 *
+	 * The sole data member of the returned object should be an integer.
 	 * 	- The data member should be -1 if an error occured and QBWC should call ->getLastError()
 	 * 	- Should be an integer 0 <= x < 100 to indicate success *and* that the application should continue to call ->sendRequestXML() at least one more time (more queued items still in the queue, the integer represents the percentage complete the total batch job is)
 	 * 	- Should be 100 to indicate success *and* that the queue has been exhausted
-	 * 
+	 *
 	 * The following user-defined hooks are invoked:
 	 * 	- QUICKBOOKS_HANDLERS_HOOK_RECEIVERESPONSEXML
-	 * 
+	 *
 	 * @param stdClass $obj
 	 * @return QuickBooks_Result_ReceiveResponseXML
 	 */
@@ -1271,39 +1271,39 @@ class QuickBooks_WebConnector_Handlers
 	{
 		//$this->_driver->log('receiveResponseXML()', $obj->ticket, QUICKBOOKS_LOG_VERBOSE);
 		$this->_log('receiveResponseXML()', $obj->ticket, QUICKBOOKS_LOG_VERBOSE);
-		
+
 		if ($this->_driver->authCheck($obj->ticket)) // Check the ticket
 		{
 			$user = $this->_driver->authResolve($obj->ticket);
-			
+
 			$hookdata = array(
-				'username' => $user, 
-				'ticket' => $obj->ticket, 
+				'username' => $user,
+				'ticket' => $obj->ticket,
 				);
 			$hookerr = '';
 			$this->_callHook($obj->ticket, QUICKBOOKS_HANDLERS_HOOK_RECEIVERESPONSEXML, null, null, null, null, $hookerr, null, array(), $hookdata);
-			
+
 			//$this->_driver->log('Incoming XML response: ' . $obj->response, $obj->ticket, QUICKBOOKS_LOG_DEBUG);
 			$this->_log('Incoming XML response: ' . $obj->response, $obj->ticket, QUICKBOOKS_LOG_DEBUG);
-			
+
 			// Check if we got a error message...
-			if (strlen($obj->message) or 
+			if (strlen($obj->message) or
 				$this->_extractStatusCode($obj->response)) // or an error code
 			{
 				//$this->_log('Extracted code[' . $this->_extractStatusCode($obj->response) . ']', $obj->ticket, QUICKBOOKS_LOG_DEBUG);
-				
+
 				$action = null;
 				$ident = null;
 				$current = null;		// The current item we're receiving a response for
-				
+
 				$errnum = null;
 				if ($requestID = $this->_extractRequestID($obj->response))
 				{
-					// This happens if a data validation error occurs 
+					// This happens if a data validation error occurs
 					//	(string too long, vendor name already taken, etc.)
-					
+
 					$errnum = $this->_extractStatusCode($obj->response);
-					
+
 					if ($current = $this->_driver->queueGet($user, $requestID, QUICKBOOKS_STATUS_PROCESSING))
 					{
 						// This is the particular item that experienced an error
@@ -1314,7 +1314,7 @@ class QuickBooks_WebConnector_Handlers
 					{
 						$requestID = null;
 					}
-					
+
 					//$action = '';
 					//$ident = '';
 					//$this->_parseRequestID($requestID, $action, $ident);
@@ -1323,9 +1323,9 @@ class QuickBooks_WebConnector_Handlers
 				{
 					// This happens if a protocol error occurs
 					//	Poorly formed XML documents, missing XML node, missing line items, etc.)
-					
+
 					$errnum = $obj->hresult;
-					
+
 					// Try to guess at the request that caused an error (the last request that went out)
 					if ($current = $this->_driver->queueProcessing($user))
 					{
@@ -1334,11 +1334,11 @@ class QuickBooks_WebConnector_Handlers
 						$ident = $current['ident'];
 					}
 				}
-				
+
 				//if ($user and $action and $ident)
 				if ($current)
 				{
-					// Fetch the request that was processed and EXPERIENCED AN ERROR! 
+					// Fetch the request that was processed and EXPERIENCED AN ERROR!
 					$extra = null;
 					/*
 					if ($current = $this->_driver->queueFetch($user, $action, $ident, QUICKBOOKS_STATUS_PROCESSING))
@@ -1349,12 +1349,12 @@ class QuickBooks_WebConnector_Handlers
 						}
 					}
 					*/
-					
+
 					if ($current['extra'])
 					{
 						$extra = unserialize($current['extra']);
 					}
-					
+
 					$errmsg = null;
 					if ($obj->message)
 					{
@@ -1364,11 +1364,11 @@ class QuickBooks_WebConnector_Handlers
 					{
 						$errmsg = $status;
 					}
-					
+
 					$errerr = '';
 					$continue = $this->_handleError($obj->ticket, $errnum, $errmsg, $requestID, $action, $ident, $extra, $errerr, $obj->response, array());
 					//					$errnum, $errmsg, $requestID, $action, $ident, $extra, &$err, $xml, $qb_identifiers = array()
-					
+
 					if ($errerr)
 					{
 						// The error handler returned an error too...
@@ -1379,8 +1379,8 @@ class QuickBooks_WebConnector_Handlers
 				else	// Generic error (poorly encoded XML, XML syntax error, etc.)
 				{
 					$errerr = '';
-					$continue = $this->_handleError($obj->ticket, $obj->hresult, $obj->message, null, null, null, null, $errerr, $obj->response, array()); 
-					
+					$continue = $this->_handleError($obj->ticket, $obj->hresult, $obj->message, null, null, null, null, $errerr, $obj->response, array());
+
 					if ($errerr)
 					{
 						// The error handler returned an error too...
@@ -1388,27 +1388,27 @@ class QuickBooks_WebConnector_Handlers
 						$this->_log('An error occured while handling generic error ' . $obj->hresult . ': ' . $obj->message . ': ' . $errerr, $obj->ticket, QUICKBOOKS_LOG_NORMAL);
 					}
 				}
-				
+
 				// Calculate the percentage done
 				$progress = $this->_calculateProgress($obj->ticket);
-				
+
 				if (!$continue)
 				{
 					$progress = -1;
 				}
-				
+
 				//$this->_driver->log('Transaction error at ' . $progress . '% complete... ', $obj->ticket, QUICKBOOKS_LOG_VERBOSE);
 				$this->_log('Transaction error at ' . $progress . '% complete... ', $obj->ticket, QUICKBOOKS_LOG_VERBOSE);
-				
+
 				return new QuickBooks_WebConnector_Result_ReceiveResponseXML($progress);
 			}
-			
+
 			$extra = null;
 			$action = null;
 			$ident = null;
-			
+
 			$requestID = null;
-			if ($requestID = $this->_extractRequestID($obj->response) and 
+			if ($requestID = $this->_extractRequestID($obj->response) and
 				$current = $this->_driver->queueGet($user, $requestID, QUICKBOOKS_STATUS_PROCESSING))
 			{
 				//$action = current(explode('|', $requestID));
@@ -1418,10 +1418,10 @@ class QuickBooks_WebConnector_Handlers
 				$ident = '';
 				$this->_parseRequestID($requestID, $action, $ident);
 				*/
-				
+
 				$action = $current['qb_action'];
 				$ident = $current['ident'];
-				
+
 				// Fetch the request that's being processed
 				$extra = null;
 				/*
@@ -1433,12 +1433,12 @@ class QuickBooks_WebConnector_Handlers
 					}
 				}
 				*/
-				
+
 				if ($current['extra'])
 				{
 					$extra = unserialize($current['extra']);
 				}
-				
+
 				// Update the status to success (no error occured)
 				//$this->_driver->queueStatus($obj->ticket, $action, $ident, QUICKBOOKS_STATUS_SUCCESS);
 				$this->_driver->queueStatus($obj->ticket, $requestID, QUICKBOOKS_STATUS_SUCCESS);
@@ -1447,18 +1447,18 @@ class QuickBooks_WebConnector_Handlers
 			{
 				// It's a good response... but we couldn't fetch the requestID for some reason?
 				$this->_log('This appears to be a correct response, but the requestID could not be validated... ', $obj->ticket, QUICKBOOKS_LOG_VERBOSE);
-				
+
 				$progress = -1;
-				
+
 				return new QuickBooks_WebConnector_Result_ReceiveResponseXML($progress);
 			}
-			
+
 			// Extract ListID, TxnID, etc. from the response
 			$identifiers = $this->_extractIdentifiers($obj->response);
-			
+
 			//$this->_driver->log(var_export($identifiers, true), $obj->ticket, QUICKBOOKS_LOG_VERBOSE);
-			
-			// Auto-map $ident unique identifier from web application to the QuickBooks ListID or TxnID 
+
+			// Auto-map $ident unique identifier from web application to the QuickBooks ListID or TxnID
 			/*
 			if ($this->_config['map_application_identifiers'])
 			{
@@ -1466,13 +1466,13 @@ class QuickBooks_WebConnector_Handlers
 				$mods = QuickBooks_Utilities::listActions('*Mod*');
 				$qbkey = QuickBooks_Utilities::keyForAction($action);
 				$type = QuickBooks_Utilities::actionToObject($action);
-				
+
 				$EditSequence = '';
 				if (isset($identifiers['EditSequence']))
 				{
 					$EditSequence = $identifiers['EditSequence'];
 				}
-				
+
 				if (in_array($action, $adds) and isset($identifiers[$qbkey]) and $type)
 				{
 					// Try to map the $ident to the QuickBooks identifier
@@ -1481,57 +1481,57 @@ class QuickBooks_WebConnector_Handlers
 				else if (in_array($action, $mods) and isset($identifiers[$qbkey]) and $type)
 				{
 					// Try to map the $ident to the QuickBooks identifier
-					$this->_driver->identMap($user, $type, $ident, $identifiers[$qbkey], $EditSequence);					
+					$this->_driver->identMap($user, $type, $ident, $identifiers[$qbkey], $EditSequence);
 				}
 			}
 			*/
-			
+
 			$err = null;
 			//$last_action_time = $this->_driver->queueActionLast($user, $action);
 			//$last_actionident_time = $this->_driver->queueActionIdentLast($user, $action, $ident);
 			$last_action_time = null;
 			$last_actionident_time = null;
-				
-			//if ($ident) // If they didn't pass a requestID, $ident will not be set, and we can't call this reliably 
+
+			//if ($ident) // If they didn't pass a requestID, $ident will not be set, and we can't call this reliably
 			if ($requestID)
 			{
 				$this->_callMappedFunction(1, $user, $requestID, $action, $ident, $extra, $err, $last_action_time, $last_actionident_time, $obj->response, $identifiers);
 			}
-			
+
 			// Calculate the percentage done
 			$progress = $this->_calculateProgress($obj->ticket);
-			
+
 			if ($err)
 			{
 				$errerr = '';
 				$continue = $this->_handleError($obj->ticket, QUICKBOOKS_ERROR_HANDLER, $err, $requestID, $action, $ident, $extra, $errerr, $obj->response, $identifiers);
-				
+
 				if (!$continue)
 				{
 					$progress = -1;
 				}
 			}
-			
+
 			//$this->_driver->log($progress . '% complete... ', $obj->ticket, QUICKBOOKS_LOG_VERBOSE);
 			$this->_log($progress . '% complete... ', $obj->ticket, QUICKBOOKS_LOG_VERBOSE);
-			
+
 			return new QuickBooks_WebConnector_Result_ReceiveResponseXML($progress);
 		}
-		
+
 		return new QuickBooks_WebConnector_Result_ReceiveResponseXML(-1);
 	}
 
 	/**
 	 * QuickBooks Web Connector ->connectionError() SOAP method
-	 * 
+	 *
 	 * The stdClass object passed in as a parameter has these members:
 	 * 	- ->ticket 		The ticket string
 	 * 	- ->hresult		An error code
 	 * 	- ->message 	An error message from QuickBooks/QBWC
-	 * 
+	 *
 	 * The following user-defined hooks are invoked:
 	 * 	- QUICKBOOKS_HANDLERS_HOOK_CONNECTIONERROR
-	 * 
+	 *
 	 * @param stdClass $obj
 	 * @return QuickBooks_Result_ConnectionError
 	 */
@@ -1539,112 +1539,112 @@ class QuickBooks_WebConnector_Handlers
 	{
 		//$this->_driver->log('connectionErrorXML()', $obj->ticket, QUICKBOOKS_LOG_VERBOSE);
 		$this->_log('connectionErrorXML()', $obj->ticket, QUICKBOOKS_LOG_VERBOSE);
-		
+
 		if ($this->_driver->authCheck($obj->ticket))
 		{
 			$user = $this->_driver->authResolve($obj->ticket);
-			
+
 			$hookdata = array(
-				'username' => $user, 
-				'ticket' => $obj->ticket, 
-				'hresult' => $obj->hresult, 
-				'message' => $obj->message, 
+				'username' => $user,
+				'ticket' => $obj->ticket,
+				'hresult' => $obj->hresult,
+				'message' => $obj->message,
 				);
 			$hookerr = '';
 			$this->_callHook($obj->ticket, QUICKBOOKS_HANDLERS_HOOK_CONNECTIONERROR, null, null, null, null, $hookerr, null, array(), $hookdata);
-			
+
 			$err = '';
 			$this->_handleError($obj->ticket, $obj->hresult, $obj->message, null, null, null, null, $err, null);
-			
+
 			return new QuickBooks_WebConnector_Result_ConnectionError('done');
 		}
-		
+
 		return new QuickBooks_WebConnector_Result_ConnectionError('done');
 	}
 
 	/**
 	 * QuickBooks Web Connector ->getLastError() SOAP method
-	 * 
+	 *
 	 * The stdClass object passed in as a parameter has these members:
 	 * 	- ->ticket		The ticket string
-	 * 
-	 * The returned object should have just one member, an error message 
+	 *
+	 * The returned object should have just one member, an error message
 	 * describing the last error that occured.
-	 * 
+	 *
 	 * The following user-defined hooks are invoked:
 	 * 	- QUICKBOOKS_HANDLERS_HOOK_GETLASTERROR
-	 * 
+	 *
 	 * @return QuickBooks_Result_GetLastError
 	 */
 	public function getLastError($obj)
 	{
 		//$this->_driver->log('getLastError()', $obj->ticket, QUICKBOOKS_LOG_VERBOSE);
 		$this->_log('getLastError()', $obj->ticket, QUICKBOOKS_LOG_VERBOSE);
-		
+
 		if ($this->_driver->authCheck($obj->ticket))
 		{
 			$user = $this->_driver->authResolve($obj->ticket);
-			
+
 			$hookdata = array(
-				'username' => $user, 
-				'ticket' => $obj->ticket, 
+				'username' => $user,
+				'ticket' => $obj->ticket,
 				);
 			$hookerr = '';
 			$this->_callHook($obj->ticket, QUICKBOOKS_HANDLERS_HOOK_GETLASTERROR, null, null, null, null, $hookerr, null, array(), $hookdata);
-			
+
 			$lasterr = $this->_driver->errorLast($obj->ticket);
-			
+
 			return new QuickBooks_WebConnector_Result_GetLastError($lasterr);
 		}
-	
+
 		return new QuickBooks_WebConnector_Result_GetLastError('Bad ticket.');
 	}
-	
+
 	/**
 	 * QuickBooks Web Connector ->closeConnection() SOAP method
-	 * 
+	 *
 	 * The stdClass object passed in as a parameter has these members:
 	 * 	- ->ticket 		The ticket string
-	 * 
+	 *
 	 * The sole member of the returned object should be a string describing the reason for closing the connection
-	 * 
+	 *
 	 * @todo The "Complete!" message should probably be based on a configuration variable, user configurable
-	 * 
+	 *
 	 * The following user-defined hooks are invoked:
 	 * 	- QUICKBOOKS_HANDLERS_HOOK_CLOSECONNECTION
-	 * 
+	 *
 	 * @return QuickBooks_Result_CloseConnection
 	 */
 	public function closeConnection($obj)
 	{
 		//$this->_driver->log('closeConnection()', $obj->ticket, QUICKBOOKS_LOG_VERBOSE);
 		$this->_log('closeConnection()', $obj->ticket, QUICKBOOKS_LOG_VERBOSE);
-		
+
 		if ($this->_driver->authCheck($obj->ticket))
 		{
 			$user = $this->_driver->authResolve($obj->ticket);
-			
+
 			$hookdata = array(
-				'username' => $user, 
-				'ticket' => $obj->ticket, 
+				'username' => $user,
+				'ticket' => $obj->ticket,
 				);
 			$hookerr = '';
 			$this->_callHook($obj->ticket, QUICKBOOKS_HANDLERS_HOOK_CLOSECONNECTION, null, null, null, null, $hookerr, null, array(), $hookdata);
-			
-			// 
+
+			//
 			return new QuickBooks_WebConnector_Result_CloseConnection('Complete!');
 		}
-		
+
 		// Bad ticket
 		return new QuickBooks_WebConnector_Result_CloseConnection('Bad ticket.');
 	}
-	
+
 	/**
 	 * QuickBooks Web Connector ->getServerVersion() SOAP method
-	 * 
+	 *
 	 * The following user-defined hooks are invoked:
 	 * 	- QUICKBOOKS_HANDLERS_HOOK_SERVERVERSION
-	 * 
+	 *
 	 * @param stdClass $obj
 	 * @return QuickBooks_Result_GetServerVersion
 	 */
@@ -1652,34 +1652,34 @@ class QuickBooks_WebConnector_Handlers
 	{
 		//$this->_driver->log('serverVersion()', '', QUICKBOOKS_LOG_VERBOSE);
 		$this->_log('serverVersion()', '', QUICKBOOKS_LOG_VERBOSE);
-		
+
 		$hookdata = array(  );
 		$hookerr = '';
 		$this->_callHook(null, QUICKBOOKS_HANDLERS_HOOK_SERVERVERSION, null, null, null, null, $hookerr, null, array(), $hookdata);
-		
+
 		return new QuickBooks_WebConnector_Result_ServerVersion($this->_config['server_version']);
 	}
-	
+
 	/**
 	 * QuickBooks Web Connector ->clientVersion() SOAP method - Receive the QuickBooks Web Connector client version (and, if neccessary, act on it)
-	 * 
-	 * This is an *optional* method, and not all versions of the QuickBooks Web 
-	 * Connector will support this method. It doesn't really even *need* to be 
-	 * implemented, but PHP will dump notices in our error log if we don't 
-	 * implement it and then the web connector tries to call it. 
-	 * 
+	 *
+	 * This is an *optional* method, and not all versions of the QuickBooks Web
+	 * Connector will support this method. It doesn't really even *need* to be
+	 * implemented, but PHP will dump notices in our error log if we don't
+	 * implement it and then the web connector tries to call it.
+	 *
 	 * The stdClass object passed as a parameter will have the following members:
 	 * 	- strVersion	A string version code indicating the version of the QuickBooks Web Connector that's being used
-	 * 
+	 *
 	 * The one member of the returned object should be:
 	 * 	- The empty string to tell the web connector to continue with the update
 	 * 	- A string that begins with "W:" to display a warning message to the end-user, specify the warning message after the "W:"
 	 * 	- A string that begins with "E:" to display an error message to the end-user, specify the error message after the "E:"
 	 * 	- A string that begins with "O:" (as in OKAY) to tell the end-user that the server expects a newer version of the web connector, specify the minimum required version after the "O:"
-	 * 
+	 *
 	 * The following user-defined hooks are invovked:
 	 * 	- QUICKBOOKS_HANDLERS_HOOK_CLIENTVERSION
-	 * 
+	 *
 	 * @param stdClass $obj
 	 * @return QuickBooks_Result_ClientVersion
 	 */
@@ -1687,35 +1687,35 @@ class QuickBooks_WebConnector_Handlers
 	{
 		//$this->_driver->log('clientVersion()', '', QUICKBOOKS_LOG_VERBOSE);
 		$this->_log('clientVersion()', '', QUICKBOOKS_LOG_VERBOSE);
-		
+
 		$hookdata = array();
 		$hookerr = '';
 		$this->_callHook(null, QUICKBOOKS_HANDLERS_HOOK_CLIENTVERSION, null, null, null, null, $hookerr, null, array(), $hookdata);
-		
+
 		if (!is_null($this->_config['qbwc_min_version']))
 		{
 			if (version_compare($obj->strVersion, $this->_config['qbwc_min_version'], '<'))
 			{
 				//$this->_driver->log('Version Requirement, current: ' . $obj->strVersion . ', required: ' . $this->_config['qbwc_min_version'], '', QUICKBOOKS_LOG_NORMAL);
 				$this->_log('Version Requirement, current: ' . $obj->strVersion . ', required: ' . $this->_config['qbwc_min_version'], '', QUICKBOOKS_LOG_NORMAL);
-				
+
 				return new QuickBooks_WebConnector_Result_ClientVersion('O:' . $this->_config['qbwc_min_version']);
 			}
 		}
 
 		return new QuickBooks_WebConnector_Result_ClientVersion('');
 	}
-	
+
 	/**
 	 * QuickBooks Web Connector ->getInteractiveURL() SOAP method - Get the URL to use for an interactive session
-	 * 
+	 *
 	 * The stdClass object passed as a parameter will have the following members:
 	 * 	- ticket		The ticket string
 	 * 	- sessionID		??? (undocumented in QBWC documentation...?)
-	 * 
+	 *
 	 * The following user-defined hooks are invoked:
 	 * 	- QUICKBOOKS_HANDLERS_HOOK_GETINTERACTIVEURL
-	 * 
+	 *
 	 * @param stdClass $obj
 	 * @return QuickBooks_Result_GetInteractiveURL
 	 */
@@ -1724,29 +1724,29 @@ class QuickBooks_WebConnector_Handlers
 	{
 		//$this->_driver->log('getInteractiveURL()', $obj->ticket, QUICKBOOKS_LOG_VERBOSE);
 		$this->_log('getInteractiveURL()', $obj->ticket, QUICKBOOKS_LOG_VERBOSE);
-		
+
 		if ($this->_driver->authCheck($obj->ticket))
 		{
 			$user = $this->_driver->authResolve($obj->ticket);
-			
+
 			$hookdata = array(
-				'username' => $user, 
-				'ticket' => $obj->ticket, 
+				'username' => $user,
+				'ticket' => $obj->ticket,
 				);
 			$hookerr = '';
 			$this->_callHook($obj->ticket, QUICKBOOKS_HANDLERS_HOOK_GETINTERACTIVEURL, null, null, null, null, $hookerr, null, array(), $hookdata);
-			
+
 			return new QuickBooks_Result_GetInteractiveURL($this->_config['qbwc_interactive_url']);
 		}
-		
+
 		return new QuickBooks_Result_GetInteractiveURL('');
 	}
 	*/
-	
+
 	/**
-	 * 
+	 *
 	 * @todo Implement this... returned object is null!
-	 * 
+	 *
 	 * @param stdClass $obj
 	 * @return void
 	 */
@@ -1755,31 +1755,31 @@ class QuickBooks_WebConnector_Handlers
 	{
 		//$this->_driver->log('interactiveRejected()', $obj->ticket, QUICKBOOKS_LOG_VERBOSE);
 		$this->_log('interactiveRejected()', $obj->ticket, QUICKBOOKS_LOG_VERBOSE);
-		
+
 		if ($this->_driver->authCheck($obj->ticket))
 		{
 			$user = $this->_driver->authResolve($obj->ticket);
-			
+
 			$hookdata = array(
-				'username' => $user, 
-				'ticket' => $obj->ticket, 
+				'username' => $user,
+				'ticket' => $obj->ticket,
 				);
 			$hookerr = '';
 			$this->_callHook($obj->ticket, QUICKBOOKS_HANDLERS_HOOK_GETINTERACTIVEURL, null, null, null, null, $hookerr, null, array(), $hookdata);
-			
+
 			return null;
 		}
-		
+
 		return null;
 	}
 	*/
-	
+
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 * The stdClass object passed as a parameter will have the following members:
 	 * 	- ticket
-	 * 
+	 *
 	 * @param stdClass $obj
 	 * @return QuickBooks_Result_InteractiveDone
 	 */
@@ -1788,21 +1788,21 @@ class QuickBooks_WebConnector_Handlers
 	{
 		//$this->_driver->log('interactiveDone()', $obj->ticket, QUICKBOOKS_LOG_VERBOSE);
 		$this->_log('interactiveDone()', $obj->ticket, QUICKBOOKS_LOG_VERBOSE);
-		
+
 		if ($this->_driver->authCheck($obj->ticket))
 		{
 			$user = $this->_driver->authResolve($obj->ticket);
-			
+
 			$hookdata = array(
-				'username' => $user, 
-				'ticket' => $obj->ticket, 
+				'username' => $user,
+				'ticket' => $obj->ticket,
 				);
 			$hookerr = '';
 			$this->_callHook($obj->ticket, QUICKBOOKS_HANDLERS_HOOK_INTERACTIVEDONE, null, null, null, null, $hookerr, null, array(), $hookdata);
-			
+
 			return new QuickBooks_Result_InteractiveDone('Done');
 		}
-		
+
 		return new QuickBooks_Result_InteractiveDone('');
 	}
 	*/

--- a/QuickBooks/WebConnector/Queue/Singleton.php
+++ b/QuickBooks/WebConnector/Queue/Singleton.php
@@ -1,24 +1,24 @@
 <?php
 
-/** 
+/**
  * QuickBooks singleton class for the queueing class
- * 
+ *
  * Copyright (c) {2010-04-16} {Keith Palmer / ConsoliBYTE, LLC.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.opensource.org/licenses/eclipse-1.0.php
- * 
- * Web Connector applications will often use the queueing class within many 
- * different functions within the applications. It is desireable then to always 
- * use a single instance of the queueing class to avoid unneccessary database 
- * connections and code cruft. This singleton class provides a way to use a 
- * single instance of the queueing class without resorting to the use of 
- * globals.  
- * 
+ *
+ * Web Connector applications will often use the queueing class within many
+ * different functions within the applications. It is desireable then to always
+ * use a single instance of the queueing class to avoid unneccessary database
+ * connections and code cruft. This singleton class provides a way to use a
+ * single instance of the queueing class without resorting to the use of
+ * globals.
+ *
  * @author Keith Palmer <keith@consolibyte.com>
  * @license LICENSE.txt
- * 
+ *
  * @package QuickBooks
  * @subpackage Queue
  */
@@ -30,11 +30,12 @@ class QuickBooks_WebConnector_Queue_Singleton
 {
 	/**
 	 * Initialize the queueing object
-	 * 
+	 *
 	 * @param string $dsn
 	 * @param string $user
-	 * @param string $config
-	 * @return QuickBooks_Queue
+	 * @param array  $config
+	 * @param bool   $return_boolean
+	 * @return QuickBooks_WebConnector_Queue
 	 */
 	static public function initialize($dsn = null, $user = null, $config = array(), $return_boolean = true)
 	{
@@ -45,30 +46,30 @@ class QuickBooks_WebConnector_Queue_Singleton
 			{
 				return false;
 			}
-			
+
 			$instance = new QuickBooks_WebConnector_Queue($dsn, $user, $config);
 		}
-		
+
 		if ($return_boolean and $instance)
 		{
 			return true;
 		}
-		
+
 		return $instance;
 	}
-	
+
 	/**
-	 * ??? 
+	 * ???
 	 */
 	static protected function _hash($dsn, $config)
 	{
 		return md5(serialize($dsn) . serialize($config));
 	}
-	
+
 	/**
 	 * Get the instance of the queueing class
-	 * 
-	 * @return QuickBooks_Queue
+	 *
+	 * @return QuickBooks_WebConnector_Queue
 	 */
 	static public function getInstance()
 	{

--- a/QuickBooks/XML/Node.php
+++ b/QuickBooks/XML/Node.php
@@ -2,20 +2,20 @@
 
 /**
  * QuickBooks XML node - individual tags within an XML document
- * 
+ *
  * Copyright (c) 2010-04-16 Keith Palmer / ConsoliBYTE, LLC.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.opensource.org/licenses/eclipse-1.0.php
- * 
+ *
  * @todo YAML exporting *does not* work correctly
  * @todo Array exporting *does not* work correctly
  * @todo JSON exporting *does not* work correctly
- * 
+ *
  * @author Keith Palmer <keith@consolibyte.com>
- * @license LICENSE.txt 
- * 
+ * @license LICENSE.txt
+ *
  * @package QuickBooks
  * @subpackage XML
  */
@@ -30,7 +30,7 @@ class QuickBooks_XML_Node
 	 * @var string
 	 */
 	protected $_name;
-	
+
 	/**
 	 * Tag data
 	 * @var string
@@ -42,37 +42,37 @@ class QuickBooks_XML_Node
 	 * @var array
 	 */
 	protected $_attributes;
-	
+
 	/**
 	 * A string containing comments that were found immediately after this tag
 	 * @var string
 	 */
 	protected $_comment;
-	
+
 	/**
 	 * An array of child tags within this tag
-	 * @var array
+	 * @var QuickBooks_XML_Node[]
 	 */
 	protected $_children;
-	
+
 	/**
 	 * Create a new XML node
-	 * 
+	 *
 	 * @param string $name
 	 * @param string $data
 	 */
 	public function __construct($name = null, $data = null)
 	{
 		$this->_name = $name;
-		
+
 		$this->_data = $data;
 		$this->_children = array();
 		$this->_attributes = array();
 	}
-	
+
 	/**
 	 * Add a child tag (another node) to this tag
-	 * 
+	 *
 	 * @param QuickBooks_XML_Node $node
 	 * @param boolean $prepend
 	 * @return boolean
@@ -87,13 +87,13 @@ class QuickBooks_XML_Node
 		{
 			$this->_children[] = $node;
 		}
-		
+
 		return true;
 	}
-	
+
 	/**
 	 * Add an attribute to this XML tag/node
-	 * 
+	 *
 	 * @param string $attr		The attribute name
 	 * @param mixed $value		The attribute value
 	 * @return boolean
@@ -103,22 +103,22 @@ class QuickBooks_XML_Node
 		$this->_attributes[$attr] = $value;
 		return true;
 	}
-	
+
 	/**
 	 * Set an attribute in this XML tag/node
-	 * 
+	 *
 	 * @param string $attr
 	 * @param mixed $value
-	 * @return boolean 
+	 * @return boolean
 	 */
 	public function setAttribute($attr, $value)
 	{
 		return $this->addAttribute($attr, $value);
 	}
-	
+
 	/**
 	 * Get an attribute from this XML tag/node
-	 * 
+	 *
 	 * @param string $attr
 	 * @return mixed
 	 */
@@ -128,13 +128,13 @@ class QuickBooks_XML_Node
 		{
 			return $this->_attributes[$attr];
 		}
-		
+
 		return false;
 	}
-	
+
 	/**
 	 * Tell whether or not an attribute exists
-	 * 
+	 *
 	 * @param string $attr
 	 * @return boolean
 	 */
@@ -142,10 +142,10 @@ class QuickBooks_XML_Node
 	{
 		return isset($this->_attributes[$attr]);
 	}
-	
+
 	/**
 	 * Set the name of this tag/node
-	 * 
+	 *
 	 * @param string $name
 	 * @return boolean
 	 */
@@ -154,10 +154,10 @@ class QuickBooks_XML_Node
 		$this->_name = $name;
 		return true;
 	}
-	
+
 	/**
 	 * Set the data contained by the XML node
-	 * 
+	 *
 	 * @param string
 	 * @return boolean
 	 */
@@ -171,7 +171,7 @@ class QuickBooks_XML_Node
 	 *
 	 * @param <type> $path
 	 * @param <type> $attr
-	 * @param <type> $value 
+	 * @param <type> $value
 	 */
 	public function setChildAttributeAt($path, $attr, $value, $create = false)
 	{
@@ -191,13 +191,13 @@ class QuickBooks_XML_Node
 			$this->setChildDataAt($path, null, true);
 			return $this->setChildAttributeAt($path, $attr, $value, false);
 		}
-		
+
 		return false;
 	}
-	
+
 	/**
 	 * Recursive helper function - get child at location
-	 * 
+	 *
 	 * @param QuickBooks_XML_Node $root
 	 * @param string $path
 	 * @return QuickBooks_XML_Node
@@ -208,12 +208,12 @@ class QuickBooks_XML_Node
 		{
 			$path = str_replace(' ', '/', $path);
 		}
-		
+
 		$explode = explode('/', $path);
 		//$explode = explode(' ', $path);
 		$current = array_shift($explode);
 		$next = current($explode);
-		
+
 		if ($path == $root->name())
 		{
 			return $root;
@@ -221,7 +221,7 @@ class QuickBooks_XML_Node
 		else if ($current == $root->name())
 		{
 			$path = implode('/', $explode);
-			
+
 			foreach ($root->children() as $child)
 			{
 				if ($child->name() == $next)
@@ -230,13 +230,13 @@ class QuickBooks_XML_Node
 				}
 			}
 		}
-		
+
 		return false;
 	}
-	
+
 	/**
 	 * Get the data segment of an XML child node at a particular path
-	 * 
+	 *
 	 * @param string $path
 	 * @return mixed
 	 */
@@ -246,13 +246,13 @@ class QuickBooks_XML_Node
 		{
 			return $child->data();
 		}
-		
+
 		return false;
 	}
-	
+
 	/**
 	 * Get a child XML node at a particular path
-	 * 
+	 *
 	 * @param string $path
 	 * @return QuickBooks_XML_Node
 	 */
@@ -260,22 +260,22 @@ class QuickBooks_XML_Node
 	{
 		return $this->_getChildAtHelper($this, $path);
 	}
-	
+
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 * @param <type> $path
-	 * @return <type> 
+	 * @return <type>
 	 */
 	public function childExistsAt($path)
 	{
 		$child = $this->getChildAt($path);
 		return is_object($child);
 	}
-	
+
 	/**
 	 * Add a child XML node at a particular path
-	 * 
+	 *
 	 * @param string $path
 	 * @param QuickBooks_XML_Node $child
 	 * @param boolean $create
@@ -285,10 +285,10 @@ class QuickBooks_XML_Node
 	{
 		return $this->_addChildAtHelper($this, $path, $node, $create);
 	}
-	
+
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 * @param QuickBooks_XML_Node $root
 	 * @param string $path
 	 * @param QuickBooks_XML_Node $child
@@ -301,12 +301,12 @@ class QuickBooks_XML_Node
 		{
 			$path = str_replace(' ', '/', $path);
 		}
-		
+
 		$explode = explode('/', $path);
 		/*$explode = explode(' ', $path);*/
 		$current = array_shift($explode);
 		$next = current($explode);
-		
+
 		if ($path == $root->name())
 		{
 			return $root->addChild($node);
@@ -314,7 +314,7 @@ class QuickBooks_XML_Node
 		else
 		{
 			$path = implode('/', $explode);
-			
+
 			foreach ($root->children() as $child)
 			{
 				if ($child->name() == $next)
@@ -323,7 +323,7 @@ class QuickBooks_XML_Node
 				}
 			}
 		}
-		
+
 		if ($create)
 		{
 			$root->addChild(new QuickBooks_XML_Node($next));
@@ -335,48 +335,48 @@ class QuickBooks_XML_Node
 				}
 			}
 		}
-		
+
 		return false;
 	}
-	
+
 	public function setChildDataAt($path, $data, $create = false)
 	{
 		if (false !== strpos($path, ' ') and false === strpos($path, '/'))
 		{
 			$path = str_replace(' ', '/', $path);
 		}
-		
+
 		$explode = explode('/', $path);
 		$allbutend = implode('/', array_slice($explode, 0, -1));
-		
+
 		/*
 		$explode = explode(' ', $path);
 		$allbutend = implode(' ', array_slice($explode, 0, -1));
 		*/
-		
+
 		$end = end($explode);
-		
+
 		$child = $this->getChildAt($path);
-		
+
 		if (!$child and $create)
 		{
 			$this->addChildAt($allbutend, new QuickBooks_XML_Node($end), true);
 			$child = $this->getChildAt($path);
 		}
-		
+
 		if ($child)
 		{
 			$child->setData($data);
 		}
-		
+
 		return false;
 	}
-	
+
 	/**
 	 * Get a child XML node's attributes (associative array)
-	 * 
+	 *
 	 * @param string $path
-	 * @return array 
+	 * @return array
 	 */
 	public function getChildAttributesAt($path)
 	{
@@ -384,45 +384,45 @@ class QuickBooks_XML_Node
 		{
 			return $child->attributes();
 		}
-		
+
 		return false;
 	}
-	
+
 	/**
-	 * 
+	 *
 	 */
 	protected function _pathHelper()
 	{
-		
+
 	}
-	
+
 	/**
-	 * 
+	 *
 	 */
 	public function path($path)
 	{
-		
+
 	}
-	
+
 	/**
-	 * 
+	 *
 	 */
 	protected function _getChildByTagHelper()
 	{
-		
+
 	}
-	
+
 	/**
-	 * 
+	 *
 	 */
 	public function getChildByTag($name)
 	{
-		
+
 	}
-	
+
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 * @param string $pattern
 	 * @param string $str
 	 * @return boolean
@@ -430,24 +430,24 @@ class QuickBooks_XML_Node
 	static protected function _fnmatch($pattern, $str)
 	{
 		$arr = array(
-			'\*' => '.*', 
+			'\*' => '.*',
 			'\?' => '.'
 			);
 		return preg_match('#^' . strtr(preg_quote($pattern, '#'), $arr) . '$#i', $str);
 	}
-	
+
 	/**
 	 * Get an array of child nodes for this XML node
-	 * 
+	 *
 	 * @param string $pattern
-	 * @return array
+	 * @return QuickBooks_XML_Node[]
 	 */
 	public function children($pattern = null)
 	{
 		if (!is_null($pattern))
 		{
 			$list = array();
-			
+
 			foreach ($this->_children as $Child)
 			{
 				if ($this->_fnmatch($pattern, $Child->name()))
@@ -455,17 +455,17 @@ class QuickBooks_XML_Node
 					$list[] = $Child;
 				}
 			}
-			
+
 			return $list;
 		}
-		
+
 		return $this->_children;
 	}
-	
+
 	/**
 	 * Get the data contained by this XML node
-	 * 
-	 * @return mixed 
+	 *
+	 * @return mixed
 	 */
 	public function data()
 	{
@@ -474,17 +474,17 @@ class QuickBooks_XML_Node
 
 	/**
 	 * Tell whether or not this XML node contains data
-	 * 
+	 *
 	 * @return boolean
 	 */
 	public function hasData()
 	{
 		return strlen($this->_data) > 0;
 	}
-	
+
 	/**
 	 * Set a comment for this node
-	 * 
+	 *
 	 * @param string $comment
 	 * @return boolean
 	 */
@@ -493,67 +493,67 @@ class QuickBooks_XML_Node
 		$this->_comment = $comment;
 		return true;
 	}
-	
+
 	/**
 	 * Retrieve any comment set for this XML node
-	 * 
+	 *
 	 * @return string
 	 */
 	public function comment()
 	{
 		return $this->_comment;
 	}
-	
+
 	/**
 	 * Tell whether or not this XML node contains a comment
-	 * 
+	 *
 	 * @return boolean
 	 */
 	public function hasComment()
 	{
 		return strlen($this->_comment) > 0;
 	}
-	
+
 	/**
 	 * Tell the name of this XML node/tag
-	 * 
+	 *
 	 * @return string
 	 */
 	public function name()
 	{
 		return $this->_name;
 	}
-	
+
 	/**
 	 * Get an associative array of attributes the XML node contains
-	 * 
+	 *
 	 * @return array
 	 */
 	public function attributes()
 	{
 		return $this->_attributes;
 	}
-	
+
 	/**
 	 * Tell how many child elements this particular XML node has
-	 * 
+	 *
 	 * @return integer
 	 */
 	public function childCount()
 	{
 		return count($this->_children);
 	}
-	
+
 	/**
 	 * Tell whether or not this XML node has any children
-	 * 
+	 *
 	 * @return boolean
 	 */
 	public function hasChildNodes()
 	{
 		return $this->childCount() > 0;
 	}
-	
+
 	/**
 	 * Alias of {@link QuickBooks_XML_Node::hasChildNodes()}
 	 */
@@ -561,73 +561,73 @@ class QuickBooks_XML_Node
 	{
 		return $this->hasChildNodes();
 	}
-	
+
 	/**
 	 * Tell how many attributes this particular XML node has
-	 * 
+	 *
 	 * @return integer
 	 */
 	public function attributeCount()
 	{
 		return count($this->_attributes);
 	}
-	
+
 	public function removeChild($which)
 	{
 		if (isset($this->_children[$which]))
 		{
 			unset($this->_children[$which]);
 			$this->_children = array_merge($this->_children);
-			
+
 			return true;
 		}
-		
+
 		return false;
 	}
-	
+
 	public function replaceChild($which, $node)
 	{
-		
+
 	}
-	
+
 	public function getChild($which)
 	{
 		if (isset($this->_children[$which]))
 		{
 			return $this->_children[$which];
 		}
-		
+
 		return null;
 	}
-	
+
 	public function normalize()
 	{
-		
+
 	}
-	
+
 	public function equals($node, $recurse = true)
 	{
-		
+
 	}
-	
+
 	public function getElementById()
 	{
-		
+
 	}
-	
+
 	public function getElementByTagName()
 	{
-		
+
 	}
-	
+
 	public function hasAttributes()
 	{
 		return $this->attributeCount() > 0;
 	}
-	
+
 	/**
 	 * Remove an attribute from the XML node
-	 * 
+	 *
 	 * @param string $attr
 	 * @return boolean
 	 */
@@ -638,13 +638,13 @@ class QuickBooks_XML_Node
 			unset($this->_attributes[$attr]);
 			return true;
 		}
-		
+
 		return false;
 	}
-	
+
 	/**
 	 * Resursive helper function for converting to XML
-	 * 
+	 *
 	 * @param QuickBooks_XML_Node $node
 	 * @param integer $tabs
 	 * @param boolean $empty				A constant, one of: QUICKBOOKS_XML_XML_PRESERVE, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_COMPRESS
@@ -654,18 +654,18 @@ class QuickBooks_XML_Node
 	public function _asXMLHelper($node, $tabs, $empty, $indent)
 	{
 		$xml = '';
-		
+
 		if ($node->childCount())
 		{
 			$xml .= str_repeat($indent, $tabs) . '<' . $node->name();
-			
+
 			foreach ($node->attributes() as $key => $value)
 			{
-				// Make sure double-encode is *off* 
+				// Make sure double-encode is *off*
 				//$xml .= ' ' . $key . '="' . QuickBooks_XML::encode($value, true, false) . '"';
 				$xml .= ' ' . $key . '="' . QuickBooks_XML::encode($value) . '"';
 			}
-			
+
 			$xml .= '>' . "\n";
 			foreach ($node->children() as $child)
 			{
@@ -678,21 +678,21 @@ class QuickBooks_XML_Node
 			if ($node->hasAttributes())		// if the node has attributes, we'll build the whole thing no matter what
 			{
 				$xml .= str_repeat($indent, $tabs) . '<' . $node->name();
-				
+
 				foreach ($node->attributes() as $key => $value)
 				{
 					// Double-encode is *off*
 					//$xml .= ' ' . $key . '="' . QuickBooks_XML::encode($value, true, false) . '"';
 					$xml .= ' ' . $key . '="' . QuickBooks_XML::encode($value) . '"';
 				}
-				
+
 				// Double-encode is *off*
 				//$xml .= '>' . QuickBooks_XML::encode($node->data(), true, false) . '</' . $node->name() . '>' . "\n";
 				$xml .= '>' . QuickBooks_XML::encode($node->data()) . '</' . $node->name() . '>' . "\n";
 			}
 			else
 			{
-				if ($node->data() == '__EMPTY__')		// ick, bad hack 
+				if ($node->data() == '__EMPTY__')		// ick, bad hack
 				{
 					$xml .= str_repeat($indent, $tabs) . '<' . $node->name() . '></' . $node->name() . '>' . "\n";
 				}
@@ -711,16 +711,16 @@ class QuickBooks_XML_Node
 					; // do nothing, drop the empty element
 				}
 			}
-			
-			
+
+
 		}
-		
+
 		return $xml;
 	}
-	
+
 	/**
 	 * Get an XML representation of this XML node and it's child XML nodes
-	 * 
+	 *
 	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
 	 * @param string $indent					The character to use to indent the XML with
 	 * @return string
@@ -729,54 +729,54 @@ class QuickBooks_XML_Node
 	{
 		return $this->_asXMLHelper($this, 0, $todo_for_empty_elements, $indent);
 	}
-	
+
 	/**
-	 * 
+	 *
 	 */
 	protected function _asJSONHelper($node, $tabs, $indent)
 	{
 		$json = '';
-		
+
 		if ($node->childCount() or $node->attributeCount())	// container elements surrounded with { ... }
 		{
 			$json .= str_repeat($indent, $tabs) . $node->name() . ':{' . "\n";
-			
+
 			$list = array();
 			foreach ($node->children() as $child)
 			{
 				$json .= $this->_asJSONHelper($child, $tabs + 1, $indent);
 			}
-		
+
 			foreach ($node->attributes() as $key => $value)
 			{
 				$json .= str_repeat($indent, $tabs) . '"' . $key . '": "' . $value . '", ' . "\n";
 			}
-			
+
 			$json .= "\n" . str_repeat($indent, $tabs) . '}';
 		}
 		else
 		{
 			$json .= str_repeat($indent, $tabs) . '"' . $node->name() . '": "' . $node->data() . '", ' . "\n";
 		}
-		
+
 		return $json;
 	}
-	
+
 	/**
 	 * Get a JSON representation of this XML node
-	 * 
+	 *
 	 * @return string
 	 */
 	public function asJSON($indent = "\t")
 	{
-		return '{' . "\n" . $this->_asJSONHelper($this, 1, $indent) . '}'; 
+		return '{' . "\n" . $this->_asJSONHelper($this, 1, $indent) . '}';
 	}
-	
+
 	/**
 	 * Get an array represtation of this XML node
-	 * 
+	 *
 	 * @param string $mode
-	 * @return array 
+	 * @return array
 	 */
 	public function asArray($mode = QuickBooks_XML::ARRAY_NOATTRIBUTES)
 	{
@@ -787,21 +787,21 @@ class QuickBooks_XML_Node
 			case QuickBooks_XML::ARRAY_BRANCHED:
 				return $this->_asArrayBranchedHelper($this);
 			case QuickBooks_XML::ARRAY_PATHS:
-				
+
 				$current = '';
 				$paths = array();
 				$this->_asArrayPathsHelper($this, $current, $paths);
-				
+
 				return $paths;
 			case QuickBooks_XML::ARRAY_NOATTRIBUTES:
 			default:
 				return $this->_asArrayNoAttributesHelper($this);
 		}
 	}
-	
+
 	/**
 	 * Helper function for converting to an array mapping paths to tag values
-	 * 
+	 *
 	 * @param QuickBooks_XML_Node $node
 	 * @param string $current
 	 * @param array $paths
@@ -821,74 +821,74 @@ class QuickBooks_XML_Node
 			$paths[trim($current . ' ' . $node->name())] = $node->data();
 		}
 	}
-	
+
 	/**
 	 * Save this XML node structure as an XML file
-	 * 
+	 *
 	 * @param mixed $path_or_resource			The filepath of the file you want write to *or* an opened file resource
 	 * @param string $mode						The mode to open the file in
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE 
+	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
 	 * @return integer							The number of bytes written to the file
 	 */
 	public function saveXML($path_or_resource, $mode = 'wb', $todo_for_empty_elements = QuickBooks_XML::XML_COMPRESS)
 	{
 		$xml = $this->asXML($todo_for_empty_elements);
-		
+
 		if (is_resource($path_or_resource))
 		{
 			return fwrite($path_or_resource, $xml);
 		}
-		
+
 		$fp = fopen($path_or_resource, $mode);
 		$bytes = fwrite($fp, $xml);
 		fclose($fp);
-		
+
 		return $bytes;
 	}
-	
+
 	/**
 	 * Save the XML node structure as a JSON document
-	 * 
+	 *
 	 * @param mixed $path_or_resource
 	 * @param string $mode
-	 * @return integer 
+	 * @return integer
 	 */
 	public function saveJSON($path_or_resource, $mode = 'wb')
 	{
 		$json = $this->_root->asJSON();
-		
+
 		if (is_resource($path_or_resource))
 		{
 			return fwrite($path_or_resource, $json);
 		}
-		
+
 		$fp = fopen($path_or_resource, $mode);
 		$bytes = fwrite($fp, $json);
 		fclose($fp);
-		
+
 		return $bytes;
 	}
-	
+
 	/**
 	 * Get a YAML representation of this XML node
-	 * 
+	 *
 	 * @return string
 	 */
 	public function asYAML()
 	{
-		
+
 	}
-	
+
 	/**
-	 * Save a YAML representation of this XML node structure to disk 
-	 * 
+	 * Save a YAML representation of this XML node structure to disk
+	 *
 	 * @param mixed $path_or_resource
 	 * @param string $mode
 	 * @return integer
 	 */
 	public function saveYAML($path_or_resource, $mode = 'wb')
 	{
-		
+
 	}
 }
 

--- a/QuickBooks/XML/Parser.php
+++ b/QuickBooks/XML/Parser.php
@@ -2,20 +2,20 @@
 
 /**
  * Simple QuickBooks XML parsing class
- * 
+ *
  * Copyright (c) 2010-04-16 Keith Palmer / ConsoliBYTE, LLC.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.opensource.org/licenses/eclipse-1.0.php
- * 
- * This is intended as a simple alternative to the PHP SimpleXML or DOM 
- * extensions (some of the machines I'm working on don't have the SimpleXML 
- * extension enabled) for parsing XML documents. 
- * 
+ *
+ * This is intended as a simple alternative to the PHP SimpleXML or DOM
+ * extensions (some of the machines I'm working on don't have the SimpleXML
+ * extension enabled) for parsing XML documents.
+ *
  * @author Keith Palmer <keith@consolibyte.com>
  * @license LICENSE.txt
- * 
+ *
  * @package QuickBooks
  * @subpackage XML
  */
@@ -47,28 +47,28 @@ QuickBooks_Loader::import('/QuickBooks/XML/Backend');
 
 /**
  * QuickBooks XML Parser
- * 
- * Create an instance of the QuickBooks_XML parser by calling the constructor 
- * with either a file-path or the contents of an XML document. 
+ *
+ * Create an instance of the QuickBooks_XML parser by calling the constructor
+ * with either a file-path or the contents of an XML document.
  * <code>
  * $xml = '<Tag1><NestedTag age="25" gender="male"><AnotherTag>Keith</AnotherTag></NestedTag></Tag1>';
- * 
+ *
  * // Create the new object
  * $Parser = new QuickBooks_XML_Parser($xml);
- * 
+ *
  * // Parse the XML document
  * $errnum = 0;
  * $errmsg = '';
  * if ($Parser->validate($errnum, $errmsg))
  * {
  * 	$Doc = $Parser->parse($errnum, $errmsg);
- * 	
+ *
  * 	// Now fetch some stuff from the parsed document
  * 	print('Hello there ' . $Doc->getChildDataAt('Tag1 NestedTag AnotherTag') . "\n");
  * 	print_r($Doc->getChildAttributesAt('Tag1 NestedTag'));
  * 	print("\n");
  * 	print('Root tag name is: ' . $Doc->name() . "\n");
- * 
+ *
  * 	$NestedTag = $Doc->getChildAt('Tag1 NestedTag');
  * 	print_r($NestedTag);
  * }
@@ -77,38 +77,38 @@ QuickBooks_Loader::import('/QuickBooks/XML/Backend');
 class QuickBooks_XML_Parser
 {
 	/**
-	 * 
+	 *
 	 */
 	protected $_xml;
-	 
+
 	/**
 	 * What back-end XML parser to use
-	 * @var string
+	 * @var Quickbooks_XML_Backend
 	 */
 	protected $_backend;
-	
+
 	/**
-	 * 
+	 *
 	 */
 	const BACKEND_SIMPLEXML = 'simplexml';
-	
+
 	/**
-	 * 
+	 *
 	 */
 	const BACKEND_BUILTIN = 'builtin';
-	
+
 	/**
 	 * Create a new QuickBooks_XML parser object
-	 * 
+	 *
 	 * @param string $xml_or_file
 	 */
 	public function __construct($xml_or_file = null, $use_backend = null)
 	{
 		$xml_or_file = $this->_read($xml_or_file);
-		
+
 		$this->_xml = $xml_or_file;
-		
-		if (is_null($use_backend) and 
+
+		if (is_null($use_backend) and
 			function_exists('simplexml_load_string'))
 		{
 			$use_backend = QuickBooks_XML::PARSER_SIMPLEXML;
@@ -117,14 +117,14 @@ class QuickBooks_XML_Parser
 		{
 			$use_backend = QuickBooks_XML::PARSER_BUILTIN;
 		}
-		
+
 		$class = 'QuickBooks_XML_Backend_' . ucfirst(strtolower($use_backend));
 		$this->_backend = new $class($xml_or_file);
 	}
-	
+
 	/**
 	 * Read an open file descriptor, XML file, or string
-	 * 
+	 *
 	 * @param mixed $mixed
 	 * @return string
 	 */
@@ -134,7 +134,7 @@ class QuickBooks_XML_Parser
 		{
 			return '';
 		}
-		else if (is_resource($mixed) and 
+		else if (is_resource($mixed) and
 			get_resource_type($mixed) == 'stream')
 		{
 			$buffer = '';
@@ -143,76 +143,76 @@ class QuickBooks_XML_Parser
 			{
 				$buffer .= $tmp;
 			}
-			
+
 			return $buffer;
 		}
 		else if (substr(trim($mixed), 0, 1) != '<')
 		{
 			return file_get_contents($mixed);
 		}
-		
+
 		return $mixed;
 	}
-	
+
 	/**
 	 * Load the XML parser with data from a string or file
-	 * 
-	 * @param string $xml_or_file		An XML string or 
+	 *
+	 * @param string $xml_or_file		An XML string or
 	 * @return integer
 	 */
 	public function load($xml_or_file)
 	{
 		$xml_or_file = $this->_read($xml_or_file);
-		
+
 		$this->_xml = $xml_or_file;
 		return $this->_backend->load($xml_or_file);
 	}
-	
+
 	/**
 	 * Check if the XML document is valid
-	 * 
-	 * *** WARNING *** This does not check against the actual QuickBooks 
-	 * schemas, and in reality even the XML validation stuff it *does* do is 
-	 * pretty light. You should probably double check any validation you're 
-	 * doing in a better XML validator.  
-	 * 
+	 *
+	 * *** WARNING *** This does not check against the actual QuickBooks
+	 * schemas, and in reality even the XML validation stuff it *does* do is
+	 * pretty light. You should probably double check any validation you're
+	 * doing in a better XML validator.
+	 *
 	 * @param integer $errnum
 	 * @param string $errmsg
-	 * @return boolean 
+	 * @return boolean
 	 */
 	public function validate(&$errnum, &$errmsg)
 	{
 		return $this->_backend->validate($errnum, $errmsg);
 	}
-	
+
 	/**
-	 * 
+	 *
 	 */
 	public function beautify(&$errnum, &$errmsg, $compress_empty_elements = true)
 	{
 		$errnum = 0;
 		$errmsg = '';
-		
+
 		$Node = $this->parse($errnum, $errmsg);
-		
+
 		if (!$errnum and is_object($Node))
 		{
 			return $Node->asXML($compress_empty_elements);
 		}
-		
+
 		return false;
 	}
-	
+
 	/**
 	 * Parse an XML document into an XML node structure
-	 * 
-	 * This function returns either a QuickBooks_XML_Node on success, or false 
-	 * on failure. You can use the ->validate() method first so you can tell 
+	 *
+	 * This function returns either a QuickBooks_XML_Document on success, or false
+	 * on failure. You can use the ->validate() method first so you can tell
 	 * whether or not the parser will succeed.
-	 * 
+	 *
 	 * @param integer $errnum
 	 * @param string $errmsg
-	 * @return QuickBooks_XML_Node
+	 * @return QuickBooks_XML_Document
 	 */
 	public function parse(&$errnum, &$errmsg)
 	{
@@ -222,16 +222,16 @@ class QuickBooks_XML_Parser
 			$errmsg = 'No XML content to parse.';
 			return false;
 		}
-		
+
 		// first, let's remove all of the comments
 		if ($this->validate($errnum, $errmsg))
 		{
 			return $this->_backend->parse($errnum, $errmsg);
 		}
-		
+
 		return false;
 	}
-	
+
 	public function backend()
 	{
 		$str = get_class($this->_backend);


### PR DESCRIPTION
Redefinition of parameters is now a fatal error in PHP7.0+. This patch corrects the calls to the callback class from the handlers class, and includes a few PHPDoc corrections which were falsely labeled, misleading IDE's parsing them.

*Note: my IDE automatically strips trailing whitespace which these files had very many of, sorry about the resulting long diff*