### PR TITLE
Fixed Case mismatch in class name

### DIFF
--- a/QuickBooks/XML/Backend/Builtin.php
+++ b/QuickBooks/XML/Backend/Builtin.php
@@ -1,6 +1,6 @@
 <?php
 
-class QuickBooks_XML_Backend_BuiltIn implements QuickBooks_XML_Backend
+class QuickBooks_XML_Backend_Builtin implements QuickBooks_XML_Backend
 {
 	protected $_xml;
 	

--- a/QuickBooks/XML/Backend/Simplexml.php
+++ b/QuickBooks/XML/Backend/Simplexml.php
@@ -10,7 +10,7 @@ QuickBooks_Loader::load('/QuickBooks/XML/Node.php');
 
 QuickBooks_Loader::load('/QuickBooks/XML/Document.php');
 
-class QuickBooks_XML_Backend_SimpleXML implements QuickBooks_XML_Backend
+class QuickBooks_XML_Backend_Simplexml implements QuickBooks_XML_Backend
 {
 	protected $_xml;
 	protected $_root;


### PR DESCRIPTION
Couple more throwing "Case mismatch between loaded and declared class names: QuickBooks_XML_Backend_Builtin vs QuickBooks_XML_Backend_BuiltIn" since these class names are constructed with `ucfirst(strtolower($use_backend))` in XML/Parser.php they need to be lowercase.