### PR TITLE
Fixed Case mismatch in class name

### DIFF
--- a/QuickBooks/Driver/Sql/Mysqli.php
+++ b/QuickBooks/Driver/Sql/Mysqli.php
@@ -147,7 +147,7 @@ if (!defined('QUICKBOOKS_DRIVER_SQL_MYSQLI_CONNECTIONTABLE'))
 /**
  * QuickBooks MySQL back-end driver
  */
-class QuickBooks_Driver_SQL_Mysqli extends QuickBooks_Driver_Sql
+class QuickBooks_Driver_Sql_Mysqli extends QuickBooks_Driver_Sql
 {
 	
 	/**


### PR DESCRIPTION
Case mismatch between loaded and declared class names: QuickBooks_Driver_Sql_Mysqli vs QuickBooks_Driver_SQL_Mysqli