### PR TITLE
Added Othername Import definition

### DIFF
--- a/QuickBooks.php
+++ b/QuickBooks.php
@@ -679,6 +679,7 @@ define('QUICKBOOKS_OBJECT_OTHERNAME', 'OtherName');
 define('QUICKBOOKS_ADD_OTHERNAME', 'OtherNameAdd');
 define('QUICKBOOKS_MOD_OTHERNAME', 'OtherNameMod');
 define('QUICKBOOKS_QUERY_OTHERNAME', 'OtherNameQuery');
+define('QUICKBOOKS_IMPORT_OTHERNAME', 'OtherNameImport');
 
 define('QUICKBOOKS_OBJECT_PAYMENTMETHOD', 'PaymentMethod');
 define('QUICKBOOKS_ADD_PAYMENTMETHOD', 'PaymentMethodAdd');


### PR DESCRIPTION
Other objects have distinct definitions for both Query and Import, and in my current experience OtherName items is the only one without such a distinction.