### PR TITLE
Fix a bug with authDisable and authEnable and added important functionality that was previously impossible

### DIFF
--- a/QuickBooks/Driver.php
+++ b/QuickBooks/Driver.php
@@ -63,6 +63,12 @@ define('QUICKBOOKS_DRIVER_HOOK_AUTHRESOLVE', 'QuickBooks_Driver::authResolve');
 define('QUICKBOOKS_DRIVER_HOOK_AUTHDISABLE', 'QuickBooks_Driver::authDisable');
 
 /**
+ * Hook called by the ->authUpdatePassword() method
+ * @var string
+ */
+define('QUICKBOOKS_DRIVER_HOOK_AUTHUPDATE', 'QuickBooks_Driver::authUpdatePassword');
+
+/**
  * Hook called by the ->authEnable() method
  * @var string
  */
@@ -1288,11 +1294,53 @@ abstract class QuickBooks_Driver
 	 * @see QuickBooks_Driver::authCreate()
 	 */
 	abstract protected function _authCreate($username, $password, $company_file = null, $wait_before_next_update = null, $min_run_every_n_seconds = null);
-	
+
+	/**
+	 * @see Quickbooks_Driver::authExists
+	 */
+	abstract protected function _authExists($username);
+
+	/**
+	 * Check if a user exists
+	 *
+	 * @param string username
+	 * @return boolean
+	 */
+	final public function authExists($username)
+	{
+		return $this->_authExists($username);
+	}
+
+	/**
+	 * @see QuickBooks_Driver::authUpdatePassword()
+	 */
+	abstract protected function _authUpdatePassword($username, $password);
+
+	/**
+	 * Update the password of a user
+	 *
+	 * @param string username
+	 * @param string password
+	 * @return boolean
+	 */
+	final public function authUpdatePassword($username, $password)
+	{
+		$hookdata = array(
+			'username' => $username,
+			'password' => $password,
+		);
+
+		$err = '';
+		$this->_callHook(QUICKBOOKS_DRIVER_HOOK_AUTHUPDATE, null, $err, $hookdata);
+
+		return $this->_authUpdatePassword($username, $password);
+	}
+
 	/**
 	 * @see QuickBooks_Driver::authEnable()
 	 */
 	abstract protected function _authEnable($username);
+	
 	
 	/** 
 	 * Enable a username

--- a/QuickBooks/Driver/Sql.php
+++ b/QuickBooks/Driver/Sql.php
@@ -610,6 +610,19 @@ abstract class QuickBooks_Driver_Sql extends QuickBooks_Driver
 		return '';
 	}
 
+	/**
+	 * Check if a user exists in the SOAP server
+	 *
+	 * @param string $username
+	 * @param string $password
+	 * @return boolean
+	 */
+	protected function _authExists($username) {
+		$errnum = 0;
+		$errmsg = '';
+
+		return $this->_count($this->_query("SELECT qb_username FROM " . $this->_mapTableName(QUICKBOOKS_DRIVER_SQL_USERTABLE) . " WHERE qb_username = '" . $this->_escape($username) . "' ", $errnum, $errmsg, 0, 1));
+	}
 
 	/**
 	 * Create a new user for the SOAP server
@@ -623,7 +636,7 @@ abstract class QuickBooks_Driver_Sql extends QuickBooks_Driver
 		$errnum = 0;
 		$errmsg = '';
 
-		if (!$this->_count($this->_query("SELECT qb_username FROM " . $this->_mapTableName(QUICKBOOKS_DRIVER_SQL_USERTABLE) . " WHERE qb_username = '" . $this->_escape($username) . "' ", $errnum, $errmsg, 0, 1)))
+		if (!$this->_authExists($username))
 		{
 			return $this->_query("
 				INSERT INTO
@@ -650,6 +663,27 @@ abstract class QuickBooks_Driver_Sql extends QuickBooks_Driver
 		}
 
 		return false;
+	}
+
+	/**
+	 * Update the password
+	 *
+	 * @param string $username
+	 * @return boolean
+	 */
+	protected function _authUpdatePassword($username, $password)
+	{
+		$errnum = 0;
+		$errmsg = '';
+
+		return $this->_query("
+			UPDATE
+				" . $this->_mapTableName(QUICKBOOKS_DRIVER_SQL_USERTABLE) . "
+			SET
+				touch_datetime = '" . date('Y-m-d H:i:s') . "',
+				qb_password = '" . $this->_escape($this->_hash($password)) . "'
+			WHERE
+				qb_username = '" . $this->_escape($username) . "' ", $errnum, $errmsg);
 	}
 
 	/**

--- a/QuickBooks/Driver/Sql.php
+++ b/QuickBooks/Driver/Sql.php
@@ -670,7 +670,7 @@ abstract class QuickBooks_Driver_Sql extends QuickBooks_Driver
 				status = '" . QUICKBOOKS_USER_ENABLED . "',
 				touch_datetime = '" . date('Y-m-d H:i:s') . "'
 			WHERE
-				qb_username = '" . $this->_escape($username) . "' ");
+				qb_username = '" . $this->_escape($username) . "' ", $errnum, $errmsg);
 	}
 
 	/**
@@ -691,7 +691,7 @@ abstract class QuickBooks_Driver_Sql extends QuickBooks_Driver
 				status = '" . QUICKBOOKS_USER_DISABLED . "',
 				touch_datetime = '" . date('Y-m-d H:i:s') . "'
 			WHERE
-				qb_username = '" . $this->_escape($username) . "' ");
+				qb_username = '" . $this->_escape($username) . "' ", $errnum, $errmsg);
 	}
 
 	/**

--- a/QuickBooks/Utilities.php
+++ b/QuickBooks/Utilities.php
@@ -439,7 +439,36 @@ class QuickBooks_Utilities
 		
 		return $driver->authCreate($username, $password, $company_file, $wait_before_next_update, $min_run_every_n_seconds);
 	}
-	
+
+	/**
+	 * Check if a user exists for the QuickBooks Web Connector SOAP server
+	 *
+	 * @param string $dsn		A DSN-style connection string for the back-end driver
+	 * @param string $username	The username to check if exists
+	 * @return boolean
+	 */
+	static public function userExists($dsn, $username)
+	{
+		$driver = QuickBooks_Utilities::driverFactory($dsn);
+
+		return $driver->authExists($username);
+	}
+
+	/**
+	 * Update the password for a user for the QuickBooks Web Connector Soap server
+	 *
+	 * @param string $dsn		A DSN-style connection string for the back-end driver
+	 * @param string $username	The username for the user to update
+	 * @param string $password	The new password for the user
+	 * @return boolean
+	 */
+	static public function updateUserPassword($dsn, $username, $password)
+	{
+		$driver = QuickBooks_Utilities::driverFactory($dsn);
+
+		return $driver->authUpdatePassword($username, $password);
+	}
+
 	/**
 	 * Disable a user for the QuickBooks Web Connector SOAP server
 	 * 


### PR DESCRIPTION
Auth disable/enable both failed because _query was not fed the two non-optional parameters in Sql.php

Additionally, I found it does not seem possible to change a user's password.  I added an update password request as well as a way to check if a user with a username exists.

This helped my code so I can now have something like this:

```
$username = self::getUsername();
$pass = substr(str_shuffle("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"), -15);

if (QuickBooks_Utilities::userExists($dsn, $username)) {
	QuickBooks_Utilities::updateUserPassword($dsn, $username, $pass);
}
else {
	QuickBooks_Utilities::createUser($dsn, $username, $pass);
}
```