### PR TITLE
Change all occurrences of QUICKBOOKS_ADD_RECEIPTITEM to QUICKBOOKS_AD…

### DIFF
--- a/QuickBooks/QBXML/Object/ItemReceipt.php
+++ b/QuickBooks/QBXML/Object/ItemReceipt.php
@@ -302,7 +302,7 @@ class QuickBooks_QBXML_Object_ItemReceipt extends QuickBooks_QBXML_Object
 	{
 		switch ($request)
 		{
-			case QUICKBOOKS_ADD_RECEIPTITEM . 'Rq':
+			case QUICKBOOKS_ADD_ITEMRECEIPT . 'Rq':
 				if (isset($this->_object['ItemLine']))
 				{
 					$this->_object['ItemLineAdd'] = $this->_object['ItemLine'];
@@ -370,7 +370,7 @@ class QuickBooks_QBXML_Object_ItemReceipt extends QuickBooks_QBXML_Object
 		
 		switch ($root)
 		{
-			case QUICKBOOKS_ADD_RECEIPTITEM:
+			case QUICKBOOKS_ADD_ITEMRECEIPT:
 				if (isset($object['ItemLineAdd']))
 				{
 					foreach ($object['ItemLineAdd'] as $key => $obj)

--- a/QuickBooks/QBXML/Object/ItemReceipt/ExpenseLine.php
+++ b/QuickBooks/QBXML/Object/ItemReceipt/ExpenseLine.php
@@ -154,7 +154,7 @@ class QuickBooks_QBXML_Object_ItemReceipt_ExpenseLine extends QuickBooks_QBXML_O
 		
 		switch ($parent)
 		{
-			case QUICKBOOKS_ADD_RECEIPTITEM:
+			case QUICKBOOKS_ADD_ITEMRECEIPT:
 				$root = 'ExpenseLineAdd';
 				$parent = null;
 				break;

--- a/QuickBooks/QBXML/Object/ItemReceipt/ItemGroupLine.php
+++ b/QuickBooks/QBXML/Object/ItemReceipt/ItemGroupLine.php
@@ -101,7 +101,7 @@ class QuickBooks_QBXML_Object_ItemReceipt_ItemGroupLine extends QuickBooks_QBXML
 		
 		switch ($parent)
 		{
-			case QUICKBOOKS_ADD_RECEIPTITEM:
+			case QUICKBOOKS_ADD_ITEMRECEIPT:
 				$root = 'ItemGroupLineAdd';
 				$parent = null;
 				break;

--- a/QuickBooks/QBXML/Object/ItemReceipt/ItemLine.php
+++ b/QuickBooks/QBXML/Object/ItemReceipt/ItemLine.php
@@ -251,7 +251,7 @@ class QuickBooks_QBXML_Object_ItemReceipt_ItemLine extends QuickBooks_QBXML_Obje
 		
 		switch ($parent)
 		{
-			case QUICKBOOKS_ADD_RECEIPTITEM:
+			case QUICKBOOKS_ADD_ITEMRECEIPT:
 				$root = 'ItemLineAdd';
 				$parent = null;
 				break;


### PR DESCRIPTION
…D_ITEMRECEIPT.

The constant `QUICKBOOKS_ADD_RECEIPTITEM` was used in a few places, but it seems that it was changed to `QUICKBOOKS_ADD_ITEMRECEIPT` at some point, so those references weren't working.

This change fixed the ItemReceipt->addExpenseLine() function for me, which was not working previously.