### PR TITLE
Discovered a bug when trying to use the Vendor Object.  It looks like…

### DIFF
--- a/QuickBooks/QBXML/Object/Account.php
+++ b/QuickBooks/QBXML/Object/Account.php
@@ -2,37 +2,37 @@
 
 /**
  * QuickBooks Account object container
- * 
+ *
  * @author Keith Palmer <keith@consolibyte.com>
  * @license LICENSE.txt
- * 
+ *
  * @package QuickBooks
  * @subpackage Object
  */
 
 /**
- * 
+ *
  */
 QuickBooks_Loader::load('/QuickBooks/QBXML/Object.php');
 
 /**
- * 
+ *
  */
 class QuickBooks_QBXML_Object_Account extends QuickBooks_QBXML_Object
 {
 	/**
 	 * Create a new QuickBooks_Object_Account object
-	 * 
+	 *
 	 * @param array $arr
 	 */
 	public function __construct($arr = array())
 	{
 		parent::__construct($arr);
 	}
-	
+
 	/**
 	 * Set the ListID of the Class
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return boolean
 	 */
@@ -40,58 +40,58 @@ class QuickBooks_QBXML_Object_Account extends QuickBooks_QBXML_Object
 	{
 		return $this->set('ListID', $ListID);
 	}
-	
+
 	/**
 	 * Get the ListID of the Class
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getListID()
 	{
 		return $this->get('ListID');
 	}
-	
+
 	/**
-	 * 
+	 *
 	 */
 	public function setParentListID($ListID)
 	{
 		return $this->set('ParentRef ListID', $ListID);
 	}
-	
+
 	public function getParentListID()
 	{
 		return $this->get('ParentRef ListID');
 	}
-	
+
 	public function setParentName($name)
 	{
 		return $this->set('ParentRef FullName', $name);
 	}
-	
+
 	public function getParentName()
 	{
 		return $this->get('ParentRef FullName');
 	}
-	
+
 	public function getParentFullName()
 	{
 		return $this->get('ParentRef FullName');
 	}
-	
+
 	public function setParentApplicationID($value)
 	{
 		return $this->set('ParentRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_ACCOUNT, QUICKBOOKS_LISTID, $value));
 	}
-	
+
 	public function getParentApplicationID()
 	{
 		return $this->get('ParentRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	/**
 	 * Set the name of the class
-	 * 
+	 *
 	 * @param string $name
 	 * @return boolean
 	 */
@@ -99,19 +99,19 @@ class QuickBooks_QBXML_Object_Account extends QuickBooks_QBXML_Object
 	{
 		return $this->set('Name', $name);
 	}
-	
+
 	/**
 	 * Get the name of the class
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getName()
 	{
 		return $this->get('Name');
 	}
-	
+
 	/**
-	 * 
+	 *
 	 */
 	public function getFullName()
 	{
@@ -122,10 +122,10 @@ class QuickBooks_QBXML_Object_Account extends QuickBooks_QBXML_Object
 	{
 		return $this->set('FullName', $name);
 	}
-	
+
 	/**
 	 * Set this Class active or not
-	 * 
+	 *
 	 * @param boolean $value
 	 * @return boolean
 	 */
@@ -133,57 +133,57 @@ class QuickBooks_QBXML_Object_Account extends QuickBooks_QBXML_Object
 	{
 		return $this->set('IsActive', (boolean) $value);
 	}
-	
+
 	/**
 	 * Tell whether or not this class object is active
-	 * 
+	 *
 	 * @return boolean
 	 */
 	public function getIsActive()
 	{
 		return $this->getBooleanType('IsActive');
 	}
-	
+
 	public function setAccountType($type)
 	{
 		return $this->setBooleanType('AccountType', $type);
 	}
-	
+
 	public function getAccountType()
 	{
 		return $this->get('AccountType');
 	}
-	
+
 	public function setAccountNumber($number)
 	{
 		return $this->set('AccountNumber', $number);
 	}
-	
+
 	public function getAccountNumber()
 	{
 		return $this->get('AccountNumber');
 	}
-	
+
 	public function setBankNumber($number)
 	{
 		return $this->set('BankNumber', $number);
 	}
-	
+
 	public function getBankNumber()
 	{
 		return $this->get('BankNumber');
 	}
-	
+
 	public function setDescription($descrip)
 	{
 		return $this->set('Desc', $descrip);
 	}
-	
+
 	public function getDescription()
 	{
 		return $this->get('Desc');
 	}
-	
+
 	public function setOpenBalance($balance)
 	{
 		return $this->set('OpenBalance', (float) $balance);
@@ -193,7 +193,7 @@ class QuickBooks_QBXML_Object_Account extends QuickBooks_QBXML_Object
 	{
 		return $this->get('OpenBalance');
 	}
-	
+
 	public function setOpenBalanceDate($date)
 	{
 		return $this->setDateType('OpenBalanceDate', $date);
@@ -203,7 +203,7 @@ class QuickBooks_QBXML_Object_Account extends QuickBooks_QBXML_Object
 	{
 		return $this->getDateType('OpenBalanceDate');
 	}
-	
+
 	public function setTaxLineID($value)
 	{
 		return $this->set('TxLineID', $value);
@@ -213,7 +213,7 @@ class QuickBooks_QBXML_Object_Account extends QuickBooks_QBXML_Object
 	{
 		return $this->get('TxLineID');
 	}
-	
+
 	public function getBalance()
 	{
 		return $this->get('Balance');
@@ -223,7 +223,7 @@ class QuickBooks_QBXML_Object_Account extends QuickBooks_QBXML_Object
 	{
 		return $this->set('Balance', $value);
 	}
-	
+
 	public function getTotalBalance()
 	{
 		return $this->get('TotalBalance');
@@ -233,7 +233,7 @@ class QuickBooks_QBXML_Object_Account extends QuickBooks_QBXML_Object
 	{
 		return $this->set('TotalBalance', $value);
 	}
-	
+
 	public function getSpecialAccountType()
 	{
 		return $this->get('SpecialAccountType');
@@ -243,7 +243,7 @@ class QuickBooks_QBXML_Object_Account extends QuickBooks_QBXML_Object
 	{
 		return $this->set('SpecialAccountType', $type);
 	}
-	
+
 	public function getCashFlowClassification()
 	{
 		return $this->get('CashFlowClassification');
@@ -254,50 +254,9 @@ class QuickBooks_QBXML_Object_Account extends QuickBooks_QBXML_Object
 		return $this->set('CashFlowClassification', $type);
 	}
 
-
 	/**
-	 * Perform any needed clean-up of the object data members
-	 * 
-	 * @return boolean
-	 */
-	protected function _cleanup()
-	{
-		return true;
-	}
-	
-	/**
-	 * Get an array representation of this Class object
-	 * 
-	 * @param string $request
-	 * @param boolean $nest
-	 * @return array
-	 */
-	public function asArray($request, $nest = true)
-	{
-		$this->_cleanup();
-		
-		return parent::asArray($request, $nest);
-	}
-	
-	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
-	 * Tell what type of object this is 
-	 * 
+	 * Tell what type of object this is
+	 *
 	 * @return string
 	 */
 	public function object()

--- a/QuickBooks/QBXML/Object/BillPaymentCheck.php
+++ b/QuickBooks/QBXML/Object/BillPaymentCheck.php
@@ -2,10 +2,10 @@
 
 /**
  * QuickBooks ReceivePayment object container
- * 
+ *
  * @author Keith Palmer <keith@consolibyte.com>
- * @license LICENSE.txt 
- * 
+ * @license LICENSE.txt
+ *
  * @package QuickBooks
  * @subpackage Object
  */
@@ -21,23 +21,23 @@ QuickBooks_Loader::load('/QuickBooks/QBXML/Object.php');
 QuickBooks_Loader::load('/QuickBooks/QBXML/Object/BillPaymentCheck/AppliedToTxn.php');
 
 /**
- * QuickBooks ReceivePayment object 
+ * QuickBooks ReceivePayment object
  */
 class QuickBooks_QBXML_Object_BillPaymentCheck extends QuickBooks_QBXML_Object
 {
 	/**
 	 * Create a new QuickBooks_Object_ReceivePayment object
-	 * 
+	 *
 	 * @param array $arr
 	 */
 	public function __construct($arr = array())
 	{
 		parent::__construct($arr);
 	}
-	
+
 	/**
 	 * Set the TxnID of the Class
-	 * 
+	 *
 	 * @param string $TxnID
 	 * @return boolean
 	 */
@@ -45,7 +45,7 @@ class QuickBooks_QBXML_Object_BillPaymentCheck extends QuickBooks_QBXML_Object
 	{
 		return $this->set('TxnID', $TxnID);
 	}
-	
+
 	/**
 	 * Alias of {@link QuickBooks_Object_ReceivePayment::setTxnID()}
 	 */
@@ -53,17 +53,17 @@ class QuickBooks_QBXML_Object_BillPaymentCheck extends QuickBooks_QBXML_Object
 	{
 		return $this->setTxnID($TxnID);
 	}
-	
+
 	/**
 	 * Get the ListID of the Class
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getTxnID()
 	{
 		return $this->get('TxnID');
 	}
-	
+
 	/**
 	 * Alias of {@link QuickBooks_Object_ReceivePayment::getTxnID()}
 	 */
@@ -71,10 +71,10 @@ class QuickBooks_QBXML_Object_BillPaymentCheck extends QuickBooks_QBXML_Object
 	{
 		return $this->getTxnID();
 	}
-	
+
 	/**
 	 * Set the customer ListID
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return boolean
 	 */
@@ -82,10 +82,10 @@ class QuickBooks_QBXML_Object_BillPaymentCheck extends QuickBooks_QBXML_Object
 	{
 		return $this->set('PayeeEntityRef ListID' , $ListID);
 	}
-	
+
 	/**
 	 * Set the customer ApplicationID (auto-replaced by the API with a ListID)
-	 * 
+	 *
 	 * @param mixed $value
 	 * @return boolean
 	 */
@@ -93,16 +93,16 @@ class QuickBooks_QBXML_Object_BillPaymentCheck extends QuickBooks_QBXML_Object
 	{
 		return $this->set('PayeeEntityRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_VENDOR, QUICKBOOKS_LISTID, $value));
 	}
-	
-	
+
+
 	public function getPayeeEntityApplicationID()
 	{
 		return $this->get('PayeeEntityRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	/**
 	 * Set the customer name
-	 * 
+	 *
 	 * @param string $name
 	 * @return boolean
 	 */
@@ -110,30 +110,30 @@ class QuickBooks_QBXML_Object_BillPaymentCheck extends QuickBooks_QBXML_Object
 	{
 		return $this->set('PayeeEntityRef FullName', $name);
 	}
-	
+
 	/**
 	 * Get the customer ListID
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getPayeeEntityListID()
 	{
 		return $this->get('PayeeEntityRef ListID');
 	}
-	
+
 	/**
 	 * Get the customer name
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getPayeeEntityFullName()
 	{
 		return $this->get('PayeeEntityRef FullName');
 	}
-	
+
 		/**
 	 * Set the transaction date
-	 * 
+	 *
 	 * @param string $date
 	 * @return boolean
 	 */
@@ -141,7 +141,7 @@ class QuickBooks_QBXML_Object_BillPaymentCheck extends QuickBooks_QBXML_Object
 	{
 		return $this->setDateType('TxnDate', $date);
 	}
-	
+
 	/**
 	 * Alias of {@link QuickBooks_Object_Invoice::setTxnDate()}
 	 */
@@ -149,30 +149,30 @@ class QuickBooks_QBXML_Object_BillPaymentCheck extends QuickBooks_QBXML_Object
 	{
 		return $this->setTxnDate($date);
 	}
-	
+
 	/**
 	 * Get the transaction date
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getTxnDate($format = 'Y-m-d')
 	{
 		return $this->getDateType('TxnDate');
 	}
-	
+
 	public function setIsToBePrinted($bool)
 	{
 		return $this->setBooleanType('IsToBePrinted', $bool);
 	}
-	
+
 	public function getIsToBePrinted()
 	{
 		return $this->getBooleanType('IsToBePrinted');
 	}
-	
+
 	/**
 	 * Set the reference number
-	 * 
+	 *
 	 * @param string $str
 	 * @return boolean
 	 */
@@ -180,17 +180,17 @@ class QuickBooks_QBXML_Object_BillPaymentCheck extends QuickBooks_QBXML_Object
 	{
 		return $this->set('RefNumber', $str);
 	}
-	
+
 	/**
 	 * Get the reference number
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getRefNumber()
 	{
 		return $this->get('RefNumber');
 	}
-	
+
 	/**
 	 * Alias of {@link QuickBooks_Object_ReceivePayment::addAppliedToTxn()}
 	 */
@@ -198,29 +198,29 @@ class QuickBooks_QBXML_Object_BillPaymentCheck extends QuickBooks_QBXML_Object
 	{
 		return $this->addAppliedToTxn($obj);
 	}
-	
+
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 */
 	public function addAppliedToTxn($obj)
 	{
 		/*
 		$lines = $this->get('AppliedToTxn');
-		
+
 		if (!is_array($lines))
 		{
 			$lines = array();
 		}
-		
+
 		//
 		$lines[] = $obj;
-		
+
 		return $this->set('AppliedToTxn', $lines);*/
-		
+
 		return $this->addListItem('AppliedToTxn', $obj);
 	}
-	
+
 	/**
 	 * Alias of {@link QuickBooks_Object_Invoice::getTxnDate()}
 	 */
@@ -228,10 +228,10 @@ class QuickBooks_QBXML_Object_BillPaymentCheck extends QuickBooks_QBXML_Object
 	{
 		return $this->getDateType('TxnDate', $format);
 	}
-	
+
 	/**
 	 * Set the total amount of the received payment
-	 * 
+	 *
 	 * @param float $amount
 	 * @return boolean
 	 */
@@ -239,27 +239,27 @@ class QuickBooks_QBXML_Object_BillPaymentCheck extends QuickBooks_QBXML_Object
 	{
 		return $this->setAmountType('TotalAmount', $amount);
 	}
-	
+
 	/**
 	 * Get the total amount of the received payment
-	 * 
+	 *
 	 * @return float
 	 */
 	public function getTotalAmount()
 	{
 		return $this->getAmountType('TotalAmount');
 	}
-	
+
 	public function setAPAccountListID($ListID)
 	{
 		return $this->set('APAccountRef ListID', $ListID);
 	}
-	
+
 	public function setAPAccountFullName($name)
 	{
 		return $this->set('APAccountRef FullName', $name);
 	}
-	
+
 	public function setAPAccountApplicationID($value)
 	{
 		return $this->set('APAccountRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_ACCOUNT, QUICKBOOKS_LISTID, $value));
@@ -269,27 +269,27 @@ class QuickBooks_QBXML_Object_BillPaymentCheck extends QuickBooks_QBXML_Object
 	{
 		return $this->get('APAccountRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function getAPAccountListID()
 	{
 		return $this->get('APAccountRef ListID');
 	}
-	
+
 	public function getAPAccountFullName()
 	{
 		return $this->get('APAccountRef FullName');
 	}
-		
+
 	public function setBankAccountListID($ListID)
 	{
 		return $this->set('BankAccountRef ListID', $ListID);
 	}
-	
+
 	public function setBankAccountFullName($name)
 	{
 		return $this->set('BankAccountRef FullName', $name);
 	}
-	
+
 	public function setBankAccountApplicationID($value)
 	{
 		return $this->set('BankAccountRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_ACCOUNT, QUICKBOOKS_LISTID, $value));
@@ -299,40 +299,40 @@ class QuickBooks_QBXML_Object_BillPaymentCheck extends QuickBooks_QBXML_Object
 	{
 		return $this->get('BankAccountRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function getBankAccountListID()
 	{
 		return $this->get('BankAccountRef ListID');
 	}
-	
+
 	public function getBankAccountFullName()
 	{
 		return $this->get('BankAccountRef FullName');
 	}
-	
+
 	public function setMemo($memo)
 	{
 		return $this->set('Memo', $memo);
 	}
-	
+
 	public function getMemo()
 	{
 		return $this->get('Memo');
 	}
-		
+
 	/**
 	 * Perform any needed clean-up of the object data members
-	 * 
+	 *
 	 * @return boolean
 	 */
 	protected function _cleanup()
 	{
 		return true;
 	}
-	
+
 	/**
 	 * Get an array representation of this Class object
-	 * 
+	 *
 	 * @param string $request
 	 * @param boolean $nest
 	 * @return array
@@ -340,53 +340,53 @@ class QuickBooks_QBXML_Object_BillPaymentCheck extends QuickBooks_QBXML_Object
 	/*public function asArray($request, $nest = true)
 	{
 		$this->_cleanup();
-		
+
 		return parent::asArray($request, $nest);
 	}*/
-	
+
 	public function asList($request)
 	{
 		switch ($request)
 		{
 			case 'BillPaymentCheckAddRq':
-				
+
 				if (isset($this->_object['AppliedToTxn']))
 				{
 					$this->_object['AppliedToTxnAdd'] = $this->_object['AppliedToTxn'];
 				}
-				
+
 				break;
 			case 'BillPaymentCheckModRq':
-				
+
 				if (isset($this->_object['AppliedToTxn']))
 				{
-					$this->_object['AppliedToTxnMod'] = $this->_object['AppliedToTxn'];	
+					$this->_object['AppliedToTxnMod'] = $this->_object['AppliedToTxn'];
 				}
-				
+
 				break;
 		}
-		
+
 		return parent::asList($request);
 	}
-	
+
 	public function asXML($root = null, $parent = null, $object = null)
 	{
 		if (is_null($object))
 		{
 			$object = $this->_object;
 		}
-				
+
 		switch ($root)
 		{
 			case QUICKBOOKS_ADD_BILLPAYMENTCHECK:
-				
+
 				/*
 				if (isset($this->_object['AppliedToTxn']))
 				{
 					$this->_object['AppliedToTxnAdd'] = $this->_object['AppliedToTxn'];
 				}
 				*/
-				
+
 				if ($this->exists('AppliedToTxnAdd'))
 				{
 					foreach ($object['AppliedToTxnAdd'] as $key => $obj)
@@ -394,39 +394,21 @@ class QuickBooks_QBXML_Object_BillPaymentCheck extends QuickBooks_QBXML_Object
 						$obj->setOverride('AppliedToTxnAdd');
 					}
 				}
-				
+
 				break;
 			case QUICKBOOKS_MOD_BILLPAYMENTCHECK:
-				
+
 				// finish me!
-				
+
 				break;
 		}
-		
+
 		return parent::asXML($root, $parent, $object);
 	}
-	
+
 	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	/*
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	*/
-	
-	/**
-	 * Tell what type of object this is 
-	 * 
+	 * Tell what type of object this is
+	 *
 	 * @return string
 	 */
 	public function object()

--- a/QuickBooks/QBXML/Object/Check.php
+++ b/QuickBooks/QBXML/Object/Check.php
@@ -1,14 +1,14 @@
-<?php 
+<?php
 
 /**
- * Check class for QuickBooks 
- * 
+ * Check class for QuickBooks
+ *
  * @author Keith Palmer Jr. <keith@ConsoliBYTE.com>
  * @license LICENSE.txt
- * 
+ *
  * @package QuickBooks
  * @subpackage Object
- */ 
+ */
 
 /**
  * QuickBooks object base class
@@ -36,13 +36,13 @@ QuickBooks_Loader::load('/QuickBooks/QBXML/Object/Check/ItemGroupLine.php');
 QuickBooks_Loader::load('/QuickBooks/QBXML/Object/Check/ApplyCheckToTxn.php');
 
 /**
- * 
+ *
  */
 class QuickBooks_QBXML_Object_Check extends QuickBooks_QBXML_Object
 {
 	/**
 	 * Create a new QuickBooks_Object_Check object
-	 * 
+	 *
 	 * @param array $arr
 	 */
 	public function __construct($arr = array())
@@ -50,11 +50,11 @@ class QuickBooks_QBXML_Object_Check extends QuickBooks_QBXML_Object
 		parent::__construct($arr);
 	}
 
-	// Path: AccountRef ListID, datatype: 
-	
+	// Path: AccountRef ListID, datatype:
+
 	/**
 	 * Set the AccountRef ListID for the Check
-	 * 
+	 *
 	 * @param string $ListID		The ListID of the record to reference
 	 * @return boolean
 	 */
@@ -65,7 +65,7 @@ class QuickBooks_QBXML_Object_Check extends QuickBooks_QBXML_Object
 
 	/**
 	 * Get the AccountRef ListID for the Check
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getAccountListID()
@@ -75,7 +75,7 @@ class QuickBooks_QBXML_Object_Check extends QuickBooks_QBXML_Object
 
 	/**
 	 * Set the primary key for the related record within your own application for the Check
-	 * 
+	 *
 	 * @param mixed $value			The primary key within your own application
 	 * @return string
 	 */
@@ -89,11 +89,11 @@ class QuickBooks_QBXML_Object_Check extends QuickBooks_QBXML_Object
 		return $this->get('AccountRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
 
-	// Path: AccountRef FullName, datatype: 
-	
+	// Path: AccountRef FullName, datatype:
+
 	/**
 	 * Set the AccountRef FullName for the Check
-	 * 
+	 *
 	 * @param string $FullName		The FullName of the record to reference
 	 * @return boolean
 	 */
@@ -104,7 +104,7 @@ class QuickBooks_QBXML_Object_Check extends QuickBooks_QBXML_Object
 
 	/**
 	 * Get the AccountRef FullName for the Check
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getAccountName()
@@ -112,11 +112,11 @@ class QuickBooks_QBXML_Object_Check extends QuickBooks_QBXML_Object
 		return $this->get('AccountRef FullName');
 	}
 
-	// Path: PayeeEntityRef ListID, datatype: 
-	
+	// Path: PayeeEntityRef ListID, datatype:
+
 	/**
 	 * Set the PayeeEntityRef ListID for the Check
-	 * 
+	 *
 	 * @param string $ListID		The ListID of the record to reference
 	 * @return boolean
 	 */
@@ -127,7 +127,7 @@ class QuickBooks_QBXML_Object_Check extends QuickBooks_QBXML_Object
 
 	/**
 	 * Get the PayeeEntityRef ListID for the Check
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getPayeeEntityListID()
@@ -137,7 +137,7 @@ class QuickBooks_QBXML_Object_Check extends QuickBooks_QBXML_Object
 
 	/**
 	 * Set the primary key for the related record within your own application for the Check
-	 * 
+	 *
 	 * @param mixed $value			The primary key within your own application
 	 * @return string
 	 */
@@ -151,11 +151,11 @@ class QuickBooks_QBXML_Object_Check extends QuickBooks_QBXML_Object
 		return $this->get('PayeeEntityRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
 
-	// Path: PayeeEntityRef FullName, datatype: 
-	
+	// Path: PayeeEntityRef FullName, datatype:
+
 	/**
 	 * Set the PayeeEntityRef FullName for the Check
-	 * 
+	 *
 	 * @param string $FullName		The FullName of the record to reference
 	 * @return boolean
 	 */
@@ -166,7 +166,7 @@ class QuickBooks_QBXML_Object_Check extends QuickBooks_QBXML_Object
 
 	/**
 	 * Get the PayeeEntityRef FullName for the Check
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getPayeeEntityFullName()
@@ -175,10 +175,10 @@ class QuickBooks_QBXML_Object_Check extends QuickBooks_QBXML_Object
 	}
 
 	// Path: RefNumber, datatype: STRTYPE
-	
+
 	/**
 	 * Set the RefNumber for the Check
-	 * 
+	 *
 	 * @param string $value
 	 * @return boolean
 	 */
@@ -189,7 +189,7 @@ class QuickBooks_QBXML_Object_Check extends QuickBooks_QBXML_Object
 
 	/**
 	 * Get the RefNumber for the Check
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getRefNumber()
@@ -198,10 +198,10 @@ class QuickBooks_QBXML_Object_Check extends QuickBooks_QBXML_Object
 	}
 
 	// Path: TxnDate, datatype: DATETYPE
-	
+
 	/**
 	 * Set the TxnDate for the Check
-	 * 
+	 *
 	 * @param string $date
 	 * @return boolean
 	 */
@@ -212,7 +212,7 @@ class QuickBooks_QBXML_Object_Check extends QuickBooks_QBXML_Object
 
 	/**
 	 * Get the TxnDate for the Check
-	 * 
+	 *
 	 * @param ? $format = null
 	 * @return string
 	 */
@@ -226,7 +226,7 @@ class QuickBooks_QBXML_Object_Check extends QuickBooks_QBXML_Object
 	 */
 	public function setTransactionDate($date)
 	{
-		return $this->setTxnDate($date); 
+		return $this->setTxnDate($date);
 	}
 
 	/**
@@ -237,10 +237,10 @@ class QuickBooks_QBXML_Object_Check extends QuickBooks_QBXML_Object
 		return $this->getTxnDate($format = null);
 	}
 	// Path: Memo, datatype: STRTYPE
-	
+
 	/**
 	 * Set the Memo for the Check
-	 * 
+	 *
 	 * @param string $value
 	 * @return boolean
 	 */
@@ -251,7 +251,7 @@ class QuickBooks_QBXML_Object_Check extends QuickBooks_QBXML_Object
 
 	/**
 	 * Get the Memo for the Check
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getMemo()
@@ -260,10 +260,10 @@ class QuickBooks_QBXML_Object_Check extends QuickBooks_QBXML_Object
 	}
 
 	// Path: IsToBePrinted, datatype: BOOLTYPE
-	
+
 	/**
 	 * Set the IsToBePrinted for the Check
-	 * 
+	 *
 	 * @param boolean $bool
 	 * @return boolean
 	 */
@@ -274,7 +274,7 @@ class QuickBooks_QBXML_Object_Check extends QuickBooks_QBXML_Object
 
 	/**
 	 * Get the IsToBePrinted for the Check
-	 * 
+	 *
 	 * @return boolean
 	 */
 	public function getIsToBePrinted()
@@ -283,10 +283,10 @@ class QuickBooks_QBXML_Object_Check extends QuickBooks_QBXML_Object
 	}
 
 	// Path: IsTaxIncluded, datatype: BOOLTYPE
-	
+
 	/**
 	 * Set the IsTaxIncluded for the Check
-	 * 
+	 *
 	 * @param boolean $bool
 	 * @return boolean
 	 */
@@ -297,7 +297,7 @@ class QuickBooks_QBXML_Object_Check extends QuickBooks_QBXML_Object
 
 	/**
 	 * Get the IsTaxIncluded for the Check
-	 * 
+	 *
 	 * @return boolean
 	 */
 	public function getIsTaxIncluded()
@@ -305,11 +305,11 @@ class QuickBooks_QBXML_Object_Check extends QuickBooks_QBXML_Object
 		return $this->getBooleanType('IsTaxIncluded');
 	}
 
-	// Path: SalesTaxCodeRef ListID, datatype: 
-	
+	// Path: SalesTaxCodeRef ListID, datatype:
+
 	/**
 	 * Set the SalesTaxCodeRef ListID for the Check
-	 * 
+	 *
 	 * @param string $ListID		The ListID of the record to reference
 	 * @return boolean
 	 */
@@ -320,7 +320,7 @@ class QuickBooks_QBXML_Object_Check extends QuickBooks_QBXML_Object
 
 	/**
 	 * Get the SalesTaxCodeRef ListID for the Check
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getSalesTaxCodeListID()
@@ -330,7 +330,7 @@ class QuickBooks_QBXML_Object_Check extends QuickBooks_QBXML_Object
 
 	/**
 	 * Set the primary key for the related record within your own application for the Check
-	 * 
+	 *
 	 * @param mixed $value			The primary key within your own application
 	 * @return string
 	 */
@@ -344,11 +344,11 @@ class QuickBooks_QBXML_Object_Check extends QuickBooks_QBXML_Object
 		return $this->get('SalesTaxCodeRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
 
-	// Path: SalesTaxCodeRef FullName, datatype: 
-	
+	// Path: SalesTaxCodeRef FullName, datatype:
+
 	/**
 	 * Set the SalesTaxCodeRef FullName for the Check
-	 * 
+	 *
 	 * @param string $FullName		The FullName of the record to reference
 	 * @return boolean
 	 */
@@ -359,7 +359,7 @@ class QuickBooks_QBXML_Object_Check extends QuickBooks_QBXML_Object
 
 	/**
 	 * Get the SalesTaxCodeRef FullName for the Check
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getSalesTaxCodeName()
@@ -376,17 +376,17 @@ class QuickBooks_QBXML_Object_Check extends QuickBooks_QBXML_Object
 	{
 		return $this->addListItem('ItemGroupLine', $obj);
 	}
-	
+
 	public function addExpenseLine($obj)
 	{
 		return $this->addListItem('ExpenseLine', $obj);
 	}
-	
+
 	public function addAddCheckToTxn($obj)
 	{
 		return $this->addListItem('AddCheckToTxn', $obj);
 	}
-	
+
 	public function setAddress($addr1, $addr2 = '', $addr3 = '', $addr4 = '', $addr5 = '', $city = '', $state = '', $postalcode = '', $country = '', $note = '')
 	{
 		return $this->_setAddress('', $addr1, $addr2, $addr3, $addr4, $addr5, $city, $state, $postalcode, $country, $note);
@@ -410,48 +410,48 @@ class QuickBooks_QBXML_Object_Check extends QuickBooks_QBXML_Object
 		switch ($request)
 		{
 			case 'CheckAddRq':
-				
+
 				if (isset($this->_object['ItemLine']))
 				{
 					$this->_object['ItemLineAdd'] = $this->_object['ItemLine'];
 				}
-				
+
 				if (isset($this->_object['ItemGroupLine']))
 				{
 					$this->_object['ItemGroupLineAdd'] = $this->_object['ItemGroupLine'];
 				}
-				
+
 				if (isset($this->_object['ExpenseLine']))
 				{
 					$this->_object['ExpenseLineAdd'] = $this->_object['ExpenseLine'];
 				}
-				
+
 				if (isset($this->_object['AddCheckToTxn']))
 				{
 					$this->_object['AddCheckToTxnAdd'] = $this->_object['AddCheckToTxn'];
 				}
-				
+
 				break;
 			case 'CheckModRq':
-				
-				
+
+
 				break;
 		}
-		
+
 		return parent::asList($request);
 	}
-	
+
 	public function asXML($root = null, $parent = null, $object = null)
 	{
 		if (is_null($object))
 		{
 			$object = $this->_object;
 		}
-		
+
 		switch ($root)
 		{
 			case QUICKBOOKS_ADD_CHECK:
-				
+
 				if (!empty($object['ItemLineAdd']))
 				{
 					foreach ($object['ItemLineAdd'] as $key => $obj)
@@ -465,9 +465,9 @@ class QuickBooks_QBXML_Object_Check extends QuickBooks_QBXML_Object
 					foreach ($object['ItemGroupLineAdd'] as $key => $obj)
 					{
 						$obj->setOverride('ItemGroupLineAdd');
-					}				
+					}
 				}
-				
+
 				if (!empty($object['ExpenseLineAdd']))
 				{
 					foreach ($object['ExpenseLineAdd'] as $key => $obj)
@@ -475,15 +475,15 @@ class QuickBooks_QBXML_Object_Check extends QuickBooks_QBXML_Object
 						$obj->setOverride('ExpenseLineAdd');
 					}
 				}
-				
+
 				if (!empty($object['ApplyCheckToTxnAdd']))
 				{
 					foreach ($object['ApplyCheckToTxnAdd'] as $key => $obj)
 					{
 						$obj->setOverride('ApplyCheckToTxnAdd');
-					}			
+					}
 				}
-				
+
 				break;
 			case QUICKBOOKS_MOD_CHECK:
 				if (isset($object['ItemLine']))
@@ -492,49 +492,18 @@ class QuickBooks_QBXML_Object_Check extends QuickBooks_QBXML_Object
 				}
 				break;
 		}
-		
+
 		return parent::asXML($root, $parent, $object);
 	}
-	
+
 	/**
-	 * 
-	 */
-	public function asArray($request, $nest = true)
-	{
-		$this->_cleanup();
-		return parent::asArray($request, $nest);
-	}
-	
-	/**
-	 * 
-	 * 
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QuickBooks_QBXML_Object::XML_DROP, $indent = "\t", $root = null, $parent = null)
-	{
-		$this->_cleanup();
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
+	 * Tell what type of object this is
 	 *
-	 */
-	protected function _cleanup()
-	{
-		
-	}
-	
-	/**
-	 * Tell what type of object this is 
-	 * 
 	 * @return string
 	 */
 	public function object()
 	{
 		return QUICKBOOKS_OBJECT_CHECK;
-	}	
+	}
 }
 

--- a/QuickBooks/QBXML/Object/Class.php
+++ b/QuickBooks/QBXML/Object/Class.php
@@ -2,37 +2,37 @@
 
 /**
  * QuickBooks Class object container
- * 
+ *
  * @author Keith Palmer <keith@consolibyte.com>
  * @license LICENSE.txt
- * 
+ *
  * @package QuickBooks
  * @subpackage Object
  */
 
 /**
- * 
+ *
  */
 QuickBooks_Loader::load('/QuickBooks/QBXML/Object.php');
 
 /**
- * 
+ *
  */
 class QuickBooks_QBXML_Object_Class extends QuickBooks_QBXML_Object
 {
 	/**
 	 * Create a new QuickBooks_Object_Class object
-	 * 
+	 *
 	 * @param array $arr
 	 */
 	public function __construct($arr = array())
 	{
 		parent::__construct($arr);
 	}
-	
+
 	/**
 	 * Set the ListID of the Class
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return boolean
 	 */
@@ -40,30 +40,30 @@ class QuickBooks_QBXML_Object_Class extends QuickBooks_QBXML_Object
 	{
 		return $this->set('ListID', $ListID);
 	}
-	
+
 	/**
 	 * Get the ListID of the Class
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getListID()
 	{
 		return $this->get('ListID');
 	}
-	
+
 	/**
-	 * 
+	 *
 	 */
 	public function setParentListID($ListID)
 	{
 		return $this->set('ParentRef ListID', $ListID);
 	}
-	
+
 	public function getParentListID()
 	{
 		return $this->get('ParentRef ListID');
 	}
-	
+
 	/**
 	 * @deprecated
 	 */
@@ -76,12 +76,12 @@ class QuickBooks_QBXML_Object_Class extends QuickBooks_QBXML_Object
 	{
 		return $this->set('ParentRef FullName', $name);
 	}
-	
+
 	public function getParentFullName()
 	{
 		return $this->get('ParentRef FullName');
 	}
-	
+
 	/**
 	 * @deprecated
 	 */
@@ -89,10 +89,10 @@ class QuickBooks_QBXML_Object_Class extends QuickBooks_QBXML_Object
 	{
 		return $this->get('ParentRef FullName');
 	}
-	
+
 	/**
 	 * Set the name of the class
-	 * 
+	 *
 	 * @param string $name
 	 * @return boolean
 	 */
@@ -100,19 +100,19 @@ class QuickBooks_QBXML_Object_Class extends QuickBooks_QBXML_Object
 	{
 		return $this->set('Name', $name);
 	}
-	
+
 	/**
 	 * Get the name of the class
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getName()
 	{
 		return $this->get('Name');
 	}
-	
+
 	/**
-	 * 
+	 *
 	 */
 	public function getFullName()
 	{
@@ -123,10 +123,10 @@ class QuickBooks_QBXML_Object_Class extends QuickBooks_QBXML_Object
 	{
 		return $this->set('FullName', $name);
 	}
-	
+
 	/**
 	 * Set this Class active or not
-	 * 
+	 *
 	 * @param boolean $value
 	 * @return boolean
 	 */
@@ -134,60 +134,20 @@ class QuickBooks_QBXML_Object_Class extends QuickBooks_QBXML_Object
 	{
 		return $this->set('IsActive', (boolean) $value);
 	}
-	
+
 	/**
 	 * Tell whether or not this class object is active
-	 * 
+	 *
 	 * @return boolean
 	 */
 	public function getIsActive()
 	{
 		return $this->get('IsActive');
 	}
-	
+
 	/**
-	 * Perform any needed clean-up of the object data members
-	 * 
-	 * @return boolean
-	 */
-	protected function _cleanup()
-	{
-		return true;
-	}
-	
-	/**
-	 * Get an array representation of this Class object
-	 * 
-	 * @param string $request
-	 * @param boolean $nest
-	 * @return array
-	 */
-	public function asArray($request, $nest = true)
-	{
-		$this->_cleanup();
-		
-		return parent::asArray($request, $nest);
-	}
-	
-	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $version = null, $locale = null, $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $version, $locale, $root);
-	}
-	
-	/**
-	 * Tell what type of object this is 
-	 * 
+	 * Tell what type of object this is
+	 *
 	 * @return string
 	 */
 	public function object()

--- a/QuickBooks/QBXML/Object/CreditCardRefund.php
+++ b/QuickBooks/QBXML/Object/CreditCardRefund.php
@@ -2,12 +2,12 @@
 
 /**
  * QuickBooks CreditCardRefund object
- * 
+ *
  * @author Jayson Lindsley <jay.lindsley@gmail.com>
  * @author Keith Palmer <keith@consolibyte.com>
  *
  * @license LICENSE.txt
- * 
+ *
  * @package QuickBooks
  * @subpackage Object
  */
@@ -25,7 +25,7 @@ QuickBooks_Loader::load('/QuickBooks/QBXML/Object.php');
  {
  	/**
 	 * Create a new QuickBooks_Object_Customer object
-	 * 
+	 *
 	 * @param array $arr
 	 */
 
@@ -68,17 +68,17 @@ QuickBooks_Loader::load('/QuickBooks/QBXML/Object.php');
 	{
 		return $this->set('ARAccountRef ListID', $ListID);
 	}
-	
+
 	public function setARAccountName($name)
 	{
 		return $this->set('ARAccountRef FullName', $name);
 	}
-	
+
 	public function getARAccountListID()
 	{
 		return $this->get('ARAccountRef ListID');
 	}
-	
+
 	public function getARAccountName()
 	{
 		return $this->get('ARAccountRef FullName');
@@ -88,17 +88,17 @@ QuickBooks_Loader::load('/QuickBooks/QBXML/Object.php');
 	{
 		return $this->set('PaymentMethodRef FullName', $name);
 	}
-	
+
 	public function getPaymentMethodName()
 	{
 		return $this->get('PaymentMethodRef FullName');
 	}
-	
+
 	public function setPaymentMethodListID($ListID)
 	{
 		return $this->set('PaymentMethodRef ListID', $ListID);
 	}
-	
+
 	public function getPaymentMethodListID()
 	{
 		return $this->get('PaymentMethodRef ListID');
@@ -128,13 +128,13 @@ QuickBooks_Loader::load('/QuickBooks/QBXML/Object.php');
 	{
 		return $this->set('Memo', $memo);
 	}
-	
+
 	public function getMemo()
 	{
 		return $this->get('Memo');
 	}
-	
-	public function setRefundAppliedToTxnID($ID) 
+
+	public function setRefundAppliedToTxnID($ID)
 	{
 		return $this->set('RefundAppliedToTxnAdd TxnID', $ID);
 	}
@@ -248,10 +248,10 @@ QuickBooks_Loader::load('/QuickBooks/QBXML/Object.php');
 
 	/**
 	 * Set the credit card information for this refund
-	 * 
+	 *
 	 * @param string $cardno		The credit card number
 	 * @param integer $expmonth		The expiration month (1 is January, 2 is February, etc.)
-	 * @param integer $expyear		The expiration year 
+	 * @param integer $expyear		The expiration year
 	 * @param string $name			The name on the credit card
 	 * @param string $address		The billing address for the credit card
 	 * @param string $postalcode	The postal code for the credit card
@@ -267,13 +267,13 @@ QuickBooks_Loader::load('/QuickBooks/QBXML/Object.php');
 		$b = $this->set('CreditCardInfo NameOnCard', $name);
 		$b = $this->set('CreditCardInfo CreditCardAddress', $address);
 		$b = $this->set('CreditCardInfo CreditCardPostalCode', $postalcode);
-		
+
 		return $b;
 	}
 
 	/**
 	 * Get credit card information from the refund
-	 * 
+	 *
 	 * @param string $part		If you just want a specific part of the card info, specify it here
 	 * @param array $defaults	Defaults for the card data if you want the entire array
 	 * @return mixed			If you specify a part, a string part is returned, otherwise an array of card data
@@ -284,13 +284,13 @@ QuickBooks_Loader::load('/QuickBooks/QBXML/Object.php');
 		{
 			return $this->get('CreditCardInfo ' . $part);
 		}
-		
-		return $this->getArray('CreditCardInfo *', $defaults);		
+
+		return $this->getArray('CreditCardInfo *', $defaults);
 	}
 
 	/**
 	 * Set the address for the refund (optional)
-	 * 
+	 *
 	 * @param string $addr1			Address line 1
 	 * @param string $addr2			Address line 2
 	 * @param string $addr3			Address line 3
@@ -310,18 +310,18 @@ QuickBooks_Loader::load('/QuickBooks/QBXML/Object.php');
 		{
 			$this->set('Address Addr' . $i, ${'addr' . $i});
 		}
-		
+
 		$this->set('Address City', $city);
 		$this->set('Address State', $state);
 		$this->set('Address Province', $province);
 		$this->set('Address PostalCode', $postalcode);
 		$this->set('Address Country', $country);
-		$this->set('Address Note', $note);  
+		$this->set('Address Note', $note);
 	}
 
 	/**
-	 * Get the address 
-	 * 
+	 * Get the address
+	 *
 	 * @param string $part			A specific portion of the address to get (i.e. "Addr1" or "State")
 	 * @param array $defaults		Default values if a value isn't filled in
 	 * @return array				The address
@@ -332,13 +332,13 @@ QuickBooks_Loader::load('/QuickBooks/QBXML/Object.php');
 		{
 			return $this->get('Address ' . $part);
 		}
-		
+
 		return $this->getArray('Address *', $defaults);
 	}
 
 	/**
 	 * Set the transaction date
-	 * 
+	 *
 	 * @param string $date
 	 * @return boolean
 	 */
@@ -349,7 +349,7 @@ QuickBooks_Loader::load('/QuickBooks/QBXML/Object.php');
 
 	/**
 	 * Get the transaction date
-	 * 
+	 *
 	 * @param string $format	The format you want the date in (as for {@link http://www.php.net/date})
 	 * @return string
 	 */
@@ -357,34 +357,6 @@ QuickBooks_Loader::load('/QuickBooks/QBXML/Object.php');
 	{
 		//return date($format, strtotime($this->get('TxnDate')));
 		return $this->getDateType('TxnDate', $format);
-	}
-
-
-	protected function _cleanup()
-	{
-		return true;
-	}
-
-	public function asArray($request, $nest = true)
-	{
-		$this->_cleanup();
-		return parent::asArray($request, $nest);
-	}
-	
-	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request						The type of request to convert this to (ARRefundCreditCardAddRq, or ARRefundCreditCardQuery)
-	 * @param boolean $todo_for_empty_elements		A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = NULL, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
 	}
 
 	public function object()

--- a/QuickBooks/QBXML/Object/CreditMemo.php
+++ b/QuickBooks/QBXML/Object/CreditMemo.php
@@ -2,14 +2,14 @@
 
 /**
  * QuickBooks CreditCardMemo object container
- * 
+ *
  * @author Jayson Lindsley <jay.lindsley@gmail.com>
  * @author Keith Palmer <keith@consolibyte.com>
  *
  * TODO: Add support for items as per the QBXML spec
  *
  * @license LICENSE.txt
- * 
+ *
  * @package QuickBooks
  * @subpackage Object
  */
@@ -32,7 +32,7 @@ class Quickbooks_QBXML_Object_CreditMemo extends QuickBooks_QBXML_Object
 {
  	/**
 	 * Create a new QuickBooks_Object_Customer object
-	 * 
+	 *
 	 * @param array $arr
 	 */
 
@@ -61,9 +61,9 @@ class Quickbooks_QBXML_Object_CreditMemo extends QuickBooks_QBXML_Object
 		return $this->get('CustomerRef FullName');
 	}
 
-	/** 
+	/**
 	 * Set the class ListID for this creditmemo line item
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return boolean
 	 */
@@ -72,9 +72,9 @@ class Quickbooks_QBXML_Object_CreditMemo extends QuickBooks_QBXML_Object
 		return $this->set('ClassRef ListID', $ListID);
 	}
 
-	/** 
+	/**
 	 * Set the class name for this invoice line item
-	 * 
+	 *
 	 * @param string $name
 	 * @return boolean
 	 */
@@ -87,12 +87,12 @@ class Quickbooks_QBXML_Object_CreditMemo extends QuickBooks_QBXML_Object
 	{
 		return $this->set('ClassRef FullName', $name);
 	}
-	
+
 	public function getClassListID()
 	{
 		return $this->get('ClassRef ListID');
 	}
-	
+
 	public function getClassName()
 	{
 		return $this->get('ClassRef FullName');
@@ -100,7 +100,7 @@ class Quickbooks_QBXML_Object_CreditMemo extends QuickBooks_QBXML_Object
 
 	/**
 	 * Set the reference number
-	 * 
+	 *
 	 * @param string $str
 	 * @return boolean
 	 */
@@ -108,7 +108,7 @@ class Quickbooks_QBXML_Object_CreditMemo extends QuickBooks_QBXML_Object
 	{
 		return $this->set('RefNumber', $str);
 	}
-	
+
 	/**
 	 * Alias of {@link QuickBooks_Object_Invoice::setRefNumber()}
 	 */
@@ -116,10 +116,10 @@ class Quickbooks_QBXML_Object_CreditMemo extends QuickBooks_QBXML_Object
 	{
 		return $this->setRefNumber($str);
 	}
-	
+
 	/**
 	 * Get the reference number
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getRefNumber()
@@ -134,7 +134,7 @@ class Quickbooks_QBXML_Object_CreditMemo extends QuickBooks_QBXML_Object
 	{
 		return $this->getRefNumber();
 	}
-	
+
 	public function setSalesRepName($name)
 	{
 		return $this->set('SalesRepRef FullName', $name);
@@ -157,7 +157,7 @@ class Quickbooks_QBXML_Object_CreditMemo extends QuickBooks_QBXML_Object
 
 	/**
 	 * Set the transaction date
-	 * 
+	 *
 	 * @param string $date
 	 * @return boolean
 	 */
@@ -168,7 +168,7 @@ class Quickbooks_QBXML_Object_CreditMemo extends QuickBooks_QBXML_Object
 
 	/**
 	 * Get the transaction date
-	 * 
+	 *
 	 * @param string $format	The format you want the date in (as for {@link http://www.php.net/date})
 	 * @return string
 	 */
@@ -187,17 +187,17 @@ class Quickbooks_QBXML_Object_CreditMemo extends QuickBooks_QBXML_Object
 	{
 		return $this->set('ShipMethodRef FullName', $name);
 	}
-	
+
 	public function setShipMethodListID($ListID)
 	{
 		return $this->set('ShipMethodRef ListID', $ListID);
 	}
-	
+
 	public function getShipMethodName()
 	{
 		return $this->get('ShipMethodRef FullName');
 	}
-	
+
 	public function getShipMethodListID()
 	{
 		return $this->get('ShipMethodRef ListID');
@@ -207,7 +207,7 @@ class Quickbooks_QBXML_Object_CreditMemo extends QuickBooks_QBXML_Object
 	{
 		return $this->set('ItemSalesTaxRef FullName', $name);
 	}
-	
+
 	public function getSalesTaxItemName()
 	{
 		return $this->get('ItemSalesTaxRef FullName');
@@ -218,11 +218,11 @@ class Quickbooks_QBXML_Object_CreditMemo extends QuickBooks_QBXML_Object
 		switch ($request)
 		{
 			case 'CreditMemoAddRq':
-				
+
 				if (isset($this->_object['CreditMemoLine']))
 				{
 					$this->_object['CreditMemoLineAdd'] = $this->_object['CreditMemoLine'];
-				}		
+				}
 				break;
 
 			case 'CreditMemoModRq':
@@ -230,7 +230,7 @@ class Quickbooks_QBXML_Object_CreditMemo extends QuickBooks_QBXML_Object
 				if (isset($this->_object['CreditMemoLine']))
 				{
 					$this->_object['CreditMemoLineMod'] = $this->_object['CreditMemoLine'];
-				}		
+				}
 				break;
 		}
 		return parent::asList($request);
@@ -242,7 +242,7 @@ class Quickbooks_QBXML_Object_CreditMemo extends QuickBooks_QBXML_Object
 		{
 			$object = $this->_object;
 		}
-		
+
 		switch ($root)
 		{
 			case QUICKBOOKS_ADD_CREDITMEMO:
@@ -260,33 +260,6 @@ class Quickbooks_QBXML_Object_CreditMemo extends QuickBooks_QBXML_Object
 				break;
 		}
 		return parent::asXML($root, $parent, $object);
-	}
-
-	protected function _cleanup()
-	{
-		return true;
-	}
-
-	public function asArray($request, $nest = true)
-	{
-		$this->_cleanup();
-		
-		return parent::asArray($request, $nest);
-	}
-
-	/**
-	 * 
-	 * 
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QuickBooks_QBXML_Object::XML_DROP, $indent = "\t", $root = null, $parent = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
 	}
 
 	public function object() {

--- a/QuickBooks/QBXML/Object/Customer.php
+++ b/QuickBooks/QBXML/Object/Customer.php
@@ -2,10 +2,10 @@
 
 /**
  * QuickBooks Customer object container
- * 
+ *
  * @author Keith Palmer <keith@consolibyte.com>
  * @license LICENSE.txt
- * 
+ *
  * @package QuickBooks
  * @subpackage Object
  */
@@ -22,17 +22,17 @@ class QuickBooks_QBXML_Object_Customer extends QuickBooks_QBXML_Object
 {
 	/**
 	 * Create a new QuickBooks_Object_Customer object
-	 * 
+	 *
 	 * @param array $arr
 	 */
 	public function __construct($arr = array())
 	{
 		parent::__construct($arr);
 	}
-	
+
 	/**
 	 * Set the ListID of this customer record
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return boolean
 	 */
@@ -40,20 +40,20 @@ class QuickBooks_QBXML_Object_Customer extends QuickBooks_QBXML_Object
 	{
 		return $this->set('ListID', $ListID);
 	}
-	
+
 	/**
 	 * Get the ListID of this customer record
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getListID()
 	{
 		return $this->get('ListID');
 	}
-	
+
 	/**
 	 * Set the ListID of the parent client
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return boolean
 	 */
@@ -61,10 +61,10 @@ class QuickBooks_QBXML_Object_Customer extends QuickBooks_QBXML_Object
 	{
 		return $this->set('ParentRef ListID', $ListID);
 	}
-	
+
 	/**
 	 * Set the FullName of the parent client
-	 * 
+	 *
 	 * @param string $name
 	 * @return boolean
 	 */
@@ -72,12 +72,12 @@ class QuickBooks_QBXML_Object_Customer extends QuickBooks_QBXML_Object
 	{
 		return $this->set('ParentRef FullName', $name);
 	}
-	
+
 	public function setParentFullName($FullName)
 	{
 		return $this->set('ParentRef FullName', $FullName);
 	}
-	
+
 	/**
 	 * Set the application id of the parent client
 	 *
@@ -88,20 +88,20 @@ class QuickBooks_QBXML_Object_Customer extends QuickBooks_QBXML_Object
 	{
 		return $this->set('ParentRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_CUSTOMER, QUICKBOOKS_LISTID, $id));
 	}
-	
+
 	/**
 	 * Get the ListID of the parent client (if exists)
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getParentListID()
 	{
 		return $this->get('ParentRef ListID');
 	}
-	
+
 	/**
 	 * Get the FullName of the parent client (if exists)
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getParentName()
@@ -123,14 +123,14 @@ class QuickBooks_QBXML_Object_Customer extends QuickBooks_QBXML_Object
 	{
 		return $this->set('CurrencyRef ListID', $lid);
 	}
-	
+
 	public function setCurrencyFullName($FullName)
 	{
 		return $this->setFullNameType('CurrencyRef FullName', null, null, $FullName);
 	}
 
 
-	
+
 	/**
 	 * Set the customer type list id
 	 */
@@ -138,22 +138,22 @@ class QuickBooks_QBXML_Object_Customer extends QuickBooks_QBXML_Object
 	{
 		return $this->set('CustomerTypeRef ListID', $lid);
 	}
-	
+
 	public function setCustomerTypeFullName($FullName)
 	{
 		return $this->setFullNameType('CustomerTypeRef FullName', null, null, $FullName);
 	}
-	
+
 	public function setCustomerTypeName($name)
 	{
 		return $this->set('CustomerTypeRef FullName', $name);
 	}
-	
+
 	public function setCustomerTypeApplicationID($value)
 	{
 		return $this->set('CustomerTypeRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_CUSTOMERTYPE, QUICKBOOKS_LISTID, $value));
 	}
-	
+
 	/**
 	 * @deprecated
 	 */
@@ -166,12 +166,12 @@ class QuickBooks_QBXML_Object_Customer extends QuickBooks_QBXML_Object
 	{
 		return $this->set('TermsRef FullName', $name);
 	}
-	
+
 	public function setTermsListID($ListID)
 	{
 		return $this->set('TermsRef ListID', $ListID);
 	}
-	
+
 	/*
 	public function setTermsApplicationID($value)
 	{
@@ -182,12 +182,12 @@ class QuickBooks_QBXML_Object_Customer extends QuickBooks_QBXML_Object
 	{
 		return $this->get('TermsRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}*/
-	
+
 	public function getTermsName()
 	{
 		return $this->get('TermsRef FullName');
 	}
-	
+
 	public function getTermsListID()
 	{
 		return $this->get('TermsRef ListID');
@@ -202,12 +202,12 @@ class QuickBooks_QBXML_Object_Customer extends QuickBooks_QBXML_Object
 	{
 		return $this->set('SalesRepRef FullName', $name);
 	}
-	
+
 	public function setSalesRepListID($ListID)
 	{
 		return $this->set('SalesRepRef ListID', $ListID);
 	}
-	
+
 	/*
 	public function setSalesRepApplicationID($value)
 	{
@@ -223,50 +223,50 @@ class QuickBooks_QBXML_Object_Customer extends QuickBooks_QBXML_Object
 	{
 		return $this->get('SalesRepRef FullName');
 	}
-	
+
 	public function getSalesRepListID()
 	{
 		return $this->get('SalesRepRef ListID');
-	}	
-	
-	/** 
-	 * Set the delivery method 
-	 * 
+	}
+
+	/**
+	 * Set the delivery method
+	 *
 	 * @see QUICKBOOKS_CUSTOMER_DELIVERYMETHOD_PRINT, QUICKBOOKS_CUSTOMER_DELIVERYMETHOD_EMAIL, QUICKBOOKS_CUSTOMER_DELIVERYMETHOD_FAX
-	 * 
-	 * Only supported by QuickBooks Online Edition as of qbXML version 7.0. 
-	 * QuickBooks Online Edition has a bug where if you do not provide a 
-	 * DeliveryMethod when issueing CustomerAdd or CustomerMod requests, the 
-	 * CustomerAdd or CustomerMod request will take a very long time to 
-	 * process (2+ minutes sometimes). The fix is to simply provide this tag, 
-	 * after which requests process very quickly (2 seconds or less). 
-	 * 
+	 *
+	 * Only supported by QuickBooks Online Edition as of qbXML version 7.0.
+	 * QuickBooks Online Edition has a bug where if you do not provide a
+	 * DeliveryMethod when issueing CustomerAdd or CustomerMod requests, the
+	 * CustomerAdd or CustomerMod request will take a very long time to
+	 * process (2+ minutes sometimes). The fix is to simply provide this tag,
+	 * after which requests process very quickly (2 seconds or less).
+	 *
 	 * @param string $value
-	 * @return boolean 
+	 * @return boolean
 	 */
 	public function setDeliveryMethod($value)
 	{
 		return $this->set('DeliveryMethod', $value);
 	}
-	
+
 	/**
-	 * Get the delivery method 
-	 * 
+	 * Get the delivery method
+	 *
 	 * @see QUICKBOOKS_CUSTOMER_DELIVERYMETHOD_PRINT, QUICKBOOKS_CUSTOMER_DELIVERYMETHOD_EMAIL, QUICKBOOKS_CUSTOMER_DELIVERYMETHOD_FAX
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getDeliveryMethod()
 	{
 		return $this->get('DeliveryMethod');
 	}
-	
+
 	/**
 	 * Set the name of this customer
-	 * 
-	 * NOTE: This will be auto-set to ->getFirstName() ->getLastName() if you 
+	 *
+	 * NOTE: This will be auto-set to ->getFirstName() ->getLastName() if you
 	 * don't set it explicitly.
-	 * 
+	 *
 	 * @param string $name
 	 * @return boolean
 	 */
@@ -274,12 +274,12 @@ class QuickBooks_QBXML_Object_Customer extends QuickBooks_QBXML_Object
 	{
 		return $this->set('Name', $name);
 	}
-	
+
 	/**
 	 * Get the name of this customer
-	 * 
+	 *
 	 * @TODO What should the behavior of this be if "Name" is not set...?
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getName()
@@ -289,10 +289,10 @@ class QuickBooks_QBXML_Object_Customer extends QuickBooks_QBXML_Object
 
 	/**
 	 * Set the full name of this customer (full name)
-	 * 
-	 * NOTE: This will be auto-set to ->getName() if you don't set it 
+	 *
+	 * NOTE: This will be auto-set to ->getName() if you don't set it
 	 * explicitly.
-	 * 
+	 *
 	 * @param string $name
 	 * @return boolean
 	 */
@@ -300,20 +300,20 @@ class QuickBooks_QBXML_Object_Customer extends QuickBooks_QBXML_Object
 	{
 		return $this->setFullNameType('FullName', 'Name', 'ParentRef FullName', $name);
 	}
-	
+
 	/**
 	 * Get the name of this customer (full name)
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getFullName()
 	{
 		return $this->getFullNameType('FullName', 'Name', 'ParentRef FullName');
 	}
-	
+
 	/**
 	 * Set the company name of this customer
-	 * 
+	 *
 	 * @param string $name
 	 * @return boolean
 	 */
@@ -321,20 +321,20 @@ class QuickBooks_QBXML_Object_Customer extends QuickBooks_QBXML_Object
 	{
 		return $this->set('CompanyName', $name);
 	}
-	
+
 	/**
 	 * Get the company name of this customer
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getCompanyName()
 	{
 		return $this->get('CompanyName');
 	}
-	
+
 	/**
 	 * Set the first name of this customer
-	 * 
+	 *
 	 * @param string $name
 	 * @return boolean
 	 */
@@ -342,20 +342,20 @@ class QuickBooks_QBXML_Object_Customer extends QuickBooks_QBXML_Object
 	{
 		return $this->set('FirstName', $fname);
 	}
-	
+
 	/**
 	 * Get the first name of this customer
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getFirstName()
 	{
 		return $this->get('FirstName');
 	}
-	
+
 	/**
 	 * Set the last name of this customer
-	 * 
+	 *
 	 * @param string $lname
 	 * @return boolean
 	 */
@@ -363,68 +363,68 @@ class QuickBooks_QBXML_Object_Customer extends QuickBooks_QBXML_Object
 	{
 		return $this->set('LastName', $lname);
 	}
-	
+
 	/**
 	 * Get the last name of this customer
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getLastName()
 	{
 		return $this->get('LastName');
 	}
-	
+
 	public function setMiddleName($mname)
 	{
 		return $this->set('MiddleName', $mname);
 	}
-	
+
 	public function getMiddleName()
 	{
 		return $this->get('MiddleName');
 	}
-	
+
 	public function getShipAddress($part = null, $defaults = array())
 	{
 		return $this->_getXYZAddress('Ship', '', $part, $defaults);
 	}
-	
+
 	public function setShipAddress($addr1, $addr2 = '', $addr3 = '', $addr4 = '', $addr5 = '', $city = '', $state = '', $province = '', $postalcode = '', $country = '', $note = '')
 	{
-		return $this->_setXYZAddress('Ship', '', $addr1, $addr2, $addr3, $addr4, $addr5, $city, $state, $province, $postalcode, $country, $note);	
+		return $this->_setXYZAddress('Ship', '', $addr1, $addr2, $addr3, $addr4, $addr5, $city, $state, $province, $postalcode, $country, $note);
 	}
-	
+
 	public function getBillAddress($part = null, $defaults = array())
 	{
 		return $this->_getXYZAddress('Bill', '', $part, $defaults);
 	}
-	
+
 	public function setBillAddress(
-		$addr1, 
-		$addr2 = '', 
-		$addr3 = '', 
-		$addr4 = '', 
-		$addr5 = '', 
-		$city = '', 
-		$state = '', 
-		$province = '', 
-		$postalcode = '', 
-		$country = '', 
+		$addr1,
+		$addr2 = '',
+		$addr3 = '',
+		$addr4 = '',
+		$addr5 = '',
+		$city = '',
+		$state = '',
+		$province = '',
+		$postalcode = '',
+		$country = '',
 		$note = '')
 	{
-		return $this->_setXYZAddress('Bill', '', $addr1, $addr2, $addr3, $addr4, $addr5, $city, $state, $province, $postalcode, $country, $note);	
+		return $this->_setXYZAddress('Bill', '', $addr1, $addr2, $addr3, $addr4, $addr5, $city, $state, $province, $postalcode, $country, $note);
 	}
 
 	public function getShipAddressBlock($part = null, $defaults = array())
 	{
 		return $this->_getXYZAddress('Ship', 'Block', $part, $defaults);
 	}
-	
+
 	public function getBillAddressBlock($part = null, $defaults = array())
 	{
 		return $this->_getXYZAddress('Bill', 'Block', $part, $defaults);
 	}
-	
+
 	protected function _setXYZAddress($pre, $post, $addr1, $addr2, $addr3, $addr4, $addr5, $city, $state, $province, $postalcode, $country, $note)
 	{
 		$b = FALSE;
@@ -432,30 +432,30 @@ class QuickBooks_QBXML_Object_Customer extends QuickBooks_QBXML_Object
 		{
 			$b = $this->set($pre . 'Address' . $post . ' Addr' . $i, ${'addr' . $i});
 		}
-		
+
 		$b = $this->set($pre . 'Address' . $post . ' City', $city);
 		$b = $this->set($pre . 'Address' . $post . ' State', $state);
 		$b = $this->set($pre . 'Address' . $post . ' Province', $province);
 		$b = $this->set($pre . 'Address' . $post . ' PostalCode', $postalcode);
 		$b = $this->set($pre . 'Address' . $post . ' Country', $country);
-		$b = $this->set($pre . 'Address' . $post . ' Note', $note);		
+		$b = $this->set($pre . 'Address' . $post . ' Note', $note);
 
 		return $b;
 	}
-	
+
 	protected function _getXYZAddress($pre, $post, $part = null, $defaults = array())
 	{
 		if (!is_null($part))
 		{
 			return $this->get($pre . 'Address' . $post . ' ' . $part);
 		}
-		
+
 		return $this->getArray($pre . 'Address' . $post . ' *', $defaults);
 	}
-	
+
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 * @param string $phone
 	 * @return boolean
 	 */
@@ -468,10 +468,10 @@ class QuickBooks_QBXML_Object_Customer extends QuickBooks_QBXML_Object
 	{
 		return $this->get('Phone');
 	}
-	
+
 	/**
 	 * Set the alternate phone number for this customer
-	 * 
+	 *
 	 * @param string $phone
 	 * @return boolean
 	 */
@@ -484,12 +484,12 @@ class QuickBooks_QBXML_Object_Customer extends QuickBooks_QBXML_Object
 	{
 		return $this->get('AltPhone');
 	}
-	
+
 	/**
 	 * Set the fax number for this customer
-	 * 
+	 *
 	 * @param string $fax
-	 * @return boolean 
+	 * @return boolean
 	 */
 	public function setFax($fax)
 	{
@@ -500,10 +500,10 @@ class QuickBooks_QBXML_Object_Customer extends QuickBooks_QBXML_Object
 	{
 		return $this->get('Fax');
 	}
-	
+
 	/**
 	 * Set the e-mail address for this customer
-	 * 
+	 *
 	 * @param string $email
 	 * @return boolean
 	 */
@@ -526,10 +526,10 @@ class QuickBooks_QBXML_Object_Customer extends QuickBooks_QBXML_Object
 	{
 		return $this->get('AccountNumber');
 	}
-	
+
 	/**
 	 * Set the contact person for this customer
-	 * 
+	 *
 	 * @param string $contact
 	 * @return boolean
 	 */
@@ -537,7 +537,7 @@ class QuickBooks_QBXML_Object_Customer extends QuickBooks_QBXML_Object
 	{
 		return $this->set('Contact', $contact);
 	}
-	
+
 	/**
 	 * Get the name of the contact at this company/customer
 	 *
@@ -547,10 +547,10 @@ class QuickBooks_QBXML_Object_Customer extends QuickBooks_QBXML_Object
 	{
 		return $this->get('Contact');
 	}
-	
+
 	/**
 	 * Set the alternate contact for this customer
-	 * 
+	 *
 	 * @param string $contact
 	 * @return boolean
 	 */
@@ -558,7 +558,7 @@ class QuickBooks_QBXML_Object_Customer extends QuickBooks_QBXML_Object
 	{
 		return $this->set('AltContact', $contact);
 	}
-	
+
 	/**
 	 * Get the name of the alternate contact for this customer/company
 	 *
@@ -568,10 +568,10 @@ class QuickBooks_QBXML_Object_Customer extends QuickBooks_QBXML_Object
 	{
 		return $this->get('AltContact');
 	}
-	
+
 	/**
 	 * Set the salutation for this customer
-	 * 
+	 *
 	 * @param string $salut
 	 * @return boolean
 	 */
@@ -579,47 +579,47 @@ class QuickBooks_QBXML_Object_Customer extends QuickBooks_QBXML_Object
 	{
 		return $this->set('Salutation', $salut);
 	}
-	
+
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 * @return string
 	 */
 	public function getSalutation()
 	{
 		return $this->get('Salutation');
 	}
-			
+
 	public function getCustomerTypeApplicationID()
 	{
 		return $this->get('CustomerTypeRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function getCustomerTypeListID()
 	{
 		return $this->get('CustomerTypeRef ListID');
 	}
-	
+
 	public function getCustomerTypeName()
 	{
 		return $this->get('CustomerTypeRef FullName');
 	}
-	
+
 	public function setOpenBalance($balance)
 	{
 		return $this->set('OpenBalance', (float) $balance);
 	}
-	
+
 	public function getOpenBalance()
 	{
 		return $this->get('OpenBalance');
 	}
-	
+
 	public function setOpenBalanceDate($date)
 	{
 		return $this->setDateType('OpenBalanceDate', $date);
 	}
-	
+
 	public function getOpenBalanceDate($format = 'Y-m-d')
 	{
 		return $this->getDateType('OpenBalanceDate', $format);
@@ -627,7 +627,7 @@ class QuickBooks_QBXML_Object_Customer extends QuickBooks_QBXML_Object
 
 	/**
 	 * Get the balance for this customer (not including sub-customers or jobs)
-	 * 
+	 *
 	 * @return float
 	 */
 	public function getBalance()
@@ -642,7 +642,7 @@ class QuickBooks_QBXML_Object_Customer extends QuickBooks_QBXML_Object
 
 	/**
 	 * Get the total balance for this customer and all of this customer's sub-customers/jobs
-	 * 
+	 *
 	 * @return float
 	 */
 	public function getTotalBalance()
@@ -654,17 +654,17 @@ class QuickBooks_QBXML_Object_Customer extends QuickBooks_QBXML_Object
 	{
 		return $this->set('TotalBalance', $value);
 	}
-	
+
 	public function setSalesTaxCodeName($name)
 	{
 		return $this->set('SalesTaxCodeRef FullName', $name);
 	}
-	
+
 	public function setSalesTaxCodeListID($ListID)
 	{
 		return $this->set('SalesTaxCodeRef ListID', $ListID);
 	}
-	
+
 	public function setSalesTaxCodeApplicationID($value)
 	{
 		return $this->set('SalesTaxCodeRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_SALESTAXCODE, QUICKBOOKS_LISTID, $value));
@@ -674,23 +674,23 @@ class QuickBooks_QBXML_Object_Customer extends QuickBooks_QBXML_Object
 	{
 		return $this->get('SalesTaxCodeRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function getSalesTaxCodeName()
 	{
 		return $this->get('SalesTaxCodeRef FullName');
 	}
-	
+
 	public function getSalesTaxCodeListID()
 	{
 		return $this->get('SalesTaxCodeRef ListID');
 	}
-	
+
 	/**
 	 * Set the credit card information for this customer
-	 * 
+	 *
 	 * @param string $cardno		The credit card number
 	 * @param integer $expmonth		The expiration month (1 is January, 2 is February, etc.)
-	 * @param integer $expyear		The expiration year 
+	 * @param integer $expyear		The expiration year
 	 * @param string $name			The name on the credit card
 	 * @param string $address		The billing address for the credit card
 	 * @param string $postalcode	The postal code for the credit card
@@ -706,13 +706,13 @@ class QuickBooks_QBXML_Object_Customer extends QuickBooks_QBXML_Object
 		$b = $this->set('CreditCardInfo NameOnCard', $name);
 		$b = $this->set('CreditCardInfo CreditCardAddress', $address);
 		$b = $this->set('CreditCardInfo CreditCardPostalCode', $postalcode);
-		
+
 		return $b;
 	}
-	
+
 	/**
 	 * Get credit card information for this customer
-	 * 
+	 *
 	 * @param string $part		If you just want a specific part of the card info, specify it here
 	 * @param array $defaults	Defaults for the card data if you want the entire array
 	 * @return mixed			If you specify a part, a string part is returned, otherwise an array of card data
@@ -723,30 +723,30 @@ class QuickBooks_QBXML_Object_Customer extends QuickBooks_QBXML_Object
 		{
 			return $this->get('CreditCardInfo ' . $part);
 		}
-		
-		return $this->getArray('CreditCardInfo *', $defaults);		
+
+		return $this->getArray('CreditCardInfo *', $defaults);
 	}
-	
+
 	public function setNotes($notes)
 	{
 		return $this->set('Notes', $notes);
 	}
-	
+
 	public function getNotes()
 	{
 		return $this->get('Notes');
 	}
-	
+
 	public function setPriceLevelName($name)
 	{
 		return $this->set('PriceLevelRef FullName', $name);
 	}
-	
+
 	public function setPriceLevelListID($ListID)
 	{
 		return $this->set('PriceLevelRef ListID', $ListID);
 	}
-	
+
 	public function setPriceLevelApplicationID($value)
 	{
 		return $this->set('PriceLevelRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_PRICELEVEL, QUICKBOOKS_LISTID, $value));
@@ -756,12 +756,12 @@ class QuickBooks_QBXML_Object_Customer extends QuickBooks_QBXML_Object
 	{
 		return $this->get('PriceLevelRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function getPriceLevelName()
 	{
 		return $this->get('PriceLevelRef FullName');
 	}
-	
+
 	public function setPreferredDeliveryMethod($value)
 	{
 		return $this->set('PreferredDeliveryMethod', $value);
@@ -776,7 +776,7 @@ class QuickBooks_QBXML_Object_Customer extends QuickBooks_QBXML_Object
 	 * Get the price level list id.
 	 *
 	 * @return string
-	 */											
+	 */
 	public function getPriceLevelListID()
 	{
 		return $this->get('PriceLevelRef ListID');
@@ -784,14 +784,14 @@ class QuickBooks_QBXML_Object_Customer extends QuickBooks_QBXML_Object
 
 	/**
 	 * Initializes the default name if one hasn't been set.
-	 * 
+	 *
 	 * @return boolean
 	 */
 	protected function _cleanup()
 	{
 		//return $this->setNameAsFirstLast();
 	}
-	
+
 	/**
 	 * Returns the customer object as an array
 	 *
@@ -800,29 +800,13 @@ class QuickBooks_QBXML_Object_Customer extends QuickBooks_QBXML_Object
 	public function asArray($request, $nest = true)
 	{
 		$this->_cleanup();
-		
+
 		return parent::asArray($request, $nest);
 	}
-	
+
 	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $version = null, $locale = null, $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $version, $locale, $root);
-	}
-	
-	/**
-	 * Tell what type of object this is 
-	 * 
+	 * Tell what type of object this is
+	 *
 	 * @return string
 	 */
 	public function object()

--- a/QuickBooks/QBXML/Object/CustomerType.php
+++ b/QuickBooks/QBXML/Object/CustomerType.php
@@ -2,37 +2,37 @@
 
 /**
  * QuickBooks CustomerType object container
- * 
+ *
  * @author Keith Palmer <keith@consolibyte.com>
- * @license LICENSE.txt 
- * 
+ * @license LICENSE.txt
+ *
  * @package QuickBooks
  * @subpackage Object
  */
 
 /**
- * 
+ *
  */
 QuickBooks_Loader::load('/QuickBooks/QBXML/Object.php');
 
 /**
- * 
+ *
  */
 class QuickBooks_QBXML_Object_CustomerType extends QuickBooks_QBXML_Object
 {
 	/**
 	 * Create a new QuickBooks_Object_Class object
-	 * 
+	 *
 	 * @param array $arr
 	 */
 	public function __construct($arr = array())
 	{
 		parent::__construct($arr);
 	}
-	
+
 	/**
 	 * Set the ListID of the Class
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return boolean
 	 */
@@ -40,30 +40,30 @@ class QuickBooks_QBXML_Object_CustomerType extends QuickBooks_QBXML_Object
 	{
 		return $this->set('ListID', $ListID);
 	}
-	
+
 	/**
 	 * Get the ListID of the Class
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getListID()
 	{
 		return $this->get('ListID');
 	}
-	
+
 	/**
-	 * 
+	 *
 	 */
 	public function setParentListID($ListID)
 	{
 		return $this->set('ParentRef ListID', $ListID);
 	}
-	
+
 	public function getParentListID()
 	{
 		return $this->get('ParentRef ListID');
 	}
-	
+
 	/**
 	 * @deprecated
 	 */
@@ -71,7 +71,7 @@ class QuickBooks_QBXML_Object_CustomerType extends QuickBooks_QBXML_Object
 	{
 		return $this->set('ParentRef FullName', $name);
 	}
-	
+
 	/**
 	 * @deprecated
 	 */
@@ -79,30 +79,30 @@ class QuickBooks_QBXML_Object_CustomerType extends QuickBooks_QBXML_Object
 	{
 		return $this->get('ParentRef FullName');
 	}
-	
+
 	public function setParentFullName($name)
 	{
 		return $this->set('ParentRef FullName', $name);
 	}
-	
+
 	public function getParentFullName()
 	{
 		return $this->get('ParentRef FullName');
 	}
-	
+
 	public function setParentApplicationID($value)
 	{
 		return $this->set('ParentRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID($this->object(), QUICKBOOKS_LISTID, $value));
 	}
-	
+
 	public function getParentApplicationID()
 	{
 		return $this->get('ParentRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	/**
 	 * Set the name of the class
-	 * 
+	 *
 	 * @param string $name
 	 * @return boolean
 	 */
@@ -110,19 +110,19 @@ class QuickBooks_QBXML_Object_CustomerType extends QuickBooks_QBXML_Object
 	{
 		return $this->set('Name', $name);
 	}
-	
+
 	/**
 	 * Get the name of the class
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getName()
 	{
 		return $this->get('Name');
 	}
-	
+
 	/**
-	 * 
+	 *
 	 */
 	public function getFullName()
 	{
@@ -133,10 +133,10 @@ class QuickBooks_QBXML_Object_CustomerType extends QuickBooks_QBXML_Object
 	{
 		return $this->set('FullName', $name);
 	}
-	
+
 	/**
 	 * Set this Class active or not
-	 * 
+	 *
 	 * @param boolean $value
 	 * @return boolean
 	 */
@@ -144,60 +144,20 @@ class QuickBooks_QBXML_Object_CustomerType extends QuickBooks_QBXML_Object
 	{
 		return $this->setBooleanType('IsActive', $value);
 	}
-	
+
 	/**
 	 * Tell whether or not this class object is active
-	 * 
+	 *
 	 * @return boolean
 	 */
 	public function getIsActive()
 	{
 		return $this->getBooleanType('IsActive');
 	}
-	
+
 	/**
-	 * Perform any needed clean-up of the object data members
-	 * 
-	 * @return boolean
-	 */
-	protected function _cleanup()
-	{
-		return true;
-	}
-	
-	/**
-	 * Get an array representation of this Class object
-	 * 
-	 * @param string $request
-	 * @param boolean $nest
-	 * @return array
-	 */
-	public function asArray($request, $nest = true)
-	{
-		$this->_cleanup();
-		
-		return parent::asArray($request, $nest);
-	}
-	
-	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
-	 * Tell what type of object this is 
-	 * 
+	 * Tell what type of object this is
+	 *
 	 * @return string
 	 */
 	public function object()

--- a/QuickBooks/QBXML/Object/DataExt.php
+++ b/QuickBooks/QBXML/Object/DataExt.php
@@ -2,37 +2,37 @@
 
 /**
  * QuickBooks DataExt object container
- * 
+ *
  * @author Keith Palmer <keith@consolibyte.com>
  * @license LICENSE.txt
- * 
+ *
  * @package QuickBooks
  * @subpackage Object
  */
 
 /**
- * 
+ *
  */
 QuickBooks_Loader::load('/QuickBooks/QBXML/Object.php');
 
 /**
- * 
+ *
  */
 class QuickBooks_QBXML_Object_DataExt extends QuickBooks_QBXML_Object
 {
 	/**
 	 * Create a new QuickBooks_Object_DataExt object
-	 * 
+	 *
 	 * @param array $arr
 	 */
 	public function __construct($arr = array())
 	{
 		parent::__construct($arr);
 	}
-	
+
 	/**
-	 * Set the OwnerID 
-	 * 
+	 * Set the OwnerID
+	 *
 	 * @param string $OwnerID
 	 * @return boolean
 	 */
@@ -40,57 +40,57 @@ class QuickBooks_QBXML_Object_DataExt extends QuickBooks_QBXML_Object
 	{
 		return $this->set('OwnerID', $OwnerID);
 	}
-	
+
 	/**
-	 * Get the OwnerID 
-	 * 
+	 * Get the OwnerID
+	 *
 	 * @return string
 	 */
 	public function getOwnerID()
 	{
 		return $this->get('OwnerID');
 	}
-	
+
 	public function setDataExtName($name)
 	{
 		return $this->set('DataExtName', $name);
 	}
-	
+
 	public function getDataExtName()
 	{
 		return $this->get('DataExtName');
 	}
-	
+
 	public function setListDataExtType($type)
 	{
 		return $this->set('ListDataExtType', $type);
 	}
-	
+
 	public function getListDataExtType()
 	{
 		return $this->get('ListDataExtType');
 	}
-	
+
 	public function setListObjListID($ListID)
 	{
 		return $this->set('ListObjRef ListID', $ListID);
 	}
-	
+
 	public function getListObjListID()
 	{
 		return $this->get('ListObjRef ListID');
 	}
-	
+
 	public function setListObjName($name)
 	{
 		return $this->set('ListObjRef FullName', $name);
 	}
-	
+
 	public function getListObjName()
 	{
 		return $this->get('ListObjRef FullName');
 	}
-	
+
 	public function setListObjApplicationID($value, $type)
 	{
 		return $this->set('ListObjRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID($type, QUICKBOOKS_LISTID, $value));
@@ -100,27 +100,27 @@ class QuickBooks_QBXML_Object_DataExt extends QuickBooks_QBXML_Object
 	{
 		return $this->get('ListObjRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function setTxnDataExtType($type)
 	{
 		return $this->set('TxnDataExtType', $type);
 	}
-	
+
 	public function getTxnDataExtType()
 	{
 		return $this->get('TxnDataExtType');
 	}
-	
+
 	public function setTxnID($TxnID)
 	{
 		return $this->set('TxnID', $TxnID);
 	}
-	
+
 	public function getTxnID()
 	{
 		return $this->get('TxnID');
 	}
-	
+
 	public function setTxnApplicationID($value)
 	{
 		return $this->set(QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_TRANSACTION, QUICKBOOKS_TXNID, $value));
@@ -135,75 +135,35 @@ class QuickBooks_QBXML_Object_DataExt extends QuickBooks_QBXML_Object
 	{
 		return $this->set('TxnLineID', $value);
 	}
-	
+
 	public function getTxnLineID()
 	{
 		return $this->get('TxnLineID');
 	}
-	
+
 	public function setOtherDataExtType($type)
 	{
 		return $this->set('OtherDataExtType', $type);
 	}
-	
+
 	public function getOtherDataExtType()
 	{
 		return $this->get('OtherDataExtType');
 	}
-	
+
 	public function setDataExtValue($value)
 	{
 		return $this->set('DataExtValue', $value);
 	}
-	
+
 	public function getDataExtValue()
 	{
 		return $this->get('DataExtValue');
 	}
-	
+
 	/**
-	 * Perform any needed clean-up of the object data members
-	 * 
-	 * @return boolean
-	 */
-	protected function _cleanup()
-	{
-		return true;
-	}
-	
-	/**
-	 * Get an array representation of this Class object
-	 * 
-	 * @param string $request
-	 * @param boolean $nest
-	 * @return array
-	 */
-	public function asArray($request, $nest = true)
-	{
-		$this->_cleanup();
-		
-		return parent::asArray($request, $nest);
-	}
-	
-	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $version = null, $locale = null, $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $version, $locale, $root);
-	}
-	
-	/**
-	 * Tell what type of object this is 
-	 * 
+	 * Tell what type of object this is
+	 *
 	 * @return string
 	 */
 	public function object()

--- a/QuickBooks/QBXML/Object/Department.php
+++ b/QuickBooks/QBXML/Object/Department.php
@@ -2,21 +2,21 @@
 
 /**
  * QuickBooks Department object container
- * 
+ *
  * @author Thomas Rientjes
  * @license LICENSE.txt
- * 
+ *
  * @package QuickBooks
  * @subpackage Object
  */
 
 /**
- * 
+ *
  */
 QuickBooks_Loader::load('/QuickBooks/QBXML/Object.php');
 
 /**
- * 
+ *
  */
 class QuickBooks_QBXML_Object_Department extends QuickBooks_QBXML_Object
 {
@@ -29,10 +29,10 @@ class QuickBooks_QBXML_Object_Department extends QuickBooks_QBXML_Object
 	{
 		parent::__construct($arr);
 	}
-	
+
 	/**
 	 * Set the ListID of the department
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return boolean
 	 */
@@ -40,17 +40,17 @@ class QuickBooks_QBXML_Object_Department extends QuickBooks_QBXML_Object
 	{
 		return $this->set('ListID', $ListID);
 	}
-	
+
 	/**
 	 * Get the ListID of the department
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getListID()
 	{
 		return $this->get('ListID');
 	}
-	
+
 	/**
 	 * @param string $ListID
 	 * @return boolean
@@ -70,7 +70,7 @@ class QuickBooks_QBXML_Object_Department extends QuickBooks_QBXML_Object
 
 	/**
 	 * Set the name of the department
-	 * 
+	 *
 	 * @param string $name
 	 * @return boolean
 	 */
@@ -78,10 +78,10 @@ class QuickBooks_QBXML_Object_Department extends QuickBooks_QBXML_Object
 	{
 		return $this->set('Name', $name);
 	}
-	
+
 	/**
 	 * Get the name of the department
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getName()
@@ -109,10 +109,10 @@ class QuickBooks_QBXML_Object_Department extends QuickBooks_QBXML_Object
 	{
 		return $this->set('FullName', $name);
 	}
-	
+
 	/**
 	 * Set this department active or not
-	 * 
+	 *
 	 * @param boolean $value
 	 * @return boolean
 	 */
@@ -120,30 +120,20 @@ class QuickBooks_QBXML_Object_Department extends QuickBooks_QBXML_Object
 	{
 		return $this->set('IsActive', (boolean) $value);
 	}
-	
+
 	/**
 	 * Tell whether or not this department object is active
-	 * 
+	 *
 	 * @return boolean
 	 */
 	public function getIsActive()
 	{
 		return $this->get('IsActive');
 	}
-	
-	/**
-	 * Perform any needed clean-up of the object data members
-	 * 
-	 * @return boolean
-	 */
-	protected function _cleanup()
-	{
-		return true;
-	}
-	
+
 	/**
 	 * Get an array representation of this department object
-	 * 
+	 *
 	 * @param string $request
 	 * @param boolean $nest
 	 * @return array
@@ -157,24 +147,8 @@ class QuickBooks_QBXML_Object_Department extends QuickBooks_QBXML_Object
 	}
 
 	/**
-	 * Convert this object to a valid qbXML request
+	 * Tell what type of object this is
 	 *
-	 * @param string $request The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param string $version
-	 * @param string $locale
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $version = null, $locale = null, $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $version, $locale, $root);
-	}
-	
-	/**
-	 * Tell what type of object this is 
-	 * 
 	 * @return string
 	 */
 	public function object()

--- a/QuickBooks/QBXML/Object/Deposit.php
+++ b/QuickBooks/QBXML/Object/Deposit.php
@@ -1,14 +1,14 @@
-<?php 
+<?php
 
 /**
- * Deposit class for QuickBooks 
- * 
+ * Deposit class for QuickBooks
+ *
  * @author Keith Palmer Jr. <keith@ConsoliBYTE.com>
  * @license LICENSE.txt
- * 
+ *
  * @package QuickBooks
  * @subpackage Object
- */ 
+ */
 
 /**
  * QuickBooks object base class
@@ -21,7 +21,7 @@ QuickBooks_Loader::load('/QuickBooks/QBXML/Object.php');
 QuickBooks_Loader::load('/QuickBooks/QBXML/Object/Deposit/DepositLine.php');
 
 /**
- * 
+ *
  */
 class QuickBooks_QBXML_Object_Deposit extends QuickBooks_QBXML_Object
 {
@@ -29,10 +29,10 @@ class QuickBooks_QBXML_Object_Deposit extends QuickBooks_QBXML_Object
 	{
 		parent::__construct($arr);
 	}
-	
+
 	/**
 	 * Set the AccountRef ListID for the Check
-	 * 
+	 *
 	 * @param string $ListID		The ListID of the record to reference
 	 * @return boolean
 	 */
@@ -43,7 +43,7 @@ class QuickBooks_QBXML_Object_Deposit extends QuickBooks_QBXML_Object
 
 	/**
 	 * Get the AccountRef ListID for the Check
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getDepositToAccountListID()
@@ -53,7 +53,7 @@ class QuickBooks_QBXML_Object_Deposit extends QuickBooks_QBXML_Object
 
 	/**
 	 * Set the primary key for the related record within your own application for the Check
-	 * 
+	 *
 	 * @param mixed $value			The primary key within your own application
 	 * @return string
 	 */
@@ -67,11 +67,11 @@ class QuickBooks_QBXML_Object_Deposit extends QuickBooks_QBXML_Object
 		return $this->get('DepositToAccountRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
 
-	// Path: AccountRef FullName, datatype: 
-	
+	// Path: AccountRef FullName, datatype:
+
 	/**
 	 * Set the AccountRef FullName for the Check
-	 * 
+	 *
 	 * @param string $FullName		The FullName of the record to reference
 	 * @return boolean
 	 */
@@ -82,7 +82,7 @@ class QuickBooks_QBXML_Object_Deposit extends QuickBooks_QBXML_Object
 
 	/**
 	 * Get the AccountRef FullName for the Check
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getDepositToAccountFullName()
@@ -91,10 +91,10 @@ class QuickBooks_QBXML_Object_Deposit extends QuickBooks_QBXML_Object
 	}
 
 	// Path: TxnDate, datatype: DATETYPE
-	
+
 	/**
 	 * Set the TxnDate for the Check
-	 * 
+	 *
 	 * @param string $date
 	 * @return boolean
 	 */
@@ -105,7 +105,7 @@ class QuickBooks_QBXML_Object_Deposit extends QuickBooks_QBXML_Object
 
 	/**
 	 * Get the TxnDate for the Check
-	 * 
+	 *
 	 * @param ? $format = null
 	 * @return string
 	 */
@@ -119,7 +119,7 @@ class QuickBooks_QBXML_Object_Deposit extends QuickBooks_QBXML_Object
 	 */
 	public function setTransactionDate($date)
 	{
-		return $this->setTxnDate($date); 
+		return $this->setTxnDate($date);
 	}
 
 	/**
@@ -130,10 +130,10 @@ class QuickBooks_QBXML_Object_Deposit extends QuickBooks_QBXML_Object
 		return $this->getTxnDate($format = null);
 	}
 	// Path: Memo, datatype: STRTYPE
-	
+
 	/**
 	 * Set the Memo for the Check
-	 * 
+	 *
 	 * @param string $value
 	 * @return boolean
 	 */
@@ -144,19 +144,19 @@ class QuickBooks_QBXML_Object_Deposit extends QuickBooks_QBXML_Object
 
 	/**
 	 * Get the Memo for the Check
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getMemo()
 	{
 		return $this->get('Memo');
 	}
-	
+
 	public function setAmount($amount)
 	{
 		return $this->setAmountType('Amount', $amount);
 	}
-	
+
 	public function getAmount()
 	{
 		return $this->getAmountType('Amount');
@@ -166,25 +166,25 @@ class QuickBooks_QBXML_Object_Deposit extends QuickBooks_QBXML_Object
 	{
 		return $this->addListItem('DepositLine', $obj);
 	}
-	
+
 	public function asList($request)
 	{
 		switch ($request)
 		{
 			case 'DepositAddRq':
-				
+
 				if (isset($this->_object['DepositLine']))
 				{
 					$this->_object['DepositLineAdd'] = $this->_object['DepositLine'];
 				}
-				
+
 				break;
 			case 'DepositModRq':
-				
-				
+
+
 				break;
 		}
-		
+
 		return parent::asList($request);
 	}
 
@@ -194,69 +194,38 @@ class QuickBooks_QBXML_Object_Deposit extends QuickBooks_QBXML_Object
 		{
 			$object = $this->_object;
 		}
-		
+
 		switch ($root)
 		{
 			case QUICKBOOKS_ADD_DEPOSIT:
-				
+
 				foreach ($object['DepositLineAdd'] as $key => $obj)
 				{
 					$obj->setOverride('DepositLineAdd');
-				}				
-				
+				}
+
 				break;
 			case QUICKBOOKS_MOD_DEPOSIT:
-				
+
 				foreach ($object['DepositLineMod'] as $key => $obj)
 				{
 					$obj->setOverride('DepositLineMod');
 				}
-				
+
 				break;
 		}
-		
+
 		return parent::asXML($root, $parent, $object);
 	}
-	
+
 	/**
-	 * 
-	 */
-	public function asArray($request, $nest = true)
-	{
-		$this->_cleanup();
-		return parent::asArray($request, $nest);
-	}
-	
-	/**
-	 * 
-	 * 
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null, $parent = null)
-	{
-		$this->_cleanup();
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
+	 * Tell what type of object this is
 	 *
-	 */
-	protected function _cleanup()
-	{
-		
-	}
-	
-	/**
-	 * Tell what type of object this is 
-	 * 
 	 * @return string
 	 */
 	public function object()
 	{
 		return QUICKBOOKS_OBJECT_DEPOSIT;
-	}	
+	}
 }
 

--- a/QuickBooks/QBXML/Object/DiscountItem.php
+++ b/QuickBooks/QBXML/Object/DiscountItem.php
@@ -2,26 +2,26 @@
 
 /**
  * QuickBooks ServiceItem object container
- * 
- * NOTE: By default, ServiceItems are created as SalesOrPurchase items, and are 
- * thus *NOT* created as SalesAndPurchase items. If you want to create an item 
+ *
+ * NOTE: By default, ServiceItems are created as SalesOrPurchase items, and are
+ * thus *NOT* created as SalesAndPurchase items. If you want to create an item
  * that is sold *and* purchased, you'll need to set the type with the method:
  * 	-> {@link QuickBooks_Object_ServiceItem::isSalesAndPurchase()}
- * 
+ *
  * @author Keith Palmer <keith@consolibyte.com>
- * @license LICENSE.txt 
- * 
+ * @license LICENSE.txt
+ *
  * @package QuickBooks
  * @subpackage Object
  */
 
 /**
- * 
+ *
  */
 QuickBooks_Loader::load('/QuickBooks/QBXML/Object.php');
 
 /**
- * 
+ *
  */
 class QuickBooks_QBXML_Object_DiscountItem extends QuickBooks_QBXML_Object
 {
@@ -29,10 +29,10 @@ class QuickBooks_QBXML_Object_DiscountItem extends QuickBooks_QBXML_Object
 	{
 		parent::__construct($arr);
 	}
-	
+
 	/**
 	 * Set the ListID for this item
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return boolean
 	 */
@@ -40,20 +40,20 @@ class QuickBooks_QBXML_Object_DiscountItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('ListID', $ListID);
 	}
-	
+
 	/**
 	 * Get the ListID for this item
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getListID()
 	{
 		return $this->get('ListID');
 	}
-	
+
 	/**
 	 * Set the name for this item
-	 * 
+	 *
 	 * @param string $name
 	 * @return boolean
 	 */
@@ -61,17 +61,17 @@ class QuickBooks_QBXML_Object_DiscountItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('Name', $name);
 	}
-	
+
 	/**
 	 * Get the name for this item
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getName()
 	{
 		return $this->get('Name');
 	}
-	
+
 	public function setParentApplicationID($value)
 	{
 		return $this->set('ParentRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_DISCOUNTITEM, QUICKBOOKS_LISTID, $value));
@@ -81,69 +81,69 @@ class QuickBooks_QBXML_Object_DiscountItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('ParentRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function setParentListID($ListID)
 	{
 		return $this->set('ParentRef ListID', $ListID);
 	}
-	
+
 	public function getParentListID()
 	{
 		return $this->get('ParentRef ListID');
 	}
-	
+
 	public function setParentName($name)
 	{
 		return $this->set('ParentRef FullName', $name);
 	}
-	
+
 	public function getParentName()
 	{
 		return $this->get('ParentRef FullName');
 	}
-	
+
 	public function setDescription($desc)
 	{
 		return $this->set('ItemDesc', $desc);
 	}
-	
+
 	public function getDescription()
 	{
 		return $this->get('ItemDesc');
 	}
-	
+
 	public function setSalesTaxCodeName($name)
 	{
 		return $this->set('SalesTaxCodeRef FullName', $name);
 	}
-	
+
 	public function getSalesTaxCodeName()
 	{
 		return $this->get('SalesTaxCodeRef FullName');
 	}
-	
+
 	/**
 	 * Discount rate amount (i.e.: $20 off purchase price)
-	 * 
+	 *
 	 * @param float $rate
-	 * @return boolean 
+	 * @return boolean
 	 */
 	public function setDiscountRate($rate)
 	{
 		return $this->set('DiscountRate', (float) $rate);
 	}
-	
+
 	/**
-	 * 
+	 *
 	 */
 	public function getDiscountRate()
 	{
 		return $this->get('DiscountRate');
 	}
-	
+
 	/**
 	 * Discount rate percentage (i.e.: 15% discount)
-	 * 
+	 *
 	 * @param float $percent
 	 * @return boolean
 	 */
@@ -151,12 +151,12 @@ class QuickBooks_QBXML_Object_DiscountItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('DiscountRatePercent', (float) $percent);
 	}
-	
+
 	public function getDiscountRatePercent()
 	{
 		return $this->get('DiscountRatePercent');
 	}
-	
+
 	public function setAccountApplicationID($value)
 	{
 		return $this->set('AccountRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_ACCOUNT, QUICKBOOKS_LISTID, $value));
@@ -166,68 +166,30 @@ class QuickBooks_QBXML_Object_DiscountItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('AccountRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function setAccountListID($ListID)
 	{
 		return $this->set('AccountRef ListID', $ListID);
 	}
-	
+
 	public function getAccountListID()
 	{
 		return $this->get('AccountRef ListID');
 	}
-	
+
 	public function setAccountName($name)
 	{
 		return $this->set('AccountRef FullName', $name);
 	}
-	
+
 	public function getAccountName()
 	{
 		return $this->get('AccountRef FullName');
 	}
-	
+
 	/**
-	 * 
-	 * 
-	 * @return boolean
-	 */
-	protected function _cleanup()
-	{
-		
-		
-		return true;
-	}
-	
-	/**
-	 * 
-	 */
-	public function asArray($request, $nest = true)
-	{
-		$this->_cleanup();
-		
-		return parent::asArray($request, $nest);
-	}
-	
-	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
-	 * Tell what type of object this is 
-	 * 
+	 * Tell what type of object this is
+	 *
 	 * @return string
 	 */
 	public function object()

--- a/QuickBooks/QBXML/Object/Employee.php
+++ b/QuickBooks/QBXML/Object/Employee.php
@@ -2,10 +2,10 @@
 
 /**
  * QuickBooks Employee object container
- * 
+ *
  * @author Keith Palmer <keith@consolibyte.com>
  * @license LICENSE.txt
- * 
+ *
  * @package QuickBooks
  * @subpackage Object
  */
@@ -22,17 +22,17 @@ class QuickBooks_QBXML_Object_Employee extends QuickBooks_QBXML_Object
 {
 	/**
 	 * Create a new QuickBooks_Object_Customer object
-	 * 
+	 *
 	 * @param array $arr
 	 */
 	public function __construct($arr = array())
 	{
 		parent::__construct($arr);
 	}
-	
+
 	/**
 	 * Set the ListID of this customer record
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return boolean
 	 */
@@ -40,10 +40,10 @@ class QuickBooks_QBXML_Object_Employee extends QuickBooks_QBXML_Object
 	{
 		return $this->set('ListID', $ListID);
 	}
-	
+
 	/**
 	 * Get the ListID of this customer record
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getListID()
@@ -53,18 +53,18 @@ class QuickBooks_QBXML_Object_Employee extends QuickBooks_QBXML_Object
 
   /**
    * Get the name of this customer
-   * 
+   *
    * @return string
    */
   public function getName()
   {
     if (!$this->exists('Name'))
-    {    
+    {
       if (!is_null($this->getFirstName()) || !is_null($this->getLastName())) {
         $this->setNameAsFirstLast();
-      }    
-    }    
-    
+      }
+    }
+
     return $this->get('Name');
   }
 
@@ -75,10 +75,10 @@ class QuickBooks_QBXML_Object_Employee extends QuickBooks_QBXML_Object
 
   /**
    * Set the full name of this customer (full name)
-   * 
-   * NOTE: This will be auto-set to ->getName() if you don't set it 
+   *
+   * NOTE: This will be auto-set to ->getName() if you don't set it
    * explicitly.
-   * 
+   *
    * @param string $name
    * @return boolean
    */
@@ -93,7 +93,7 @@ class QuickBooks_QBXML_Object_Employee extends QuickBooks_QBXML_Object
 
   /**
    * Get the name of this customer (full name)
-   * 
+   *
    * @return string
    */
   public function getFullName()
@@ -102,28 +102,28 @@ class QuickBooks_QBXML_Object_Employee extends QuickBooks_QBXML_Object
     {
       $this->setFullName($this->get('Name'));
     }
-    
+
     return $this->get('FullName');
   }
 
 
-  /**                                                         
-   * Sets the name as first and last.                         
-   *                                                          
-   * @return boolean                                          
-   */                                                         
-  public function setNameAsFirstLast() {                      
-    $first = $this->getFirstName();                           
-    $last = $this->getLastName();                             
-    if (is_null($first)) { $first = ''; }                     
-    if (is_null($last)) { $last = ''; }                       
-                                                              
-    return $this->set('Name', $first .' '. $last);            
+  /**
+   * Sets the name as first and last.
+   *
+   * @return boolean
+   */
+  public function setNameAsFirstLast() {
+    $first = $this->getFirstName();
+    $last = $this->getLastName();
+    if (is_null($first)) { $first = ''; }
+    if (is_null($last)) { $last = ''; }
+
+    return $this->set('Name', $first .' '. $last);
   }
-  
+
 	/**
 	 * Set the first name of this customer
-	 * 
+	 *
 	 * @param string $name
 	 * @return boolean
 	 */
@@ -131,20 +131,20 @@ class QuickBooks_QBXML_Object_Employee extends QuickBooks_QBXML_Object
 	{
 		return $this->set('FirstName', $fname);
 	}
-	
+
 	/**
 	 * Get the first name of this customer
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getFirstName()
 	{
 		return $this->get('FirstName');
 	}
-	
+
 	/**
 	 * Set the last name of this customer
-	 * 
+	 *
 	 * @param string $lname
 	 * @return boolean
 	 */
@@ -152,65 +152,65 @@ class QuickBooks_QBXML_Object_Employee extends QuickBooks_QBXML_Object
 	{
 		return $this->set('LastName', $lname);
 	}
-	
+
 	/**
 	 * Get the last name of this customer
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getLastName()
 	{
 		return $this->get('LastName');
 	}
-	
+
 	public function setMiddleName($mname)
 	{
 		return $this->set('MiddleName', $mname);
 	}
-	
+
 	public function getMiddleName()
 	{
 		return $this->get('MiddleName');
 	}
-	
+
 	public function getEmployeeAddress($part = null, $defaults = array())
 	{
 		return $this->_getXYZAddress('Employee', '', $part, $defaults);
 	}
-	
+
 	public function setEmployeeAddress($addr1, $addr2 = '', $addr3 = '', $addr4 = '', $addr5 = '', $city = '', $state = '', $province = '', $postalcode = '', $country = '', $note = '')
 	{
-		return $this->_setXYZAddress('Employee', '', $addr1, $addr2, $addr3, $addr4, $addr5, $city, $state, $province, $postalcode, $country, $note);  
+		return $this->_setXYZAddress('Employee', '', $addr1, $addr2, $addr3, $addr4, $addr5, $city, $state, $province, $postalcode, $country, $note);
 	}
-	
+
 	protected function _setXYZAddress($pre, $post, $addr1, $addr2, $addr3, $addr4, $addr5, $city, $state, $province, $postalcode, $country, $note)
 	{
 		for ($i = 1; $i <= 5; $i++)
 		{
 			$this->set($pre . 'Address' . $post . ' Addr' . $i, ${'addr' . $i});
 		}
-		
+
 		$this->set($pre . 'Address' . $post . ' City', $city);
 		$this->set($pre . 'Address' . $post . ' State', $state);
 		$this->set($pre . 'Address' . $post . ' Province', $province);
 		$this->set($pre . 'Address' . $post . ' PostalCode', $postalcode);
 		$this->set($pre . 'Address' . $post . ' Country', $country);
-		$this->set($pre . 'Address' . $post . ' Note', $note);		
+		$this->set($pre . 'Address' . $post . ' Note', $note);
 	}
-	
+
 	protected function _getXYZAddress($pre, $post, $part = null, $defaults = array())
 	{
 		if (!is_null($part))
 		{
 			return $this->get($pre . 'Address' . $post . ' ' . $part);
 		}
-		
+
 		return $this->getArray($pre . 'Address' . $post . ' *', $defaults);
 	}
-	
+
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 * @param string $phone
 	 * @return boolean
 	 */
@@ -223,10 +223,10 @@ class QuickBooks_QBXML_Object_Employee extends QuickBooks_QBXML_Object
 	{
 		return $this->get('Phone');
 	}
-	
+
 	/**
 	 * Set the alternate phone number for this customer
-	 * 
+	 *
 	 * @param string $phone
 	 * @return boolean
 	 */
@@ -239,12 +239,12 @@ class QuickBooks_QBXML_Object_Employee extends QuickBooks_QBXML_Object
 	{
 		return $this->get('AltPhone');
 	}
-	
+
 	/**
 	 * Set the fax number for this customer
-	 * 
+	 *
 	 * @param string $fax
-	 * @return boolean 
+	 * @return boolean
 	 */
 	public function setFax($fax)
 	{
@@ -255,10 +255,10 @@ class QuickBooks_QBXML_Object_Employee extends QuickBooks_QBXML_Object
 	{
 		return $this->get('Fax');
 	}
-	
+
 	/**
 	 * Set the e-mail address for this customer
-	 * 
+	 *
 	 * @param string $email
 	 * @return boolean
 	 */
@@ -271,10 +271,10 @@ class QuickBooks_QBXML_Object_Employee extends QuickBooks_QBXML_Object
 	{
 		return $this->get('Email');
 	}
-	
+
 	/**
 	 * Set the salutation for this customer
-	 * 
+	 *
 	 * @param string $salut
 	 * @return boolean
 	 */
@@ -282,110 +282,70 @@ class QuickBooks_QBXML_Object_Employee extends QuickBooks_QBXML_Object
 	{
 		return $this->set('Salutation', $salut);
 	}
-	
+
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 * @return string
 	 */
 	public function getSalutation()
 	{
 		return $this->get('Salutation');
 	}
-	
+
 	public function setNotes($notes)
 	{
 		return $this->set('Notes', $notes);
 	}
-	
+
 	public function getNotes()
 	{
 		return $this->get('Notes');
 	}
-	
+
 	public function setMobile($mobile)
 	{
-		return $this->set('Mobile', $mobile);	
+		return $this->set('Mobile', $mobile);
 	}
-	
+
 	public function getMobile()
 	{
 		return $this->get('Mobile');
 	}
-	
+
 	public function setPager($pager)
 	{
 		return $this->set('Pager', $pager);
 	}
-	
+
 	public function getPager()
 	{
 		return $this->get('Pager');
 	}
-	
+
 	public function setGender($gender)
 	{
 		return $this->set('Gender', $gender);
 	}
-	
+
 	public function getGender()
 	{
 		return $this->get('Gender');
 	}
-	
+
 	public function setBirthDate($date)
 	{
 		return $this->setDateType('BirthDate', $date);
 	}
-	
+
 	public function getBirthDate($format = 'Y-m-d')
 	{
 		return $this->getDateType('BirthDate', $format);
 	}
-	
-	
-	
+
 	/**
-	 * 
-	 * 
-	 * @return boolean
-	 */
-	protected function _cleanup()
-	{
-		
-		
-		return true;
-	}
-	
-	/**
-	 * 
-	 */
-	public function asArray($request, $nest = true)
-	{
-		$this->_cleanup();
-		
-		return parent::asArray($request, $nest);
-	}
-	
-	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request						The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements		A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
-	 * Tell what type of object this is 
-	 * 
+	 * Tell what type of object this is
+	 *
 	 * @return string
 	 */
 	public function object()

--- a/QuickBooks/QBXML/Object/Estimate.php
+++ b/QuickBooks/QBXML/Object/Estimate.php
@@ -2,45 +2,45 @@
 
 /**
  * QuickBooks Estimate object container
- * 
+ *
  * @author Keith Palmer <keith@consolibyte.com>
- * @license LICENSE.txt 
- * 
+ * @license LICENSE.txt
+ *
  * @package QuickBooks
  * @subpackage Object
  */
 
 /**
- * 
+ *
  */
 QuickBooks_Loader::load('/QuickBooks/QBXML/Object.php');
 
 /**
- * 
+ *
  */
 QuickBooks_Loader::load('/QuickBooks/QBXML/Object/Generic.php');
 
 /**
- * 
+ *
  */
 QuickBooks_Loader::load('/QuickBooks/QBXML/Object/Estimate/EstimateLine.php');
 
 /**
- * 
- * 
+ *
+ *
  */
 class QuickBooks_QBXML_Object_Estimate extends QuickBooks_QBXML_Object
 {
 	/**
 	 * Create a new QuickBooks Invoice object
-	 * 
+	 *
 	 * @param array $arr
 	 */
 	public function __construct($arr = array())
 	{
 		parent::__construct($arr);
 	}
-	
+
 	/**
 	 * Alias of {@link QuickBooks_Object_Estimate::setTxnID()}
 	 */
@@ -48,10 +48,10 @@ class QuickBooks_QBXML_Object_Estimate extends QuickBooks_QBXML_Object
 	{
 		return $this->setTxnID($TxnID);
 	}
-	
+
 	/**
 	 * Set the transaction ID of the object
-	 * 
+	 *
 	 * @param string $TxnID
 	 * @return boolean
 	 */
@@ -67,20 +67,20 @@ class QuickBooks_QBXML_Object_Estimate extends QuickBooks_QBXML_Object
 	{
 		return $this->getTxnID();
 	}
-	
+
 	/**
 	 * Get the transaction ID for this invoice
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getTxnID()
 	{
 		return $this->get('TxnID');
 	}
-	
+
 	/**
 	 * Set the customer ListID
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return boolean
 	 */
@@ -88,10 +88,10 @@ class QuickBooks_QBXML_Object_Estimate extends QuickBooks_QBXML_Object
 	{
 		return $this->set('CustomerRef ListID' , $ListID);
 	}
-	
+
 	/**
 	 * Set the customer ApplicationID (auto-replaced by the API with a ListID)
-	 * 
+	 *
 	 * @param mixed $value
 	 * @return boolean
 	 */
@@ -99,10 +99,10 @@ class QuickBooks_QBXML_Object_Estimate extends QuickBooks_QBXML_Object
 	{
 		return $this->set('CustomerRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_CUSTOMER, QUICKBOOKS_LISTID, $value));
 	}
-	
+
 	/**
 	 * Set the customer name
-	 * 
+	 *
 	 * @param string $name
 	 * @return boolean
 	 */
@@ -110,10 +110,10 @@ class QuickBooks_QBXML_Object_Estimate extends QuickBooks_QBXML_Object
 	{
 		return $this->set('CustomerRef FullName', $name);
 	}
-	
+
 	/**
 	 * Get the customer ListID
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getCustomerListID()
@@ -123,29 +123,29 @@ class QuickBooks_QBXML_Object_Estimate extends QuickBooks_QBXML_Object
 
 	/**
 	 * Get the customer application ID
-	 * 
+	 *
 	 * @return mixed
 	 */
 	public function getCustomerApplicationID()
 	{
 		return $this->extractApplicationID($this->get('CustomerRef ' . QUICKBOOKS_API_APPLICATIONID));
 	}
-	
+
 	/**
 	 * Get the customer name
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getCustomerName()
 	{
 		return $this->get('CustomerRef FullName');
 	}
-	
+
 	public function setClassListID($ListID)
 	{
 		return $this->set('ClassRef ListID', $ListID);
 	}
-	
+
 	public function setClassApplicationID($value)
 	{
 		return $this->set('ClassRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_CLASS, QUICKBOOKS_LISTID, $value));
@@ -155,22 +155,22 @@ class QuickBooks_QBXML_Object_Estimate extends QuickBooks_QBXML_Object
 	{
 		return $this->get('ClassRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function setClassName($name)
 	{
 		return $this->set('ClassRef FullName', $name);
 	}
-	
+
 	public function getClassName()
 	{
 		return $this->get('ClassRef FullName');
 	}
-	
+
 	public function getClassListID()
 	{
 		return $this->get('ClassRef ListID');
 	}
-	
+
 	public function setTemplateApplicationID($value)
 	{
 		return $this->set('TemplateRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_TEMPLATE, QUICKBOOKS_LISTID, $value));
@@ -180,30 +180,30 @@ class QuickBooks_QBXML_Object_Estimate extends QuickBooks_QBXML_Object
 	{
 		return $this->get('TemplateRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function setTemplateName($name)
 	{
 		return $this->set('TemplateRef FullName', $name);
 	}
-	
+
 	public function setTemplateListID($ListID)
 	{
 		return $this->set('TemplateRef ListID', $ListID);
 	}
-	
+
 	public function getTemplateName()
 	{
 		return $this->get('TemplateRef FullName');
 	}
-	
+
 	public function getTemplateListID()
 	{
 		return $this->get('TemplateRef ListID');
 	}
-	
+
 	/**
 	 * Set the transaction date
-	 * 
+	 *
 	 * @param string $date
 	 * @return boolean
 	 */
@@ -211,7 +211,7 @@ class QuickBooks_QBXML_Object_Estimate extends QuickBooks_QBXML_Object
 	{
 		return $this->setDateType('TxnDate', $date);
 	}
-	
+
 	/**
 	 * Alias of {@link QuickBooks_Object_Estimate::setTxnDate()}
 	 */
@@ -219,10 +219,10 @@ class QuickBooks_QBXML_Object_Estimate extends QuickBooks_QBXML_Object
 	{
 		return $this->setTxnDate($date);
 	}
-	
+
 	/**
 	 * Get the transaction date
-	 * 
+	 *
 	 * @param string $format
 	 * @return string
 	 */
@@ -230,7 +230,7 @@ class QuickBooks_QBXML_Object_Estimate extends QuickBooks_QBXML_Object
 	{
 		return $this->getDateType('TxnDate', $format);
 	}
-	
+
 	/**
 	 * Alias of {@link QuickBooks_Object_Estimate::getTxnDate()}
 	 */
@@ -238,10 +238,10 @@ class QuickBooks_QBXML_Object_Estimate extends QuickBooks_QBXML_Object
 	{
 		return $this->getDateType('TxnDate', $format);
 	}
-	
+
 	/**
 	 * Set the reference number
-	 * 
+	 *
 	 * @param string $str
 	 * @return boolean
 	 */
@@ -249,20 +249,20 @@ class QuickBooks_QBXML_Object_Estimate extends QuickBooks_QBXML_Object
 	{
 		return $this->set('RefNumber', $str);
 	}
-	
+
 	/**
 	 * Get the reference number
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getRefNumber()
 	{
 		return $this->get('RefNumber');
 	}
-	
+
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 * @param string $part
 	 * @param array $defaults
 	 * @return array
@@ -273,13 +273,13 @@ class QuickBooks_QBXML_Object_Estimate extends QuickBooks_QBXML_Object
 		{
 			return $this->get('ShipAddress ' . $part);
 		}
-		
+
 		return $this->getArray('ShipAddress *', $defaults);
 	}*/
-	
+
 	/**
 	 * Set the shipping address for the invoice
-	 * 
+	 *
 	 * @param string $addr1
 	 * @param string $addr2
 	 * @param string $addr3
@@ -298,18 +298,18 @@ class QuickBooks_QBXML_Object_Estimate extends QuickBooks_QBXML_Object
 		{
 			$this->set('ShipAddress Addr' . $i, ${'addr' . $i});
 		}
-		
+
 		$this->set('ShipAddress City', $city);
 		$this->set('ShipAddress State', $state);
 		$this->set('ShipAddress Province', $province);
 		$this->set('ShipAddress PostalCode', $postalcode);
 		$this->set('ShipAddress Country', $country);
-		$this->set('ShipAddress Note', $note);  
+		$this->set('ShipAddress Note', $note);
 	}*/
-	
+
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 * @param string $part
 	 * @param array $defaults
 	 * @return array
@@ -320,13 +320,13 @@ class QuickBooks_QBXML_Object_Estimate extends QuickBooks_QBXML_Object
 		{
 			return $this->get('BillAddress ' . $part);
 		}
-		
+
 		return $this->getArray('BillAddress *', $defaults);
 	}
-	
+
 	/**
 	 * Set the billing address for the invoice
-	 * 
+	 *
 	 * @param string $addr1
 	 * @param string $addr2
 	 * @param string $addr3
@@ -345,30 +345,30 @@ class QuickBooks_QBXML_Object_Estimate extends QuickBooks_QBXML_Object
 		{
 			$this->set('BillAddress Addr' . $i, ${'addr' . $i});
 		}
-		
+
 		$this->set('BillAddress City', $city);
 		$this->set('BillAddress State', $state);
 		$this->set('BillAddress Province', $province);
 		$this->set('BillAddress PostalCode', $postalcode);
 		$this->set('BillAddress Country', $country);
-		$this->set('BillAddress Note', $note);  
+		$this->set('BillAddress Note', $note);
 	}
-	
+
 	public function setPONumber($num)
 	{
 		return $this->set('PONumber', $num);
 	}
-	
+
 	public function getPONumber()
 	{
 		return $this->get('PONumber');
 	}
-	
+
 	public function setTermsListID($ListID)
 	{
 		return $this->set('TermsRef ListID', $ListID);
 	}
-	
+
 	public function setTermsApplicationID($value)
 	{
 		return $this->set('TermsRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_TERMS, QUICKBOOKS_LISTID, $value));
@@ -378,42 +378,42 @@ class QuickBooks_QBXML_Object_Estimate extends QuickBooks_QBXML_Object
 	{
 		return $this->get('TermsRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function setTermsName($name)
 	{
 		return $this->set('TermsRef FullName', $name);
 	}
-	
+
 	public function getTermsName()
 	{
 		return $this->get('TermsRef FullName');
 	}
-	
+
 	public function getTermsListID()
 	{
 		return $this->get('TermsRef ListID');
 	}
-	
+
 	public function setDueDate($date)
 	{
 		return $this->setDateType('DueDate', $date);
 	}
-	
+
 	public function getDueDate($format = 'Y-m-d')
 	{
 		return $this->getDateType('DueDate', $format);
 	}
-	
+
 	public function setSalesRepName($name)
 	{
 		return $this->set('SalesRepRef FullName', $name);
 	}
-	
+
 	public function setSalesRepListID($ListID)
 	{
 		return $this->set('SalesRepRef ListID', $ListID);
 	}
-	
+
 	public function setSalesRepApplicationID($value)
 	{
 		return $this->set('SalesRepRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_SALESREP, QUICKBOOKS_LISTID, $value));
@@ -423,32 +423,32 @@ class QuickBooks_QBXML_Object_Estimate extends QuickBooks_QBXML_Object
 	{
 		return $this->get('SalesRepRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function getSalesRepName()
 	{
 		return $this->get('SalesRepRef FullName');
 	}
-	
+
 	public function getSalesRepListID()
 	{
 		return $this->get('SalesRepRef ListID');
 	}
-	
+
 	public function getFOB()
 	{
 		return $this->get('FOB');
 	}
-	
+
 	public function setFOB($fob)
 	{
 		return $this->set('FOB', $fob);
 	}
-	
+
 	public function setSalesTaxItemListID($ListID)
 	{
 		return $this->set('ItemSalesTaxRef ListID', $ListID);
 	}
-	
+
 	public function setSalesTaxItemApplicationID($value)
 	{
 		return $this->set('ItemSalesTaxRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_SALESTAXITEM, QUICKBOOKS_LISTID, $value));
@@ -458,85 +458,85 @@ class QuickBooks_QBXML_Object_Estimate extends QuickBooks_QBXML_Object
 	{
 		return $this->get('ItemSalesTaxRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function setSalesTaxItemName($name)
 	{
 		return $this->set('ItemSalesTaxRef FullName', $name);
 	}
-	
+
 	public function getSalesTaxItemName()
 	{
 		return $this->get('ItemSalesTaxRef FullName');
 	}
-	
+
 	public function getSalesTaxItemListID()
 	{
 		return $this->get('ItemSalesTaxRef ListID');
 	}
-	
+
 	public function setMemo($memo)
 	{
 		return $this->set('Memo', $memo);
 	}
-	
+
 	public function getMemo()
 	{
 		return $this->get('Memo');
 	}
-	
+
 	public function setIsToBeEmailed($emailed)
 	{
 		return $this->setBooleanType('IsToBeEmailed', $emailed);
 	}
-	
+
 	public function getIsToBeEmailed()
 	{
 		return $this->getBooleanType('IsToBeEmailed');
 	}
-	
+
 	public function setCustomerSalesTaxCodeListID($ListID)
 	{
 		return $this->set('CustomerSalesTaxCodeRef ListID', $ListID);
 	}
-	
+
 	public function setCustomerSalesTaxCodeName($name)
 	{
 		return $this->set('CustomerSalesTaxCodeRef FullName', $name);
 	}
-	
+
 	public function getCustomerSalesTaxCodeListID()
 	{
 		return $this->get('CustomerSalesTaxCodeRef ListID');
 	}
-	
+
 	public function getCustomerSalesTaxCodeName()
 	{
 		return $this->get('CustomerSalesTaxCodeRef FullName');
 	}
-	
+
 	/**
-	 * 
-	 * 
-	 * @param 
+	 *
+	 *
+	 * @param
 	 */
 	public function addEstimateLine($obj)
 	{
 		return $this->addListItem('EstimateLine', $obj);
 	}
-	
+
 	public function setEstimateLine($i, $obj)
 	{
-		
+
 	}
-	
+
 	public function setEstimateLineData($i, $key, $value)
 	{
 		$lines = $this->getEstimateLines();
 		if (isset($lines[$i]))
 		{
-			
+
 		}
-		
+
 		return $this->set('EstimateLine', $lines);
 	}
 
@@ -544,7 +544,7 @@ class QuickBooks_QBXML_Object_Estimate extends QuickBooks_QBXML_Object
 	{
 		return $this->get('EstimateLine');
   }
-	
+
 	public function getEstimateLine($i)
 	{
 		return $this->getListItem('EstimateLine', $i);
@@ -559,69 +559,69 @@ class QuickBooks_QBXML_Object_Estimate extends QuickBooks_QBXML_Object
 	{
 		return $this->getList('EstimateLine');
 	}
-	
+
 	public function setOther($other)
 	{
 		return $this->set('Other', $other);
 	}
-	
+
 	public function getOther()
 	{
 		return $this->get('Other');
 	}
-		
+
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 * @return boolean
 	 */
 	protected function _cleanup()
 	{
-		
+
 		return true;
 	}
-	
+
 	public function asList($request)
 	{
 		switch ($request)
 		{
 			case 'EstimateAddRq':
-				
+
 				if (isset($this->_object['EstimateLine']))
 				{
 					$this->_object['EstimateLineAdd'] = $this->_object['EstimateLine'];
 				}
-				
+
 				break;
 			case 'EstimateModRq':
-				
+
 				if (isset($this->_object['EstimateLine']))
 				{
-					$this->_object['EstimateLineMod'] = $this->_object['EstimateLine'];	
+					$this->_object['EstimateLineMod'] = $this->_object['EstimateLine'];
 				}
-				
+
 				break;
 		}
-		
+
 		return parent::asList($request);
 	}
-	
+
 	public function asXML($root = null, $parent = null, $object = null)
 	{
 		if (is_null($object))
 		{
 			$object = $this->_object;
 		}
-		
+
 		switch ($root)
 		{
 			case QUICKBOOKS_ADD_ESTIMATE:
-				
+
 				foreach ($object['EstimateLineAdd'] as $key => $obj)
 				{
 					$obj->setOverride('EstimateLineAdd');
 				}
-				
+
 				break;
 			case QUICKBOOKS_MOD_ESTIMATE:
 				if (isset($object['EstimateLine']))
@@ -630,38 +630,13 @@ class QuickBooks_QBXML_Object_Estimate extends QuickBooks_QBXML_Object
 				}
 				break;
 		}
-		
+
 		return parent::asXML($root, $parent, $object);
 	}
-	
-	/**
-	 * 
-	 */
-	public function asArray($request, $nest = true)
-	{
-		$this->_cleanup();
-		
-		return parent::asArray($request, $nest);
-	}
-	
-	/**
-	 * 
-	 * 
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null, $parent = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
+
 	/**
 	 * Tell the type of object this is
-	 * 
+	 *
 	 * @return string
 	 */
 	public function object()

--- a/QuickBooks/QBXML/Object/FixedAssetItem.php
+++ b/QuickBooks/QBXML/Object/FixedAssetItem.php
@@ -2,24 +2,24 @@
 
 /**
  * QuickBooks InventoryItem object container
- * 
+ *
  * @todo Verify the get/set methods on this one... it was copied from NonInventoryItem
  * @todo Add isActive(), getIsActive(), etc. methods
- * 
+ *
  * @author Keith Palmer <keith@consolibyte.com>
- * @license LICENSE.txt 
- * 
+ * @license LICENSE.txt
+ *
  * @package QuickBooks
  * @subpackage Object
  */
 
 /**
- * 
+ *
  */
 QuickBooks_Loader::load('/QuickBooks/QBXML/Object.php');
 
 /**
- * 
+ *
  */
 class QuickBooks_QBXML_Object_FixedAssetItem extends QuickBooks_QBXML_Object
 {
@@ -27,10 +27,10 @@ class QuickBooks_QBXML_Object_FixedAssetItem extends QuickBooks_QBXML_Object
 	{
 		parent::__construct($arr);
 	}
-	
+
 	/**
 	 * Set the ListID for this item
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return boolean
 	 */
@@ -38,20 +38,20 @@ class QuickBooks_QBXML_Object_FixedAssetItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('ListID', $ListID);
 	}
-	
+
 	/**
 	 * Get the ListID for this item
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getListID()
 	{
 		return $this->get('ListID');
 	}
-	
+
 	/**
 	 * Set the name for this item
-	 * 
+	 *
 	 * @param string $name
 	 * @return boolean
 	 */
@@ -59,20 +59,20 @@ class QuickBooks_QBXML_Object_FixedAssetItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('Name', $name);
 	}
-	
+
 	/**
 	 * Get the name for this item
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getName()
 	{
 		return $this->get('Name');
 	}
-	
+
 	/**
 	 * Set the description of this item
-	 * 
+	 *
 	 * @param string $descrip
 	 * @return boolean
 	 */
@@ -85,10 +85,10 @@ class QuickBooks_QBXML_Object_FixedAssetItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('SalesDesc');
 	}
-	
+
 	/**
 	 * Set the price for this item
-	 * 
+	 *
 	 * @param string $price
 	 * @return boolean
 	 */
@@ -96,7 +96,7 @@ class QuickBooks_QBXML_Object_FixedAssetItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('SalesPrice', sprintf('%01.2f', (float) $price));
 	}
-	
+
 	/**
 	 * Get the price for this item
 	 */
@@ -104,10 +104,10 @@ class QuickBooks_QBXML_Object_FixedAssetItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('SalesPrice');
 	}
-	
+
 	/**
 	 * Set the account ListID for this item
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return string
 	 */
@@ -115,7 +115,7 @@ class QuickBooks_QBXML_Object_FixedAssetItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('IncomeAccountRef ListID', $ListID);
 	}
-	
+
 	/**
 	 * (Sales OR Purchase)
 	 */
@@ -123,7 +123,7 @@ class QuickBooks_QBXML_Object_FixedAssetItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('IncomeAccountRef FullName', $name);
 	}
-	
+
 	/**
 	 * (Sales OR Purchase)
 	 */
@@ -136,83 +136,83 @@ class QuickBooks_QBXML_Object_FixedAssetItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('IncomeAccountRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	/**
-	 * 
+	 *
 	 */
 	public function getIncomeAccountListID()
 	{
 		return $this->get('IncomeAccountRef ListID');
 	}
-	
+
 	/**
-	 * 
+	 *
 	 */
 	public function getIncomeAccountName()
 	{
 		return $this->get('IncomeAccountRef FullName');
 	}
-	
+
 	public function setAssetAccountName($name)
 	{
 		return $this->set('AssetAccountRef FullName', $name);
 	}
-	
+
 	public function getAssetAccountName()
 	{
 		return $this->get('AssetAccountRef FullName');
 	}
-	
+
 	public function setAssetAccountListID($ListID)
 	{
 		return $this->set('AssetAccountRef ListID', $ListID);
 	}
-	
+
 	public function getAssetAccountListID()
 	{
 		return $this->get('AssetAccountRef ListID');
 	}
-	
+
 	public function setAssetAccountApplicationID($value)
 	{
 		return $this->set('AssetAccountRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_ACCOUNT, QUICKBOOKS_LISTID, $value));
 	}
-  
+
 	public function getAssetAccountApplicationID()
 	{
 		return $this->get('AssetAccountRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function setPurchaseDescription($desc)
 	{
 		return $this->set('PurchaseDesc', $desc);
 	}
-	
+
 	public function getPurchaseDescription()
 	{
 		return $this->get('PurchaseDesc');
 	}
-	
+
 	public function setPurchaseCost($cost)
 	{
 		return $this->set('PurchaseCost', sprintf('%01.2f', (float) $cost));
 	}
-	
+
 	public function getPurchaseCost()
 	{
 		return $this->get('PurchaseCost');
 	}
-	
+
 	public function setCOGSAccountListID($ListID)
 	{
 		return $this->set('COGSAccountRef ListID', $ListID);
 	}
-	
+
 	public function setCOGSAccountName($name)
 	{
 		return $this->set('COGSAccountRef FullName', $name);
 	}
-	
+
 	public function setCOGSAccountApplicationID($value)
 	{
 		return $this->set('COGSAccountRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_ACCOUNT, QUICKBOOKS_LISTID, $value));
@@ -222,27 +222,27 @@ class QuickBooks_QBXML_Object_FixedAssetItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('COGSAccountRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function getCOGSAccountListID()
 	{
 		return $this->get('COGSAccountRef ListID');
 	}
-	
+
 	public function getCOGSAccountName()
 	{
 		return $this->get('COGSAccountRef FullName');
 	}
-	
+
 	public function setPreferredVendorListID($ListID)
 	{
 		return $this->set('PrefVendorRef ListID', $ListID);
 	}
-	
+
 	public function setPreferredVendorName($name)
 	{
 		return $this->set('PrefVendorRef FullName', $name);
 	}
-	
+
 	public function setPreferredVendorApplicationID($value)
 	{
 		return $this->set('PrefVendorRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_VENDOR, QUICKBOOKS_LISTID, $value));
@@ -252,57 +252,20 @@ class QuickBooks_QBXML_Object_FixedAssetItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('PrefVendorRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function getPreferredVendorListID()
 	{
 		return $this->get('PrefVendorRef ListID');
 	}
-	
+
 	public function getPreferredVendorName()
 	{
 		return $this->get('PrefVendorRef FullName');
 	}
-	
+
 	/**
-	 * 
-	 * 
-	 * @return boolean
-	 */
-	protected function _cleanup()
-	{
-		
-		return true;
-	}
-	
-	/**
-	 * 
-	 */
-	public function asArray($request, $nest = true)
-	{
-		$this->_cleanup();
-		
-		return parent::asArray($request, $nest);
-	}
-	
-	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
-	 * Tell what type of object this is 
-	 * 
+	 * Tell what type of object this is
+	 *
 	 * @return string
 	 */
 	public function object()

--- a/QuickBooks/QBXML/Object/Generic.php
+++ b/QuickBooks/QBXML/Object/Generic.php
@@ -2,87 +2,50 @@
 
 /**
  * QuickBooks Customer object container
- * 
+ *
  * Not used, might be used in future versions
- * 
+ *
  * @author Keith Palmer <keith@consolibyte.com>
- * @license LICENSE.txt 
- * 
+ * @license LICENSE.txt
+ *
  * @package QuickBooks
  * @subpackage Object
  */
 
 /**
- * 
+ *
  */
 QuickBooks_Loader::load('/QuickBooks/QBXML/Object.php');
 
 /**
- * 
+ *
  */
 class QuickBooks_QBXML_Object_Generic extends QuickBooks_QBXML_Object
 {
 	protected $_override;
-	
+
 	public function __construct($arr = array(), $override = '')
 	{
 		$this->_override = $override;
-		
+
 		parent::__construct($arr);
 	}
-	
+
 	public function getOverride()
 	{
 		return $this->_override;
 	}
-	
+
 	public function setOverride($override)
 	{
 		$this->_override = $override;
-		
+
 		return true;
 	}
-	
+
 	/**
-	 * 
-	 * 
-	 * @return boolean
-	 */
-	protected function _cleanup()
-	{
-		
-		return true;
-	}
-	
-	/**
-	 * 
-	 */
-	public function asArray($request, $nest = true)
-	{
-		$this->_cleanup();
-		
-		return parent::asArray($request, $nest);
-	}
-	
-	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
-	 * Tell what type of object this is 
-	 * 
+	 * Tell what type of object this is
+	 *
 	 * @return string
 	 */
 	public function object()

--- a/QuickBooks/QBXML/Object/GroupItem.php
+++ b/QuickBooks/QBXML/Object/GroupItem.php
@@ -2,24 +2,24 @@
 
 /**
  * QuickBooks InventoryItem object container
- * 
+ *
  * @todo Verify the get/set methods on this one... it was copied from NonInventoryItem
  * @todo Add isActive(), getIsActive(), etc. methods
- * 
+ *
  * @author Keith Palmer <keith@consolibyte.com>
- * @license LICENSE.txt 
- * 
+ * @license LICENSE.txt
+ *
  * @package QuickBooks
  * @subpackage Object
  */
 
 /**
- * 
+ *
  */
 QuickBooks_Loader::load('/QuickBooks/QBXML/Object.php');
 
 /**
- * 
+ *
  */
 class QuickBooks_QBXML_Object_GroupItem extends QuickBooks_QBXML_Object
 {
@@ -27,10 +27,10 @@ class QuickBooks_QBXML_Object_GroupItem extends QuickBooks_QBXML_Object
 	{
 		parent::__construct($arr);
 	}
-	
+
 	/**
 	 * Set the ListID for this item
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return boolean
 	 */
@@ -38,20 +38,20 @@ class QuickBooks_QBXML_Object_GroupItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('ListID', $ListID);
 	}
-	
+
 	/**
 	 * Get the ListID for this item
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getListID()
 	{
 		return $this->get('ListID');
 	}
-	
+
 	/**
 	 * Set the name for this item
-	 * 
+	 *
 	 * @param string $name
 	 * @return boolean
 	 */
@@ -59,20 +59,20 @@ class QuickBooks_QBXML_Object_GroupItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('Name', $name);
 	}
-	
+
 	/**
 	 * Get the name for this item
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getName()
 	{
 		return $this->get('Name');
 	}
-	
+
 	/**
 	 * Set the description of this item
-	 * 
+	 *
 	 * @param string $descrip
 	 * @return boolean
 	 */
@@ -85,10 +85,10 @@ class QuickBooks_QBXML_Object_GroupItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('SalesDesc');
 	}
-	
+
 	/**
 	 * Set the price for this item
-	 * 
+	 *
 	 * @param string $price
 	 * @return boolean
 	 */
@@ -96,7 +96,7 @@ class QuickBooks_QBXML_Object_GroupItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('SalesPrice', sprintf('%01.2f', (float) $price));
 	}
-	
+
 	/**
 	 * Get the price for this item
 	 */
@@ -104,10 +104,10 @@ class QuickBooks_QBXML_Object_GroupItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('SalesPrice');
 	}
-	
+
 	/**
 	 * Set the account ListID for this item
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return string
 	 */
@@ -115,7 +115,7 @@ class QuickBooks_QBXML_Object_GroupItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('IncomeAccountRef ListID', $ListID);
 	}
-	
+
 	/**
 	 * (Sales OR Purchase)
 	 */
@@ -123,7 +123,7 @@ class QuickBooks_QBXML_Object_GroupItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('IncomeAccountRef FullName', $name);
 	}
-	
+
 	/**
 	 * (Sales OR Purchase)
 	 */
@@ -136,43 +136,43 @@ class QuickBooks_QBXML_Object_GroupItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('IncomeAccountRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	/**
-	 * 
+	 *
 	 */
 	public function getIncomeAccountListID()
 	{
 		return $this->get('IncomeAccountRef ListID');
 	}
-	
+
 	/**
-	 * 
+	 *
 	 */
 	public function getIncomeAccountName()
 	{
 		return $this->get('IncomeAccountRef FullName');
 	}
-	
+
 	public function setAssetAccountName($name)
 	{
 		return $this->set('AssetAccountRef FullName', $name);
 	}
-	
+
 	public function getAssetAccountName()
 	{
 		return $this->get('AssetAccountRef FullName');
 	}
-	
+
 	public function setAssetAccountListID($ListID)
 	{
 		return $this->set('AssetAccountRef ListID', $ListID);
 	}
-	
+
 	public function getAssetAccountListID()
 	{
 		return $this->get('AssetAccountRef ListID');
 	}
-	
+
 	public function setAssetAccountApplicationID($value)
 	{
 		return $this->set('AssetAccountRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_ACCOUNT, QUICKBOOKS_LISTID, $value));
@@ -182,37 +182,37 @@ class QuickBooks_QBXML_Object_GroupItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('AssetAccountRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function setPurchaseDescription($desc)
 	{
 		return $this->set('PurchaseDesc', $desc);
 	}
-	
+
 	public function getPurchaseDescription()
 	{
 		return $this->get('PurchaseDesc');
 	}
-	
+
 	public function setPurchaseCost($cost)
 	{
 		return $this->set('PurchaseCost', sprintf('%01.2f', (float) $cost));
 	}
-	
+
 	public function getPurchaseCost()
 	{
 		return $this->get('PurchaseCost');
 	}
-	
+
 	public function setCOGSAccountListID($ListID)
 	{
 		return $this->set('COGSAccountRef ListID', $ListID);
 	}
-	
+
 	public function setCOGSAccountName($name)
 	{
 		return $this->set('COGSAccountRef FullName', $name);
 	}
-	
+
 	public function setCOGSAccountApplicationID($value)
 	{
 		return $this->set('COGSAccountRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_ACCOUNT, QUICKBOOKS_LISTID, $value));
@@ -222,27 +222,27 @@ class QuickBooks_QBXML_Object_GroupItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('COGSAccountRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function getCOGSAccountListID()
 	{
 		return $this->get('COGSAccountRef ListID');
 	}
-	
+
 	public function getCOGSAccountName()
 	{
 		return $this->get('COGSAccountRef FullName');
 	}
-	
+
 	public function setPreferredVendorListID($ListID)
 	{
 		return $this->set('PrefVendorRef ListID', $ListID);
 	}
-	
+
 	public function setPreferredVendorName($name)
 	{
 		return $this->set('PrefVendorRef FullName', $name);
 	}
-	
+
 	public function setPreferredVendorApplicationID($value)
 	{
 		return $this->set('PrefVendorRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_VENDOR, QUICKBOOKS_LISTID, $value));
@@ -252,57 +252,20 @@ class QuickBooks_QBXML_Object_GroupItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('PrefVendorRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function getPreferredVendorListID()
 	{
 		return $this->get('PrefVendorRef ListID');
 	}
-	
+
 	public function getPreferredVendorName()
 	{
 		return $this->get('PrefVendorRef FullName');
 	}
-	
+
 	/**
-	 * 
-	 * 
-	 * @return boolean
-	 */
-	protected function _cleanup()
-	{
-		
-		return true;
-	}
-	
-	/**
-	 * 
-	 */
-	public function asArray($request, $nest = true)
-	{
-		$this->_cleanup();
-		
-		return parent::asArray($request, $nest);
-	}
-	
-	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
-	 * Tell what type of object this is 
-	 * 
+	 * Tell what type of object this is
+	 *
 	 * @return string
 	 */
 	public function object()

--- a/QuickBooks/QBXML/Object/InventoryAdjustment.php
+++ b/QuickBooks/QBXML/Object/InventoryAdjustment.php
@@ -236,7 +236,7 @@ class QuickBooks_QBXML_Object_InventoryAdjustment extends QuickBooks_QBXML_Objec
 	{
 		return $this->get('TxnID');
 	}
-	
+
 	public function setTxnID($TxnID)
 	{
 		return $this->set('TxnID', $TxnID);
@@ -246,17 +246,17 @@ class QuickBooks_QBXML_Object_InventoryAdjustment extends QuickBooks_QBXML_Objec
 	{
 		return $this->get('RefNumberCaseSensitive');
 	}
-	
+
 	public function setRefNumberCaseSensitive($value)
 	{
 		return $this->set('RefNumberCaseSensitive', $value);
 	}
-	
+
 	public function getMaxReturned()
 	{
 		return $this->get('MaxReturned');
 	}
-	
+
 	public function setMaxReturned($max)
 	{
 		return $this->set('MaxReturned', $max);
@@ -266,47 +266,47 @@ class QuickBooks_QBXML_Object_InventoryAdjustment extends QuickBooks_QBXML_Objec
 	{
 		return $this->get('ModifiedDateRangeFilter FromModifiedDate');
 	}
-	
+
 	public function setFromModifiedDate($date)
 	{
 		return $this->set('ModifiedDateRangeFilter FromModifiedDate', $date);
 	}
-	
+
 	public function getToModifiedDate()
 	{
 		return $this->get('ModifiedDateRangeFilter ToModifiedDate');
 	}
-	
+
 	public function setToModifiedDate($date)
 	{
 		return $this->set('ModifiedDateRangeFilter ToModifiedDate', $date);
 	}
-	
+
 	public function getFromTxnDate()
 	{
 		return $this->get('TxnDateRangeFilter FromTxnDate');
 	}
-	
+
 	public function setFromTxnDate($date)
 	{
 		return $this->set('TxnDateRangeFilter FromTxnDate', $date);
 	}
-	
+
 	public function getToTxnDate()
 	{
 		return $this->get('TxnDateRangeFilter ToTxnDate');
 	}
-	
+
 	public function setToTxnDate($date)
 	{
 		return $this->set('TxnDateRangeFilter ToTxnDate', $date);
 	}
-	
+
 	public function getDateMacro()
 	{
 		return $this->get('TxnDateRangeFilter DateMacro');
 	}
-	
+
 	public function setDateMacro($macro)
 	{
 		return $this->set('TxnDateRangeFilter DateMacro', $macro);
@@ -316,37 +316,37 @@ class QuickBooks_QBXML_Object_InventoryAdjustment extends QuickBooks_QBXML_Objec
 	{
 		return $this->get('EntityFilter ListID');
 	}
-	
+
 	public function setEntityListID($listid)
 	{
 		return $this->set('EntityFilter ListID', $listid);
 	}
-	
+
 	public function getEntityFullName()
 	{
 		return $this->get('EntityFilter FullName');
 	}
-	
+
 	public function setEntityFullName($name)
 	{
 		return $this->set('EntityFilter FullName', $name);
 	}
-	
+
 	public function getEntityListIDWithChildren()
 	{
 		return $this->get('EntityFilter ListIDWithChildren');
 	}
-	
+
 	public function setEntityListIDWithChildren($listid)
 	{
 		return $this->set('EntityFilter ListIDWithChildren', $listid);
 	}
-	
+
 	public function getEntityFullNameWithChildren()
 	{
 		return $this->get('EntityFilter FullNameWithChildren');
 	}
-	
+
 	public function setEntityFullNameWithChildren($name)
 	{
 		return $this->set('EntityFilter FullNameWithChildren', $name);
@@ -356,37 +356,37 @@ class QuickBooks_QBXML_Object_InventoryAdjustment extends QuickBooks_QBXML_Objec
 	{
 		return $this->get('AccountFilter ListID');
 	}
-	
+
 	public function setFilterAccountListID($listid)
 	{
 		return $this->set('AccountFilter ListID', $listid);
 	}
-	
+
 	public function getFilterAccountFullName()
 	{
 		return $this->get('AccountFilter FullName');
 	}
-	
+
 	public function setFilterAccountFullName($name)
 	{
 		return $this->set('AccountFilter FullName', $name);
 	}
-	
+
 	public function getFilterAccountListIDWithChildren()
 	{
 		return $this->get('AccountFilter ListIDWithChildren');
 	}
-	
+
 	public function setFilterAccountListIDWithChildren($listid)
 	{
 		return $this->set('AccountFilter ListIDWithChildren', $listid);
 	}
-	
+
 	public function getFilterAccountFullNameWithChildren()
 	{
 		return $this->get('AccountFilter FullNameWithChildren');
 	}
-	
+
 	public function setFilterAccountFullNameWithChildren($name)
 	{
 		return $this->set('AccountFilter FullNameWithChildren', $name);
@@ -396,37 +396,37 @@ class QuickBooks_QBXML_Object_InventoryAdjustment extends QuickBooks_QBXML_Objec
 	{
 		return $this->get('ItemFilter ListID');
 	}
-	
+
 	public function setFilterItemListID($listid)
 	{
 		return $this->set('ItemFilter ListID', $listid);
 	}
-	
+
 	public function getFilterItemName()
 	{
 		return $this->get('ItemFilter FullName');
 	}
-	
+
 	public function setFilterItemName($name)
 	{
 		return $this->set('ItemFilter FullName', $name);
 	}
-	
+
 	public function getFilterItemListIDWithChildren()
 	{
 		return $this->get('ItemFilter ListIDWithChildren');
 	}
-	
+
 	public function setFilterItemListIDWithChildren($listid)
 	{
 		return $this->set('ItemFilter ListIDWithChildren', $listid);
 	}
-	
+
 	public function getFilterItemFullNameWithChildren()
 	{
 		return $this->get('ItemFilter FullNameWithChildren');
 	}
-	
+
 	public function setFilterItemFullNameWithChildren($name)
 	{
 		return $this->set('ItemFilter FullNameWithChildren', $name);
@@ -436,37 +436,37 @@ class QuickBooks_QBXML_Object_InventoryAdjustment extends QuickBooks_QBXML_Objec
 	{
 		return $this->get('RefNumberFilter MatchCriterion');
 	}
-	
+
 	public function setFilterRefNumberMatchCriterion($refnumber)
 	{
 		return $this->set('RefNumberFilter MatchCriterion', $refnumber);
 	}
-	
+
 	public function getFilterRefNumberRefNumber()
 	{
 		return $this->get('RefNumberFilter RefNumber');
 	}
-	
+
 	public function setFilterRefNumberRefNumber($refnumber)
 	{
 		return $this->set('RefNumberFilter RefNumber', $refnumber);
 	}
-	
+
 	public function getFilterRefNumberRangeFromRefNumber()
 	{
 		return $this->get('RefNumberRangeFilter FromRefNumber');
 	}
-	
+
 	public function setFilterRefNumberRangeFromRefNumber($refnumber)
 	{
 		return $this->set('RefNumberRangeFilter FromRefNumber', $refnumber);
 	}
-	
+
 	public function getFilterRefNumberRangeToRefNumber()
 	{
 		return $this->get('RefNumberRangeFilter ToRefNumber');
 	}
-	
+
 	public function setFilterRefNumberRangeToRefNumber($refnumber)
 	{
 		return $this->set('RefNumberRangeFilter ToRefNumber', $refnumber);
@@ -478,42 +478,32 @@ class QuickBooks_QBXML_Object_InventoryAdjustment extends QuickBooks_QBXML_Objec
 	{
 		return $this->get('IncludeLineItems');
 	}
-	
+
 	public function setIncludeLineItems($)
 	{
 		return $this->set('IncludeLineItems', $);
 	}
-	
+
 	public function getIncludeRetElement()
 	{
 		return $this->get('IncludeRetElement');
 	}
-	
+
 	public function setIncludeRetElement($)
 	{
 		return $this->set('IncludeRetElement', $);
 	}
-	
+
 	public function getOwnerID()
 	{
 		return $this->get('OwnerID');
 	}
-	
+
 	public function setOwnerID($)
 	{
 		return $this->set('OwnerID', $);
 	}
 */
-
-	/**
-	 *
-	 *
-	 * @return boolean
-	 */
-	protected function _cleanup()
-	{
-		return true;
-	}
 
 	public function asList($request)
 	{
@@ -531,23 +521,13 @@ class QuickBooks_QBXML_Object_InventoryAdjustment extends QuickBooks_QBXML_Objec
 		return parent::asList($request);
 	}
 
-	/**
-	 *
-	 */
-	public function asArray($request, $nest = true)
-	{
-		$this->_cleanup();
-
-		return parent::asArray($request, $nest);
-	}
-
 	public function asXML($root = null, $parent = null, $object = null)
 	{
 		if (is_null($object))
 		{
 			$object = $this->_object;
 		}
-		
+
 		switch ($root)
 		{
 			case QUICKBOOKS_ADD_INVENTORYADJUSTMENT:
@@ -560,21 +540,6 @@ class QuickBooks_QBXML_Object_InventoryAdjustment extends QuickBooks_QBXML_Objec
 		}
 
 		return parent::asXML($root, $parent, $object);
-	}
-	/**
-	 * Convert this object to a valid qbXML request
-	 *
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
 	}
 
 	/**

--- a/QuickBooks/QBXML/Object/InventoryAssemblyItem.php
+++ b/QuickBooks/QBXML/Object/InventoryAssemblyItem.php
@@ -2,24 +2,24 @@
 
 /**
  * QuickBooks InventoryItem object container
- * 
+ *
  * @todo Verify the get/set methods on this one... it was copied from NonInventoryItem
  * @todo Add isActive(), getIsActive(), etc. methods
- * 
+ *
  * @author Keith Palmer <keith@consolibyte.com>
- * @license LICENSE.txt 
- * 
+ * @license LICENSE.txt
+ *
  * @package QuickBooks
  * @subpackage Object
  */
 
 /**
- * 
+ *
  */
 QuickBooks_Loader::load('/QuickBooks/QBXML/Object.php');
 
 /**
- * 
+ *
  */
 class QuickBooks_QBXML_Object_InventoryAssemblyItem extends QuickBooks_QBXML_Object
 {
@@ -27,10 +27,10 @@ class QuickBooks_QBXML_Object_InventoryAssemblyItem extends QuickBooks_QBXML_Obj
 	{
 		parent::__construct($arr);
 	}
-	
+
 	/**
 	 * Set the ListID for this item
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return boolean
 	 */
@@ -38,30 +38,30 @@ class QuickBooks_QBXML_Object_InventoryAssemblyItem extends QuickBooks_QBXML_Obj
 	{
 		return $this->set('ListID', $ListID);
 	}
-	
+
 	/**
 	 * Get the ListID for this item
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getListID()
 	{
 		return $this->get('ListID');
 	}
-	
+
 	public function setFullName($fullname)
 	{
 		return $this->setFullNameType('FullName', 'Name', 'ParentRef FullName', $fullname);
 	}
-	
+
 	public function getFullName()
 	{
 		return $this->getFullNameType('FullName', 'Name', 'ParentRef FullName');
-	}	
-	
+	}
+
 	/**
 	 * Set the name for this item
-	 * 
+	 *
 	 * @param string $name
 	 * @return boolean
 	 */
@@ -69,20 +69,20 @@ class QuickBooks_QBXML_Object_InventoryAssemblyItem extends QuickBooks_QBXML_Obj
 	{
 		return $this->set('Name', $name);
 	}
-	
+
 	/**
 	 * Get the name for this item
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getName()
 	{
 		return $this->get('Name');
 	}
-	
+
 	/**
 	 * Set the description of this item
-	 * 
+	 *
 	 * @param string $descrip
 	 * @return boolean
 	 */
@@ -95,10 +95,10 @@ class QuickBooks_QBXML_Object_InventoryAssemblyItem extends QuickBooks_QBXML_Obj
 	{
 		return $this->get('SalesDesc');
 	}
-	
+
 	/**
 	 * Set the price for this item
-	 * 
+	 *
 	 * @param string $price
 	 * @return boolean
 	 */
@@ -106,7 +106,7 @@ class QuickBooks_QBXML_Object_InventoryAssemblyItem extends QuickBooks_QBXML_Obj
 	{
 		return $this->set('SalesPrice', sprintf('%01.2f', (float) $price));
 	}
-	
+
 	/**
 	 * Get the price for this item
 	 */
@@ -114,10 +114,10 @@ class QuickBooks_QBXML_Object_InventoryAssemblyItem extends QuickBooks_QBXML_Obj
 	{
 		return $this->get('SalesPrice');
 	}
-	
+
 	/**
 	 * Set the account ListID for this item
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return string
 	 */
@@ -125,7 +125,7 @@ class QuickBooks_QBXML_Object_InventoryAssemblyItem extends QuickBooks_QBXML_Obj
 	{
 		return $this->set('IncomeAccountRef ListID', $ListID);
 	}
-	
+
 	/**
 	 * (Sales OR Purchase)
 	 */
@@ -133,7 +133,7 @@ class QuickBooks_QBXML_Object_InventoryAssemblyItem extends QuickBooks_QBXML_Obj
 	{
 		return $this->set('IncomeAccountRef FullName', $name);
 	}
-	
+
 	/**
 	 * (Sales OR Purchase)
 	 */
@@ -146,43 +146,43 @@ class QuickBooks_QBXML_Object_InventoryAssemblyItem extends QuickBooks_QBXML_Obj
 	{
 		return $this->get('IncomeAccountRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	/**
-	 * 
+	 *
 	 */
 	public function getIncomeAccountListID()
 	{
 		return $this->get('IncomeAccountRef ListID');
 	}
-	
+
 	/**
-	 * 
+	 *
 	 */
 	public function getIncomeAccountName()
 	{
 		return $this->get('IncomeAccountRef FullName');
 	}
-	
+
 	public function setAssetAccountName($name)
 	{
 		return $this->set('AssetAccountRef FullName', $name);
 	}
-	
+
 	public function getAssetAccountName()
 	{
 		return $this->get('AssetAccountRef FullName');
 	}
-	
+
 	public function setAssetAccountListID($ListID)
 	{
 		return $this->set('AssetAccountRef ListID', $ListID);
 	}
-	
+
 	public function getAssetAccountListID()
 	{
 		return $this->get('AssetAccountRef ListID');
 	}
-	
+
 	public function setAssetAccountApplicationID($value)
 	{
 		return $this->set('AssetAccountRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_ACCOUNT, QUICKBOOKS_LISTID, $value));
@@ -192,37 +192,37 @@ class QuickBooks_QBXML_Object_InventoryAssemblyItem extends QuickBooks_QBXML_Obj
 	{
 		return $this->get('AssetAccountRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function setPurchaseDescription($desc)
 	{
 		return $this->set('PurchaseDesc', $desc);
 	}
-	
+
 	public function getPurchaseDescription()
 	{
 		return $this->get('PurchaseDesc');
 	}
-	
+
 	public function setPurchaseCost($cost)
 	{
 		return $this->set('PurchaseCost', sprintf('%01.2f', (float) $cost));
 	}
-	
+
 	public function getPurchaseCost()
 	{
 		return $this->get('PurchaseCost');
 	}
-	
+
 	public function setCOGSAccountListID($ListID)
 	{
 		return $this->set('COGSAccountRef ListID', $ListID);
 	}
-	
+
 	public function setCOGSAccountName($name)
 	{
 		return $this->set('COGSAccountRef FullName', $name);
 	}
-	
+
 	public function setCOGSAccountApplicationID($value)
 	{
 		return $this->set('COGSAccountRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_ACCOUNT, QUICKBOOKS_LISTID, $value));
@@ -232,27 +232,27 @@ class QuickBooks_QBXML_Object_InventoryAssemblyItem extends QuickBooks_QBXML_Obj
 	{
 		return $this->get('COGSAccountRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function getCOGSAccountListID()
 	{
 		return $this->get('COGSAccountRef ListID');
 	}
-	
+
 	public function getCOGSAccountName()
 	{
 		return $this->get('COGSAccountRef FullName');
 	}
-	
+
 	public function setPreferredVendorListID($ListID)
 	{
 		return $this->set('PrefVendorRef ListID', $ListID);
 	}
-	
+
 	public function setPreferredVendorName($name)
 	{
 		return $this->set('PrefVendorRef FullName', $name);
 	}
-	
+
 	public function setPreferredVendorApplicationID($value)
 	{
 		return $this->set('PrefVendorRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_VENDOR, QUICKBOOKS_LISTID, $value));
@@ -262,57 +262,20 @@ class QuickBooks_QBXML_Object_InventoryAssemblyItem extends QuickBooks_QBXML_Obj
 	{
 		return $this->get('PrefVendorRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function getPreferredVendorListID()
 	{
 		return $this->get('PrefVendorRef ListID');
 	}
-	
+
 	public function getPreferredVendorName()
 	{
 		return $this->get('PrefVendorRef FullName');
 	}
-	
+
 	/**
-	 * 
-	 * 
-	 * @return boolean
-	 */
-	protected function _cleanup()
-	{
-		
-		return true;
-	}
-	
-	/**
-	 * 
-	 */
-	public function asArray($request, $nest = true)
-	{
-		$this->_cleanup();
-		
-		return parent::asArray($request, $nest);
-	}
-	
-	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
-	 * Tell what type of object this is 
-	 * 
+	 * Tell what type of object this is
+	 *
 	 * @return string
 	 */
 	public function object()

--- a/QuickBooks/QBXML/Object/InventoryItem.php
+++ b/QuickBooks/QBXML/Object/InventoryItem.php
@@ -2,24 +2,24 @@
 
 /**
  * QuickBooks InventoryItem object container
- * 
+ *
  * @todo Verify the get/set methods on this one... it was copied from NonInventoryItem
  * @todo Add isActive(), getIsActive(), etc. methods
- * 
+ *
  * @author Keith Palmer <keith@consolibyte.com>
- * @license LICENSE.txt 
- * 
+ * @license LICENSE.txt
+ *
  * @package QuickBooks
  * @subpackage Object
  */
 
 /**
- * 
+ *
  */
 QuickBooks_Loader::load('/QuickBooks/QBXML/Object.php');
 
 /**
- * 
+ *
  */
 class QuickBooks_QBXML_Object_InventoryItem extends QuickBooks_QBXML_Object
 {
@@ -27,10 +27,10 @@ class QuickBooks_QBXML_Object_InventoryItem extends QuickBooks_QBXML_Object
 	{
 		parent::__construct($arr);
 	}
-	
+
 	/**
 	 * Set the ListID for this item
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return boolean
 	 */
@@ -38,20 +38,20 @@ class QuickBooks_QBXML_Object_InventoryItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('ListID', $ListID);
 	}
-	
+
 	/**
 	 * Get the ListID for this item
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getListID()
 	{
 		return $this->get('ListID');
 	}
-	
+
 	/**
 	 * Set the name for this item
-	 * 
+	 *
 	 * @param string $name
 	 * @return boolean
 	 */
@@ -59,30 +59,30 @@ class QuickBooks_QBXML_Object_InventoryItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('Name', $name);
 	}
-	
+
 	/**
 	 * Get the name for this item
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getName()
 	{
 		return $this->get('Name');
 	}
-	
+
 	public function setFullName($fullname)
 	{
 		return $this->setFullNameType('FullName', 'Name', 'ParentRef FullName', $fullname);
 	}
-	
+
 	public function getFullName()
 	{
 		return $this->getFullNameType('FullName', 'Name', 'ParentRef FullName');
-	}	
-	
+	}
+
 	/**
 	 * Set the QuantityOnHand for this item
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return boolean
 	 */
@@ -90,20 +90,20 @@ class QuickBooks_QBXML_Object_InventoryItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('QuantityOnHand', (int) $quantity);
 	}
-    
+
 	/**
 	 * Get the QuantityOnHand for this item
-	 * 
+	 *
 	 * @return boolean
 	 */
 	public function getQuantityOnHand()
 	{
 		return $this->get('QuantityOnHand');
 	}
-	
+
 	/**
 	 * Set the description of this item
-	 * 
+	 *
 	 * @param string $descrip
 	 * @return boolean
 	 */
@@ -116,10 +116,10 @@ class QuickBooks_QBXML_Object_InventoryItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('SalesDesc');
 	}
-	
+
 	/**
 	 * Set the price for this item
-	 * 
+	 *
 	 * @param string $price
 	 * @return boolean
 	 */
@@ -127,7 +127,7 @@ class QuickBooks_QBXML_Object_InventoryItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('SalesPrice', sprintf('%01.2f', (float) $price));
 	}
-	
+
 	/**
 	 * Get the price for this item
 	 */
@@ -135,10 +135,10 @@ class QuickBooks_QBXML_Object_InventoryItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('SalesPrice');
 	}
-	
+
 	/**
 	 * Set the account ListID for this item
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return string
 	 */
@@ -146,7 +146,7 @@ class QuickBooks_QBXML_Object_InventoryItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('IncomeAccountRef ListID', $ListID);
 	}
-	
+
 	/**
 	 * (Sales OR Purchase)
 	 * @deprecated
@@ -155,12 +155,12 @@ class QuickBooks_QBXML_Object_InventoryItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('IncomeAccountRef FullName', $name);
 	}
-	
+
 	public function setIncomeAccountFullName($FullName)
 	{
 		return $this->setFullNameType('IncomeAccountRef FullName', null, null, $FullName);
 	}
-	
+
 	/**
 	 * (Sales OR Purchase)
 	 */
@@ -173,15 +173,15 @@ class QuickBooks_QBXML_Object_InventoryItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('IncomeAccountRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	/**
-	 * 
+	 *
 	 */
 	public function getIncomeAccountListID()
 	{
 		return $this->get('IncomeAccountRef ListID');
 	}
-	
+
 	/**
 	 * @deprecated
 	 */
@@ -193,13 +193,13 @@ class QuickBooks_QBXML_Object_InventoryItem extends QuickBooks_QBXML_Object
 	public function getIncomeAccountFullName()
 	{
 		return $this->get('IncomeAccountRef FullName');
-	}	
+	}
 
 	public function setAssetAccountName($name)
 	{
 		return $this->set('AssetAccountRef FullName', $name);
 	}
-	
+
 	/**
 	 * @deprecated
 	 */
@@ -207,22 +207,22 @@ class QuickBooks_QBXML_Object_InventoryItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('AssetAccountRef FullName');
 	}
-	
+
 	public function getAssetAccountFullName()
 	{
 		return $this->get('AssetAccountRef FullName');
 	}
-	
+
 	public function setAssetAccountListID($ListID)
 	{
 		return $this->set('AssetAccountRef ListID', $ListID);
 	}
-	
+
 	public function getAssetAccountListID()
 	{
 		return $this->get('AssetAccountRef ListID');
 	}
-	
+
 	public function setAssetAccountApplicationID($value)
 	{
 		return $this->set('AssetAccountRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_ACCOUNT, QUICKBOOKS_LISTID, $value));
@@ -232,32 +232,32 @@ class QuickBooks_QBXML_Object_InventoryItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('AssetAccountRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function setPurchaseDescription($desc)
 	{
 		return $this->set('PurchaseDesc', $desc);
 	}
-	
+
 	public function getPurchaseDescription()
 	{
 		return $this->get('PurchaseDesc');
 	}
-	
+
 	public function setPurchaseCost($cost)
 	{
 		return $this->set('PurchaseCost', sprintf('%01.2f', (float) $cost));
 	}
-	
+
 	public function getPurchaseCost()
 	{
 		return $this->get('PurchaseCost');
 	}
-	
+
 	public function setCOGSAccountListID($ListID)
 	{
 		return $this->set('COGSAccountRef ListID', $ListID);
 	}
-	
+
 	/**
 	 * @deprecated
 	 */
@@ -265,12 +265,12 @@ class QuickBooks_QBXML_Object_InventoryItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('COGSAccountRef FullName', $name);
 	}
-	
+
 	public function setCOGSAccountFullName($FullName)
 	{
 		return $this->setFullNameType('COGSAccountRef FullName', null, null, $FullName);
 	}
-	
+
 	public function setCOGSAccountApplicationID($value)
 	{
 		return $this->set('COGSAccountRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_ACCOUNT, QUICKBOOKS_LISTID, $value));
@@ -280,12 +280,12 @@ class QuickBooks_QBXML_Object_InventoryItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('COGSAccountRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function getCOGSAccountListID()
 	{
 		return $this->get('COGSAccountRef ListID');
 	}
-	
+
 	/**
 	 * @deprecated
 	 */
@@ -298,17 +298,17 @@ class QuickBooks_QBXML_Object_InventoryItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('COGSAccountRef FullName');
 	}
-	
+
 	public function setPreferredVendorListID($ListID)
 	{
 		return $this->set('PrefVendorRef ListID', $ListID);
 	}
-	
+
 	public function setPreferredVendorName($name)
 	{
 		return $this->set('PrefVendorRef FullName', $name);
 	}
-	
+
 	public function setPreferredVendorApplicationID($value)
 	{
 		return $this->set('PrefVendorRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_VENDOR, QUICKBOOKS_LISTID, $value));
@@ -318,67 +318,30 @@ class QuickBooks_QBXML_Object_InventoryItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('PrefVendorRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function getPreferredVendorListID()
 	{
 		return $this->get('PrefVendorRef ListID');
 	}
-	
+
 	public function getPreferredVendorName()
 	{
 		return $this->get('PrefVendorRef FullName');
 	}
-	
+
 	public function getUnitOfMeasureSetListID()
 	{
 		return $this->get('UnitOfMeasureSetRef ListID');
 	}
-	
+
 	public function getUnitOfMeasureSetFullName()
 	{
 		return $this->get('UnitOfMeasureSetRef FullName');
 	}
-	
+
 	/**
-	 * 
-	 * 
-	 * @return boolean
-	 */
-	protected function _cleanup()
-	{
-		
-		return true;
-	}
-	
-	/**
-	 * 
-	 */
-	public function asArray($request, $nest = true)
-	{
-		$this->_cleanup();
-		
-		return parent::asArray($request, $nest);
-	}
-	
-	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $version = null, $locale = null, $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $version, $locale, $root);
-	}
-	
-	/**
-	 * Tell what type of object this is 
-	 * 
+	 * Tell what type of object this is
+	 *
 	 * @return string
 	 */
 	public function object()

--- a/QuickBooks/QBXML/Object/Invoice.php
+++ b/QuickBooks/QBXML/Object/Invoice.php
@@ -2,10 +2,10 @@
 
 /**
  * QuickBooks Invoice object container
- * 
+ *
  * @author Keith Palmer <keith@consolibyte.com>
- * @license LICENSE.txt 
- * 
+ * @license LICENSE.txt
+ *
  * @package QuickBooks
  * @subpackage Object
  */
@@ -47,14 +47,14 @@ class QuickBooks_QBXML_Object_Invoice extends QuickBooks_QBXML_Object
 {
 	/**
 	 * Create a new QuickBooks Invoice object
-	 * 
+	 *
 	 * @param array $arr
 	 */
 	public function __construct($arr = array())
 	{
 		parent::__construct($arr);
 	}
-	
+
 	/**
 	 * Alias of {@link QuickBooks_Object_Invoice::setTxnID()}
 	 */
@@ -62,10 +62,10 @@ class QuickBooks_QBXML_Object_Invoice extends QuickBooks_QBXML_Object
 	{
 		return $this->setTxnID($TxnID);
 	}
-	
+
 	/**
 	 * Set the transaction ID of the Invoice object
-	 * 
+	 *
 	 * @param string $TxnID
 	 * @return boolean
 	 */
@@ -73,7 +73,7 @@ class QuickBooks_QBXML_Object_Invoice extends QuickBooks_QBXML_Object
 	{
 		return $this->set('TxnID', $TxnID);
 	}
-	
+
 	/**
 	 * Alias of {@link QuickBooks_Object_Invoice::getTxnID()}
 	 */
@@ -81,20 +81,20 @@ class QuickBooks_QBXML_Object_Invoice extends QuickBooks_QBXML_Object
 	{
 		return $this->getTxnID();
 	}
-	
+
 	/**
 	 * Get the transaction ID for this invoice
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getTxnID()
 	{
 		return $this->get('TxnID');
 	}
-	
+
 	/**
 	 * Set the customer ListID
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return boolean
 	 */
@@ -102,10 +102,10 @@ class QuickBooks_QBXML_Object_Invoice extends QuickBooks_QBXML_Object
 	{
 		return $this->set('CustomerRef ListID' , $ListID);
 	}
-	
+
 	/**
 	 * Set the customer ApplicationID (auto-replaced by the API with a ListID)
-	 * 
+	 *
 	 * @param mixed $value
 	 * @return boolean
 	 */
@@ -113,10 +113,10 @@ class QuickBooks_QBXML_Object_Invoice extends QuickBooks_QBXML_Object
 	{
 		return $this->set('CustomerRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_CUSTOMER, QUICKBOOKS_LISTID, $value));
 	}
-	
+
 	/**
 	 * Set the customer name
-	 * 
+	 *
 	 * @param string $name
 	 * @return boolean
 	 */
@@ -132,30 +132,30 @@ class QuickBooks_QBXML_Object_Invoice extends QuickBooks_QBXML_Object
 	{
 		return $this->set('CustomerRef FullName', $name);
 	}
-	
+
 	/**
 	 * Get the customer ListID
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getCustomerListID()
 	{
 		return $this->get('CustomerRef ListID');
 	}
-	
+
 	/**
 	 * Get the customer application ID
-	 * 
+	 *
 	 * @return mixed
 	 */
 	public function getCustomerApplicationID()
 	{
 		return $this->extractApplicationID($this->get('CustomerRef ' . QUICKBOOKS_API_APPLICATIONID));
 	}
-	
+
 	/**
 	 * Get the customer name
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getCustomerFullName()
@@ -170,21 +170,21 @@ class QuickBooks_QBXML_Object_Invoice extends QuickBooks_QBXML_Object
 	{
 		return $this->get('CustomerRef FullName');
 	}
-		
-	/** 
+
+	/**
 	 * Set the class ListID for this invoice
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return boolean
-	 */ 
+	 */
 	public function setClassListID($ListID)
 	{
 		return $this->set('ClassRef ListID', $ListID);
 	}
-	
+
 	/**
 	 * Set the class application ID
-	 * 
+	 *
 	 * @param mixed $value
 	 * @return boolean
 	 */
@@ -192,101 +192,101 @@ class QuickBooks_QBXML_Object_Invoice extends QuickBooks_QBXML_Object
 	{
 		return $this->set('ClassRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_CLASS, QUICKBOOKS_LISTID, $value));
 	}
-	
+
 	public function setClassName($name)
 	{
 		return $this->set('ClassRef FullName', $name);
 	}
-	
+
 	public function getClassName()
 	{
 		return $this->get('ClassRef FullName');
 	}
-	
+
 	public function getClassListID()
 	{
 		return $this->get('ClassRef ListID');
 	}
-	
+
 	/*
 	public function getClassApplicationID()
 	{
 		return $this->extractApplicationID($this->get('ClassRef ' . QUICKBOOKS_API_APPLICATIONID));
 	}
-	
+
 	public function setARAccountApplicationID($value)
 	{
 		return $this->set('ARAccountRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_ACCOUNT, QUICKBOOKS_LISTID, $value));
 	}*/
-	
+
 	public function setARAccountListID($ListID)
 	{
 		return $this->set('ARAccountRef ListID', $ListID);
 	}
-	
+
 	public function setARAccountName($name)
 	{
 		return $this->set('ARAccountRef FullName', $name);
 	}
-	
+
 	public function getARAccountListID()
 	{
 		return $this->get('ARAccountRef ListID');
 	}
-	
+
 	public function getARAccountName()
 	{
 		return $this->get('ARAccountRef FullName');
 	}
-	
+
 	/**
 	 * Get the ARAccount application ID
-	 * 
+	 *
 	 * @return value
 	 */
 	public function getARAccountApplicationID()
 	{
 		return $this->extractApplicationID($this->get('ARAccountRef ' . QUICKBOOKS_API_APPLICATIONID));
 	}
-	
+
 	public function setTemplateApplicationID($value)
 	{
 		return $this->set('TemplateRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_TEMPLATE, QUICKBOOKS_LISTID, $value));
 	}
-	
+
 	public function setTemplateName($name)
 	{
 		return $this->set('TemplateRef FullName', $name);
 	}
-	
+
 	public function setTemplateListID($ListID)
 	{
 		return $this->set('TemplateRef ListID', $ListID);
 	}
-	
+
 	public function getTemplateName()
 	{
 		return $this->get('TemplateRef FullName');
 	}
-	
+
 	public function getTemplateListID()
 	{
 		return $this->get('TemplateRef ListID');
 	}
-	
+
 	/**
 	 * Get the template application ID
-	 * 
+	 *
 	 * @return value
 	 */
 	public function getTemplateApplicationID()
 	{
 		return $this->extractApplicationID($this->get('TemplateRef ' . QUICKBOOKS_API_APPLICATIONID));
 	}
-	
+
 	/**
 	 * Set the transaction date
-	 * 
+	 *
 	 * @param string $date
 	 * @return boolean
 	 */
@@ -294,7 +294,7 @@ class QuickBooks_QBXML_Object_Invoice extends QuickBooks_QBXML_Object
 	{
 		return $this->setDateType('TxnDate', $date);
 	}
-	
+
 	/**
 	 * Alias of {@link QuickBooks_Object_Invoice::setTxnDate()}
 	 */
@@ -302,10 +302,10 @@ class QuickBooks_QBXML_Object_Invoice extends QuickBooks_QBXML_Object
 	{
 		return $this->setTxnDate($date);
 	}
-	
+
 	/**
 	 * Get the transaction date
-	 * 
+	 *
 	 * @param string $format	The format you want the date in (as for {@link http://www.php.net/date})
 	 * @return string
 	 */
@@ -314,7 +314,7 @@ class QuickBooks_QBXML_Object_Invoice extends QuickBooks_QBXML_Object
 		//return date($format, strtotime($this->get('TxnDate')));
 		return $this->getDateType('TxnDate', $format);
 	}
-	
+
 	/**
 	 * Alias of {@link QuickBooks_Object_Invoice::getTxnDate()}
 	 */
@@ -322,10 +322,10 @@ class QuickBooks_QBXML_Object_Invoice extends QuickBooks_QBXML_Object
 	{
 		return $this->getTxnDate($format);
 	}
-	
+
 	/**
 	 * Set the reference number
-	 * 
+	 *
 	 * @param string $str
 	 * @return boolean
 	 */
@@ -333,7 +333,7 @@ class QuickBooks_QBXML_Object_Invoice extends QuickBooks_QBXML_Object
 	{
 		return $this->set('RefNumber', $str);
 	}
-	
+
 	/**
 	 * Alias of {@link QuickBooks_Object_Invoice::setRefNumber()}
 	 */
@@ -341,10 +341,10 @@ class QuickBooks_QBXML_Object_Invoice extends QuickBooks_QBXML_Object
 	{
 		return $this->setRefNumber($str);
 	}
-	
+
 	/**
 	 * Get the reference number
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getRefNumber()
@@ -359,10 +359,10 @@ class QuickBooks_QBXML_Object_Invoice extends QuickBooks_QBXML_Object
 	{
 		return $this->getRefNumber();
 	}
-	
+
 	/**
 	 * Get an shipping address as an array (or a specific portion of the address as a string)
-	 * 
+	 *
 	 * @param string $part			A specific portion of the address to get (i.e. "Addr1" or "State")
 	 * @param array $defaults		Default values if a value isn't filled in
 	 * @return array				The address
@@ -373,13 +373,13 @@ class QuickBooks_QBXML_Object_Invoice extends QuickBooks_QBXML_Object
 		{
 			return $this->get('ShipAddress ' . $part);
 		}
-		
+
 		return $this->getArray('ShipAddress *', $defaults);
 	}
-	
+
 	/**
 	 * Set the shipping address for the invoice
-	 * 
+	 *
 	 * @param string $addr1			Address line 1
 	 * @param string $addr2			Address line 2
 	 * @param string $addr3			Address line 3
@@ -399,18 +399,18 @@ class QuickBooks_QBXML_Object_Invoice extends QuickBooks_QBXML_Object
 		{
 			$this->set('ShipAddress Addr' . $i, ${'addr' . $i});
 		}
-		
+
 		$this->set('ShipAddress City', $city);
 		$this->set('ShipAddress State', $state);
 		$this->set('ShipAddress Province', $province);
 		$this->set('ShipAddress PostalCode', $postalcode);
 		$this->set('ShipAddress Country', $country);
-		$this->set('ShipAddress Note', $note);  
+		$this->set('ShipAddress Note', $note);
 	}
-	
+
 	/**
-	 * Get the billing address 
-	 * 
+	 * Get the billing address
+	 *
 	 * @param string $part			A specific portion of the address to get (i.e. "Addr1" or "State")
 	 * @param array $defaults		Default values if a value isn't filled in
 	 * @return array				The address
@@ -421,13 +421,13 @@ class QuickBooks_QBXML_Object_Invoice extends QuickBooks_QBXML_Object
 		{
 			return $this->get('BillAddress ' . $part);
 		}
-		
+
 		return $this->getArray('BillAddress *', $defaults);
 	}
-	
+
 	/**
 	 * Set the billing address for the invoice
-	 * 
+	 *
 	 * @param string $addr1			Address line 1
 	 * @param string $addr2			Address line 2
 	 * @param string $addr3			Address line 3
@@ -447,18 +447,18 @@ class QuickBooks_QBXML_Object_Invoice extends QuickBooks_QBXML_Object
 		{
 			$this->set('BillAddress Addr' . $i, ${'addr' . $i});
 		}
-		
+
 		$this->set('BillAddress City', $city);
 		$this->set('BillAddress State', $state);
 		$this->set('BillAddress Province', $province);
 		$this->set('BillAddress PostalCode', $postalcode);
 		$this->set('BillAddress Country', $country);
-		$this->set('BillAddress Note', $note);  
+		$this->set('BillAddress Note', $note);
 	}
-	
-	/** 
+
+	/**
 	 * Set an invoice as pending
-	 * 
+	 *
 	 * @param boolean $pending
 	 * @return boolean
 	 */
@@ -466,60 +466,60 @@ class QuickBooks_QBXML_Object_Invoice extends QuickBooks_QBXML_Object
 	{
 		return $this->setBooleanType('IsPending', $pending);
 	}
-	
+
 	public function getIsPending()
 	{
 		return $this->getBooleanType('IsPending');
 	}
-	
+
 	public function setPONumber($num)
 	{
 		return $this->set('PONumber', $num);
 	}
-	
+
 	public function getPONumber()
 	{
 		return $this->get('PONumber');
 	}
-	
+
 	public function setTermsListID($ListID)
 	{
 		return $this->set('TermsRef ListID', $ListID);
 	}
-	
+
 	public function setTermsApplicationID($value)
 	{
 		return $this->set('TermsRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_TERMS, QUICKBOOKS_LISTID, $value));
 	}
-	
+
 	public function setTermsName($name)
 	{
 		return $this->set('TermsRef FullName', $name);
 	}
-	
+
 	public function getTermsName()
 	{
 		return $this->get('TermsRef FullName');
 	}
-	
+
 	public function getTermsListID()
 	{
 		return $this->get('TermsRef ListID');
 	}
-	
+
 	/**
 	 * Get the terms application ID for this invoice
-	 * 
+	 *
 	 * @return value
 	 */
 	public function getTermsApplicationID()
 	{
 		return $this->extractApplicationID($this->get('TermsRef ' . QUICKBOOKS_API_APPLICATIONID));
 	}
-	
+
 	/**
 	 * Set the due date for the invoice
-	 * 
+	 *
 	 * @param string $date
 	 * @return boolean
 	 */
@@ -528,10 +528,10 @@ class QuickBooks_QBXML_Object_Invoice extends QuickBooks_QBXML_Object
 		//return $this->set('DueDate', date('Y-m-d', strtotime($date)));
 		return $this->setDateType('DueDate', $date);
 	}
-	
+
 	/**
 	 * Get the due date for the invoice
-	 * 
+	 *
 	 * @param string $format	The format to return the date in (as for {@link http://www.php.net/date})
 	 * @return string
 	 */
@@ -540,53 +540,53 @@ class QuickBooks_QBXML_Object_Invoice extends QuickBooks_QBXML_Object
 		//return date($format, strtotime($this->get('DueDate')));
 		return $this->getDateType('DueDate', $format);
 	}
-	
+
 	public function setSalesRepName($name)
 	{
 		return $this->set('SalesRepRef FullName', $name);
 	}
-	
+
 	public function setSalesRepListID($ListID)
 	{
 		return $this->set('SalesRepRef ListID', $ListID);
 	}
-	
+
 	public function setSalesRepApplicationID($value)
 	{
 		return $this->set('SalesRepRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_EMPLOYEE, QUICKBOOKS_LISTID, $value));
 	}
-	
+
 	public function getSalesRepName()
 	{
 		return $this->get('SalesRepRef FullName');
 	}
-	
+
 	public function getSalesRepListID()
 	{
 		return $this->get('SalesRepRef ListID');
 	}
-	
+
 	public function getSalesRepApplicationID()
 	{
 		return $this->extractApplicationID($this->get('SalesRepRef ' . QUICKBOOKS_API_APPLICATIONID));
 	}
-	
+
 	public function getFOB()
 	{
 		return $this->get('FOB');
 	}
-	
+
 	public function setFOB($fob)
 	{
 		return $this->set('FOB', $fob);
 	}
-	
+
 	public function setShipDate($date)
 	{
 		//return $this->set('ShipDate', date('Y-m-d', strtotime($date)));
 		return $this->setDateType('ShipDate', $date);
 	}
-	
+
 	public function getShipDate($format = 'Y-m-d')
 	{
 		/*
@@ -594,16 +594,16 @@ class QuickBooks_QBXML_Object_Invoice extends QuickBooks_QBXML_Object
 		{
 			return date($format, strtotime($this->get('ShipDate')));
 		}
-		
+
 		return null;
 		*/
-		
+
 		return $this->getDateType('ShipDate', $format);
 	}
-	
+
 	/**
 	 * Set the application ID for the shipping method
-	 * 
+	 *
 	 * @param mixed $value		The shipping method primary key from your application
 	 * @return 					boolean
 	 */
@@ -611,40 +611,40 @@ class QuickBooks_QBXML_Object_Invoice extends QuickBooks_QBXML_Object
 	{
 		return $this->set('ShipMethodRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_SHIPMETHOD, QUICKBOOKS_LISTID, $value));
 	}
-	
+
 	public function setShipMethodName($name)
 	{
 		return $this->set('ShipMethodRef FullName', $name);
 	}
-	
+
 	public function setShipMethodListID($ListID)
 	{
 		return $this->set('ShipMethodRef ListID', $ListID);
 	}
-	
+
 	public function getShipMethodName()
 	{
 		return $this->get('ShipMethodRef FullName');
 	}
-	
+
 	public function getShipMethodListID()
 	{
 		return $this->get('ShipMethodRef ListID');
 	}
-	
+
 	/**
 	 * Get the ship method application ID
-	 * 
+	 *
 	 * @return value
 	 */
 	public function getShipMethodApplicationID()
 	{
 		return $this->extractApplicationID($this->get('ShipMethodRef ' . QUICKBOOKS_API_APPLICATIONID));
 	}
-	
+
 	/**
 	 * Set the application ID for the payment method
-	 * 
+	 *
 	 * @param mixed $value		The payment method primary key from your application
 	 * @return 					boolean
 	 */
@@ -652,42 +652,42 @@ class QuickBooks_QBXML_Object_Invoice extends QuickBooks_QBXML_Object
 	{
 		return $this->set('PaymentMethodRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_PAYMENTMETHOD, QUICKBOOKS_LISTID, $value));
 	}
-	
+
 	public function setPaymentMethodName($name)
 	{
 		return $this->set('PaymentMethodRef FullName', $name);
 	}
-	
+
 	public function setPaymentMethodListID($ListID)
 	{
 		return $this->set('PaymentMethodRef ListID', $ListID);
 	}
-	
+
 	public function getPaymentMethodName()
 	{
 		return $this->get('PaymentMethodRef FullName');
 	}
-	
+
 	public function getPaymentMethodListID()
 	{
 		return $this->get('PaymentMethodRef ListID');
 	}
-	
+
 	/**
 	 * Get the payment method application ID
-	 * 
+	 *
 	 * @return value
 	 */
 	public function getPaymentMethodApplicationID()
 	{
 		return $this->extractApplicationID($this->get('PaymentMethodRef ' . QUICKBOOKS_API_APPLICATIONID));
 	}
-	
+
 	public function setSalesTaxItemListID($ListID)
 	{
 		return $this->set('ItemSalesTaxRef ListID', $ListID);
 	}
-	
+
 	public function setSalesTaxItemApplicationID($value)
 	{
 		return $this->set('ItemSalesTaxRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_SALESTAXITEM, QUICKBOOKS_LISTID, $value));
@@ -697,7 +697,7 @@ class QuickBooks_QBXML_Object_Invoice extends QuickBooks_QBXML_Object
 	{
 		return $this->get('ItemSalesTaxRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	/**
 	 * @deprecated
 	 */
@@ -710,67 +710,67 @@ class QuickBooks_QBXML_Object_Invoice extends QuickBooks_QBXML_Object
 	{
 		return $this->set('ItemSalesTaxRef FullName', $name);
 	}
-	
+
 	public function getSalesTaxItemName()
 	{
 		return $this->get('ItemSalesTaxRef FullName');
 	}
-	
+
 	public function getSalesTaxItemListID()
 	{
 		return $this->get('ItemSalesTaxRef ListID');
 	}
-	
+
 	public function setMemo($memo)
 	{
 		return $this->set('Memo', $memo);
 	}
-	
+
 	public function getMemo()
 	{
 		return $this->get('Memo');
 	}
-	
+
 	public function setIsToBePrinted($printed)
 	{
 		return $this->setBooleanType('IsToBePrinted', $printed);
 	}
-	
+
 	public function getIsToBePrinted()
 	{
 		return $this->getBooleanType('IsToBePrinted');
 	}
-	
+
 	public function setIsToBeEmailed($emailed)
 	{
 		return $this->setBooleanType('IsToBeEmailed', $emailed);
 	}
-	
+
 	public function getIsToBeEmailed()
 	{
 		return $this->getBooleanType('IsToBeEmailed');
 	}
-	
+
 	public function setCustomerSalesTaxCodeListID()
 	{
-		
+
 	}
-	
+
 	public function setCustomerSalesTaxCodeName()
 	{
-		
+
 	}
-	
+
 	public function getCustomerSalesTaxCodeListID()
 	{
-		
+
 	}
-	
+
 	public function getCustomerSalesTaxCodeName()
 	{
-		
+
 	}
-	
+
 	public function setLinkToTxnID($TxnID)
 	{
 		return $this->set('LinkToTxnID', $TxnID);
@@ -780,78 +780,78 @@ class QuickBooks_QBXML_Object_Invoice extends QuickBooks_QBXML_Object
 	{
 		return $this->get('LinkToTxnID');
 	}
-	
+
 	/*
 	public function getInvoiceLines()
 	{
 		return $this->getList('InvoiceLine');
 	}
-	
+
 	public function getInvoiceLine($which)
 	{
 		$list = $this->getInvoiceLines();
-		
+
 		if (isset($list[$which]))
 		{
 			return $list[$which];
 		}
-		
+
 		return null;
 	}
 	*/
-	
+
 	/*
-	public function setInvoiceLine($i, 
+	public function setInvoiceLine($i,
 	{
-		
+
 	}
 	*/
-	
+
 	/**
-	 * 
-	 * 
-	 * @param 
+	 *
+	 *
+	 * @param
 	 */
 	public function addInvoiceLine($obj)
 	{
 		return $this->addListItem('InvoiceLine', $obj);
-		
+
 		/*
 		$lines = $this->get('InvoiceLine');
-		
+
 		//
 		$lines[] = $obj;
-		
+
 		return $this->set('InvoiceLine', $lines);
 		*/
 	}
-	
+
 	/*
 	public function setInvoiceLineData($i, $key, $value)
 	{
 		$lines = $this->getInvoiceLines();
 		if (isset($lines[$i]))
 		{
-			
+
 		}
-		
+
 		return $this->set('InvoiceLine', $lines);
 	}
 	*/
-	
+
 	public function getInvoiceLine($i)
 	{
 		return $this->getListItem('InvoiceLine', $i);
 	}
-	
+
 	public function listInvoiceLines()
 	{
 		return $this->getList('InvoiceLine');
 	}
-	
+
 	/**
 	 * Add a discount line (only supported by Online Edition as of 8.0)
-	 * 
+	 *
 	 * @param QuickBooks_Object_Invoice_DiscountLine
 	 * @return boolean
 	 */
@@ -862,7 +862,7 @@ class QuickBooks_QBXML_Object_Invoice extends QuickBooks_QBXML_Object
 
 	/**
 	 * Add a sales tax line (only supported by Online Edition as of 8.0)
-	 * 
+	 *
 	 * @param QuickBooks_Object_Invoice_SalesTaxLine
 	 * @return boolean
 	 */
@@ -873,7 +873,7 @@ class QuickBooks_QBXML_Object_Invoice extends QuickBooks_QBXML_Object
 
 	/**
 	 * Add a shipping line (only supported by Online Edition as of 8.0)
-	 * 
+	 *
 	 * @param QuickBooks_Object_Invoice_ShippingLine
 	 * @return boolean
 	 */
@@ -883,50 +883,39 @@ class QuickBooks_QBXML_Object_Invoice extends QuickBooks_QBXML_Object
 	}
 
 	/**
-	 * 
+	 *
 	 */
 	public function setOther($other)
 	{
 		return $this->set('Other', $other);
 	}
-	
+
 	public function getOther()
 	{
 		return $this->get('Other');
 	}
-	
+
 	public function getBalanceRemaining()
 	{
 		return $this->getAmountType('BalanceRemaining');
 	}
-	
+
 	public function setBalanceRemaining($amount)
 	{
 		return $this->setAmountType('BalanceRemaining', $amount);
-	}	
-	
+	}
+
 	public function getAppliedAmount()
 	{
 		return $this->getAmountType('AppliedAmount');
 	}
-	
-	/**
-	 * 
-	 * 
-	 * @return boolean
-	 */
-	protected function _cleanup()
-	{
-		
-		return true;
-	}
-	
+
 	public function asList($request)
 	{
 		switch ($request)
 		{
 			case 'InvoiceAddRq':
-				
+
 				if (isset($this->_object['InvoiceLine']))
 				{
 					$this->_object['InvoiceLineAdd'] = $this->_object['InvoiceLine'];
@@ -935,46 +924,46 @@ class QuickBooks_QBXML_Object_Invoice extends QuickBooks_QBXML_Object
 				if (isset($this->_object['ShippingLine']))
 				{
 					$this->_object['ShippingLineAdd'] = $this->_object['ShippingLine'];
-				}				
+				}
 
 				if (isset($this->_object['SalesTaxLine']))
 				{
 					$this->_object['SalesTaxLineAdd'] = $this->_object['SalesTaxLine'];
-				}				
+				}
 
 				if (isset($this->_object['DiscountLine']))
 				{
 					$this->_object['DiscountLineAdd'] = $this->_object['DiscountLine'];
-				}				
-				
+				}
+
 				break;
 			case 'InvoiceModRq':
-				
+
 				if (isset($this->_object['InvoiceLine']))
 				{
-					$this->_object['InvoiceLineMod'] = $this->_object['InvoiceLine'];	
+					$this->_object['InvoiceLineMod'] = $this->_object['InvoiceLine'];
 				}
-				
+
 				break;
 		}
-		
+
 		return parent::asList($request);
 	}
-	
+
 	public function asXML($root = null, $parent = null, $object = null)
 	{
 		//print('INVOICE got called asXML: ' . $root . ', ' . $parent . "\n");
 		//exit;
-		
+
 		if (is_null($object))
 		{
 			$object = $this->_object;
 		}
-		
+
 		switch ($root)
 		{
 			case QUICKBOOKS_ADD_INVOICE:
-				
+
 				//if (isset($this->_object['InvoiceLine']))
 				//{
 				//	$this->_object['InvoiceLineAdd'] = $this->_object['InvoiceLine'];
@@ -996,7 +985,7 @@ class QuickBooks_QBXML_Object_Invoice extends QuickBooks_QBXML_Object
 						$obj->setOverride('ShippingLineAdd');
 					}
 				}
-				
+
 				if (!empty($object['DiscountLineAdd']))
 				{
 					foreach ($object['DiscountLineAdd'] as $key => $obj)
@@ -1004,7 +993,7 @@ class QuickBooks_QBXML_Object_Invoice extends QuickBooks_QBXML_Object
 						$obj->setOverride('DiscountLineAdd');
 					}
 				}
-				
+
 				if (!empty($object['SalesTaxLineAdd']))
 				{
 					foreach ($object['SalesTaxLineAdd'] as $key => $obj)
@@ -1012,10 +1001,10 @@ class QuickBooks_QBXML_Object_Invoice extends QuickBooks_QBXML_Object
 						$obj->setOverride('SalesTaxLineAdd');
 					}
 				}
-				
+
 				break;
 			case QUICKBOOKS_MOD_INVOICE:
-				
+
 				/*
 				if (isset($object['InvoiceLine']))
 				{
@@ -1033,40 +1022,15 @@ class QuickBooks_QBXML_Object_Invoice extends QuickBooks_QBXML_Object
 
 				break;
 		}
-		
+
 		//print_r($this->_object);
-		
+
 		return parent::asXML($root, $parent, $object);
 	}
-	
-	/**
-	 * 
-	 */
-	public function asArray($request, $nest = true)
-	{
-		$this->_cleanup();
-		
-		return parent::asArray($request, $nest);
-	}
-	
-	/**
-	 * 
-	 * 
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QuickBooks_QBXML_Object::XML_DROP, $indent = "\t", $root = null, $parent = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
+
 	/**
 	 * Tell the type of object this is
-	 * 
+	 *
 	 * @return string
 	 */
 	public function object()

--- a/QuickBooks/QBXML/Object/Item.php
+++ b/QuickBooks/QBXML/Object/Item.php
@@ -2,37 +2,37 @@
 
 /**
  * QuickBooks object container
- * 
+ *
  * @author Keith Palmer <keith@consolibyte.com>
  * @license LICENSE.txt
- * 
+ *
  * @package QuickBooks
  * @subpackage Object
  */
 
 /**
- * 
+ *
  */
 QuickBooks_Loader::load('/QuickBooks/QBXML/Object.php');
 
 /**
- * 
+ *
  */
 class QuickBooks_QBXML_Object_Item extends QuickBooks_QBXML_Object
 {
 	/**
 	 * Create a new QuickBooks_Object_Class object
-	 * 
+	 *
 	 * @param array $arr
 	 */
 	public function __construct($arr = array())
 	{
 		parent::__construct($arr);
 	}
-	
+
 	/**
 	 * Set the ListID of the Class
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return boolean
 	 */
@@ -40,10 +40,10 @@ class QuickBooks_QBXML_Object_Item extends QuickBooks_QBXML_Object
 	{
 		return $this->set('ListID', $ListID);
 	}
-	
+
 	/**
 	 * Get the ListID of the Class
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getListID()
@@ -52,12 +52,12 @@ class QuickBooks_QBXML_Object_Item extends QuickBooks_QBXML_Object
 	}
 
 
-  /** 
+  /**
    * Set the name of this customer
-   * 
-   * NOTE: This will be auto-set to ->getFirstName() ->getLastName() if you 
+   *
+   * NOTE: This will be auto-set to ->getFirstName() ->getLastName() if you
    * don't set it explicitly.
-   * 
+   *
    * @param string $name
    * @return boolean
    */
@@ -66,43 +66,43 @@ class QuickBooks_QBXML_Object_Item extends QuickBooks_QBXML_Object
     return $this->set('Name', $name);
   }
 
-  /**                                                         
-   * Sets the name as first and last.                         
-   *                                                          
-   * @return boolean                                          
-   */     
-  public function setNameAsFirstLast() {     
-    $first = $this->getFirstName();     
-    $last = $this->getLastName();     
-    if (is_null($first)) { $first = ''; }     
-    if (is_null($last)) { $last = ''; }     
-     
-    return $this->set('Name', $first .' '. $last);     
+  /**
+   * Sets the name as first and last.
+   *
+   * @return boolean
+   */
+  public function setNameAsFirstLast() {
+    $first = $this->getFirstName();
+    $last = $this->getLastName();
+    if (is_null($first)) { $first = ''; }
+    if (is_null($last)) { $last = ''; }
+
+    return $this->set('Name', $first .' '. $last);
   }
 
   /**
    * Get the name of this customer
-   * 
+   *
    * @return string
    */
   public function getName()
   {
     if (!$this->exists('Name'))
-    { 
+    {
       if (!is_null($this->getFirstName()) || !is_null($this->getLastName())) {
         $this->setNameAsFirstLast();
-      } 
-    } 
+      }
+    }
 
     return $this->get('Name');
   }
 
   /**
    * Set the full name of this customer (full name)
-   * 
-   * NOTE: This will be auto-set to ->getName() if you don't set it 
+   *
+   * NOTE: This will be auto-set to ->getName() if you don't set it
    * explicitly.
-   * 
+   *
    * @param string $name
    * @return boolean
    */
@@ -117,7 +117,7 @@ class QuickBooks_QBXML_Object_Item extends QuickBooks_QBXML_Object
 
   /**
    * Get the name of this customer (full name)
-   * 
+   *
    * @return string
    */
   public function getFullName()
@@ -132,7 +132,7 @@ class QuickBooks_QBXML_Object_Item extends QuickBooks_QBXML_Object
 
   /**
    * Set the first name of this customer
-   * 
+   *
    * @param string $name
    * @return boolean
    */
@@ -143,7 +143,7 @@ class QuickBooks_QBXML_Object_Item extends QuickBooks_QBXML_Object
 
   /**
    * Get the first name of this customer
-   * 
+   *
    * @return string
    */
   public function getFirstName()
@@ -153,7 +153,7 @@ class QuickBooks_QBXML_Object_Item extends QuickBooks_QBXML_Object
 
   /**
    * Set the last name of this customer
-   * 
+   *
    * @param string $lname
    * @return boolean
    */
@@ -164,7 +164,7 @@ class QuickBooks_QBXML_Object_Item extends QuickBooks_QBXML_Object
 
   /**
    * Get the last name of this customer
-   * 
+   *
    * @return string
    */
   public function getLastName()
@@ -178,67 +178,27 @@ class QuickBooks_QBXML_Object_Item extends QuickBooks_QBXML_Object
 
 	public function getFromModifiedDate()
 	{
-		
+
 	}
-	
+
 	public function setFromModifiedDate($date)
 	{
-		
+
 	}
-	
+
 	public function getToModifiedDate()
 	{
-		
+
 	}
-	
+
 	public function setToModifiedDate($date)
 	{
-		
+
 	}
-	
+
 	/**
-	 * Perform any needed clean-up of the object data members
-	 * 
-	 * @return boolean
-	 */
-	protected function _cleanup()
-	{
-		return true;
-	}
-	
-	/**
-	 * Get an array representation of this Class object
-	 * 
-	 * @param string $request
-	 * @param boolean $nest
-	 * @return array
-	 */
-	public function asArray($request, $nest = true)
-	{
-		$this->_cleanup();
-		
-		return parent::asArray($request, $nest);
-	}
-	
-	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $version = null, $locale = null, $root = null)
-  {
-    $this->_cleanup();
-    
-    return parent::asQBXML($request, $version, $locale, $root);
-  }
-	
-	/**
-	 * Tell what type of object this is 
-	 * 
+	 * Tell what type of object this is
+	 *
 	 * @return string
 	 */
 	public function object()

--- a/QuickBooks/QBXML/Object/ItemReceipt.php
+++ b/QuickBooks/QBXML/Object/ItemReceipt.php
@@ -228,7 +228,7 @@ class QuickBooks_QBXML_Object_ItemReceipt extends QuickBooks_QBXML_Object
 	{
 		return $this->addListItem('ItemGroupLine', $obj);
 	}
-	
+
 	public function addExpenseLine($obj)
 	{
 		return $this->addListItem('ExpenseLine', $obj);
@@ -269,7 +269,7 @@ class QuickBooks_QBXML_Object_ItemReceipt extends QuickBooks_QBXML_Object
 	{
 		return $this->getList('ItemLine');
 	}
-	
+
 	/**
 	 * Gets the ItemGroupLine at @param $i
 	 *
@@ -286,16 +286,6 @@ class QuickBooks_QBXML_Object_ItemReceipt extends QuickBooks_QBXML_Object
 	public function getItemGroupLines()
 	{
 		return $this->getList('ItemGroupLine');
-	}
-
-	/**
-	 *
-	 *
-	 * @return boolean
-	 */
-	protected function _cleanup()
-	{
-		return true;
 	}
 
 	public function asList($request)
@@ -351,23 +341,13 @@ class QuickBooks_QBXML_Object_ItemReceipt extends QuickBooks_QBXML_Object
 		return parent::asList($request);
 	}
 
-	/**
-	 *
-	 */
-	public function asArray($request, $nest = true)
-	{
-		$this->_cleanup();
-
-		return parent::asArray($request, $nest);
-	}
-
 	public function asXML($root = null, $parent = null, $object = null)
 	{
 		if (is_null($object))
 		{
 			$object = $this->_object;
 		}
-		
+
 		switch ($root)
 		{
 			case QUICKBOOKS_ADD_ITEMRECEIPT:
@@ -445,21 +425,6 @@ class QuickBooks_QBXML_Object_ItemReceipt extends QuickBooks_QBXML_Object
 		}
 
 		return parent::asXML($root, $parent, $object);
-	}
-	/**
-	 * Convert this object to a valid qbXML request
-	 *
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
 	}
 
 	/**

--- a/QuickBooks/QBXML/Object/NonInventoryItem.php
+++ b/QuickBooks/QBXML/Object/NonInventoryItem.php
@@ -2,49 +2,49 @@
 
 /**
  * QuickBooks NonInventoryItem object container
- * 
- * NOTE: By default, NonInventoryItems are created as SalesOrPurchase items, and are 
- * thus *NOT* created as SalesAndPurchase items. If you want to create an item 
+ *
+ * NOTE: By default, NonInventoryItems are created as SalesOrPurchase items, and are
+ * thus *NOT* created as SalesAndPurchase items. If you want to create an item
  * that is sold *and* purchased, you'll need to set the type with the method:
  * 	-> {@link QuickBooks_Object_NonInventoryItem::isSalesAndPurchase()}
- * 
+ *
  * @todo Verify the get/set methods on this one... it was copied from ServiceItem
  * @todo Add isActive(), getIsActive(), etc. methods
- * 
+ *
  * @author Keith Palmer <keith@consolibyte.com>
- * @license LICENSE.txt 
- * 
+ * @license LICENSE.txt
+ *
  * @package QuickBooks
  * @subpackage Object
  */
 
 /**
- * 
+ *
  */
 QuickBooks_Loader::load('/QuickBooks/QBXML/Object.php');
 
 /**
- * 
+ *
  */
 class QuickBooks_QBXML_Object_NonInventoryItem extends QuickBooks_QBXML_Object
 {
 	protected $_is_sales_and_purchase;
-	
+
 	public function __construct($arr = array(), $is_sales_and_purchase = false)
 	{
 		parent::__construct($arr);
-		
+
 		if (count($this->getArray('SalesAndPurchase')) > 0)
 		{
 			$is_sales_and_purchase = true;
 		}
-		
+
 		$this->_is_sales_and_purchase = $is_sales_and_purchase;
 	}
-	
+
 	/**
 	 * Set the ListID for this item
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return boolean
 	 */
@@ -52,20 +52,20 @@ class QuickBooks_QBXML_Object_NonInventoryItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('ListID', $ListID);
 	}
-	
+
 	/**
 	 * Get the ListID for this item
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getListID()
 	{
 		return $this->get('ListID');
 	}
-	
+
 	/**
 	 * Set the name for this item
-	 * 
+	 *
 	 * @param string $name
 	 * @return boolean
 	 */
@@ -73,10 +73,10 @@ class QuickBooks_QBXML_Object_NonInventoryItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('Name', $name);
 	}
-	
+
 	/**
 	 * Get the name for this item
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getName()
@@ -88,53 +88,53 @@ class QuickBooks_QBXML_Object_NonInventoryItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('UnitOfMeasureSetRef ListID');
 	}
-	
+
 	public function getUnitOfMeasureSetFullName()
 	{
 		return $this->get('UnitOfMeasureSetRef FullName');
 	}
-	
+
 	/**
 	 * Tell (and optionally set) whether or not this item is currently for Sale *and* Purchase
-	 * 
+	 *
 	 * @param boolean $enable
 	 * @return boolean
 	 */
 	public function isSalesAndPurchase($enable = null)
 	{
 		$current = $this->_is_sales_and_purchase;
-		
+
 		if (!is_null($enable))
 		{
 			$this->_is_sales_and_purchase = (boolean) $enable;
 		}
-		
+
 		return $current;
 	}
-	
+
 	/**
 	 * Tell (and optionall set) whether or not this item is currently for Sale *or* Purchase
-	 * 
+	 *
 	 * @param boolean $enable
 	 * @return boolean
 	 */
 	public function isSalesOrPurchase($enable = null)
 	{
 		$current = !$this->_is_sales_and_purchase;
-		
+
 		if (!is_null($enable))
 		{
 			$this->_is_sales_and_purchase = ! (boolean) $enable;
-		} 
-		
+		}
+
 		return $current;
 	}
-	
+
 	// Sales OR Purchase
-	
+
 	/**
 	 * Set the description of this item (Sales OR Purchase)
-	 * 
+	 *
 	 * @param string $descrip
 	 * @return boolean
 	 */
@@ -147,20 +147,20 @@ class QuickBooks_QBXML_Object_NonInventoryItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('SalesOrPurchase Desc');
 	}
-	
+
 	/**
 	 * Set the price for this item (Sales OR Purchase)
-	 * 
+	 *
 	 * @param string $price
 	 * @return boolean
 	 */
 	public function setPrice($price)
 	{
 		$this->remove('SalesOrPurchase PricePercent');
-		
+
 		return $this->set('SalesOrPurchase Price', sprintf('%01.2f', (float) $price));
 	}
-	
+
 	/**
 	 * Get the price for this item (Sales OR Purchase)
 	 */
@@ -168,17 +168,17 @@ class QuickBooks_QBXML_Object_NonInventoryItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('SalesOrPurchase Price');
 	}
-	
+
 	/**
 	 * Set the price percent for this item (Sales OR Purchase)
 	 */
 	public function setPricePercent($percent)
 	{
 		$this->remove('SalesOrPurchase Price');
-		
+
 		return $this->set('SalesOrPurchase PricePercent', (float) $percent);
 	}
-	
+
 	/**
 	 * Get the price percent for this item (Sales OR Purchase)
 	 */
@@ -186,10 +186,10 @@ class QuickBooks_QBXML_Object_NonInventoryItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('SalesOrPurchase PricePercent');
 	}
-	
+
 	/**
 	 * Set the account ListID for this item (Sales OR Purchase)
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return string
 	 */
@@ -197,7 +197,7 @@ class QuickBooks_QBXML_Object_NonInventoryItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('SalesOrPurchase AccountRef ListID', $ListID);
 	}
-	
+
 	/**
 	 * (Sales OR Purchase)
 	 */
@@ -205,7 +205,7 @@ class QuickBooks_QBXML_Object_NonInventoryItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('SalesOrPurchase AccountRef FullName', $name);
 	}
-	
+
 	/**
 	 * (Sales OR Purchase)
 	 */
@@ -218,7 +218,7 @@ class QuickBooks_QBXML_Object_NonInventoryItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('SalesOrPurchase AccountRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	/**
 	 * (Sales OR Purchase)
 	 */
@@ -226,7 +226,7 @@ class QuickBooks_QBXML_Object_NonInventoryItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('SalesOrPurchase AccountRef ListID');
 	}
-	
+
 	/**
 	 * (Sales OR Purchase)
 	 */
@@ -234,49 +234,49 @@ class QuickBooks_QBXML_Object_NonInventoryItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('SalesOrPurchase AccountRef FullName');
 	}
-	
+
 	// Sales AND Purchase
-	
+
 	public function setSalesDescription($descrip)
 	{
 		return $this->set('SalesAndPurchase SalesDesc', $descrip);
 	}
-	
+
 	public function getSalesDescription()
 	{
 		return $this->get('SalesAndPurchase SalesDesc');
 	}
-	
+
 	public function setSalesPrice($price)
 	{
 		return $this->set('SalesAndPurchase SalesPrice', sprintf('%01.2f', (float) $price));
 	}
-	
+
 	public function getSalesPrice()
 	{
 		return $this->get('SalesAndPurchase SalesPrice');
 	}
-	
+
 	public function setIncomeAccountListID($ListID)
 	{
 		return $this->set('SalesAndPurchase IncomeAccountRef ListID', $ListID);
 	}
-	
+
 	public function getIncomeAccountListID()
 	{
 		return $this->get('SalesAndPurchase IncomeAccountRef ListID');
 	}
-	
+
 	public function setIncomeAccountName($name)
 	{
 		return $this->set('SalesAndPurchase IncomeAccountRef FullName', $name);
 	}
-	
+
 	public function getIncomeAccountName()
 	{
 		return $this->get('SalesAndPurchase IncomeAccountRef FullName');
 	}
-	
+
 	public function setIncomeAccountApplicationID($value)
 	{
 		return $this->set('SalesAndPurchase IncomeAccountRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_ACCOUNT, QUICKBOOKS_LISTID, $value));
@@ -286,37 +286,37 @@ class QuickBooks_QBXML_Object_NonInventoryItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('SalesAndPurchase IncomeAccountRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function setPurchaseDescription($descrip)
 	{
 		return $this->set('SalesAndPurchase PurchaseDesc', $descrip);
 	}
-	
+
 	public function getPurchaseDescription()
 	{
 		return $this->get('SalesAndPurchase PurchaseDesc');
 	}
-	
+
 	public function setPurchaseCost($cost)
 	{
 		return $this->set('SalesAndPurchase PurchaseCost', sprintf('%01.2f', (float) $cost));
 	}
-	
+
 	public function getPurchaseCost()
 	{
 		return $this->get('SalesAndPurchase PurchaseCost');
 	}
-	
+
 	public function setExpenseAccountListID($ListID)
 	{
 		return $this->set('SalesAndPurchase ExpenseAccountRef ListID', $ListID);
 	}
-	
+
 	public function setExpenseAccountName($name)
 	{
 		return $this->set('SalesAndPurchase ExpenseAccountRef FullName', $name);
 	}
-	
+
 	public function setExpenseAccountApplicationID($value)
 	{
 		return $this->set('SalesAndPurchase ExpenseAccountRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_ACCOUNT, QUICKBOOKS_LISTID, $value));
@@ -326,27 +326,27 @@ class QuickBooks_QBXML_Object_NonInventoryItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('SalesAndPurchase ExpenseAccountRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function getExpenseAccountListID()
 	{
 		return $this->get('SalesAndPurchase ExpenseAccountRef ListID');
 	}
-	
+
 	public function getExpenseAccountName()
 	{
 		return $this->get('SalesAndPurchase ExpenseAccountRef FullName');
 	}
-	
+
 	public function setPreferredVendorListID($ListID)
 	{
 		return $this->set('SalesAndPurchase PrefVendorRef ListID', $ListID);
 	}
-	
+
 	public function setPreferredVendorName($name)
 	{
 		return $this->set('SalesAndPurchase PrefVendorRef FullName', $name);
 	}
-	
+
 	public function setPreferredVendorApplicationID($value)
 	{
 		return $this->set('SalesAndPurchase PrefVendorRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_VENDOR, QUICKBOOKS_LISTID, $value));
@@ -356,20 +356,20 @@ class QuickBooks_QBXML_Object_NonInventoryItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('SalesAndPurchase PrefVendorRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function getPreferredVendorListID()
 	{
 		return $this->get('SalesAndPurchase PrefVendorRef ListID');
 	}
-	
+
 	public function getPreferredVendorName()
 	{
 		return $this->get('SalesAndPurchase PrefVendorRef FullName');
 	}
-	
+
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 * @return boolean
 	 */
 	protected function _cleanup()
@@ -377,7 +377,7 @@ class QuickBooks_QBXML_Object_NonInventoryItem extends QuickBooks_QBXML_Object
 		if ($this->isSalesAndPurchase())
 		{
 			// Remove any SalesOrPurchase keys
-			
+
 			foreach ($this->getArray('SalesOrPurchase*') as $key => $value)
 			{
 				$this->remove($key);
@@ -390,39 +390,23 @@ class QuickBooks_QBXML_Object_NonInventoryItem extends QuickBooks_QBXML_Object
 				$this->remove($key);
 			}
 		}
-		
+
 		return true;
 	}
-	
+
 	/**
-	 * 
+	 *
 	 */
 	public function asArray($request, $nest = true)
 	{
 		$this->_cleanup();
-		
+
 		return parent::asArray($request, $nest);
 	}
-	
+
 	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $version = null, $locale = null, $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $version, $locale, $root);
-	}
-	
-	/**
-	 * Tell what type of object this is 
-	 * 
+	 * Tell what type of object this is
+	 *
 	 * @return string
 	 */
 	public function object()

--- a/QuickBooks/QBXML/Object/OtherChargeItem.php
+++ b/QuickBooks/QBXML/Object/OtherChargeItem.php
@@ -2,10 +2,10 @@
 
 /**
  * QuickBooks OtherChargeItem object container
- * 
+ *
  * @author Keith Palmer <keith@consolibyte.com>
- * @license LICENSE.txt 
- * 
+ * @license LICENSE.txt
+ *
  * @package QuickBooks
  * @subpackage Object
  */
@@ -16,7 +16,7 @@
 QuickBooks_Loader::load('/QuickBooks/QBXML/Object.php');
 
 /**
- * QuickBooks ServiceItem object 
+ * QuickBooks ServiceItem object
  */
 class QuickBooks_QBXML_Object_OtherChargeItem extends QuickBooks_QBXML_Object
 {
@@ -24,25 +24,25 @@ class QuickBooks_QBXML_Object_OtherChargeItem extends QuickBooks_QBXML_Object
 	 * Flag indicating whether or not this for sales *AND* purchase, or just sales *OR* purchase
 	 */
 	protected $_is_sales_and_purchase;
-	
+
 	/**
 	 * Create a new QuickBooks_Object_ServiceItem object (ServiceItem)
 	 */
 	public function __construct($arr = array(), $is_sales_and_purchase = false)
 	{
 		parent::__construct($arr);
-		
+
 		if (count($this->getArray('SalesAndPurchase')) > 0)
 		{
 			$is_sales_and_purchase = true;
 		}
-		
+
 		$this->_is_sales_and_purchase = $is_sales_and_purchase;
 	}
-	
+
 	/**
 	 * Set the ListID for this item
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return boolean
 	 */
@@ -50,20 +50,20 @@ class QuickBooks_QBXML_Object_OtherChargeItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('ListID', $ListID);
 	}
-	
+
 	/**
 	 * Get the ListID for this item
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getListID()
 	{
 		return $this->get('ListID');
 	}
-	
+
 	/**
 	 * Set the name for this item
-	 * 
+	 *
 	 * @param string $name
 	 * @return boolean
 	 */
@@ -71,137 +71,137 @@ class QuickBooks_QBXML_Object_OtherChargeItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('Name', $name);
 	}
-	
+
 	/**
 	 * Get the name for this item
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getName()
 	{
 		return $this->get('Name');
 	}
-	
+
 	public function setIsActive($active)
 	{
-		if (strtolower($active) == 'true' or 
+		if (strtolower($active) == 'true' or
 			(is_bool($active) and $active))
 		{
 			return $this->set('IsActive', 'true');
 		}
-		
+
 		return $this->set('IsActive', 'false');
 	}
-	
+
 	public function getIsActive()
 	{
 		$active = $this->get('IsActive');
-		
-		return strtolower($active) == 'true' or 
+
+		return strtolower($active) == 'true' or
 			(is_bool($active) and $active);
 	}
-	
+
 	public function setParentListID($ListID)
 	{
 		return $this->set('ParentRef ListID', $ListID);
 	}
-	
+
 	public function setParentName($name)
 	{
 		return $this->set('ParentRef FullName', $name);
 	}
-	
+
 	public function setParentApplicationID($value)
 	{
 		return $this->set('ParentRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_ITEM, QUICKBOOKS_LISTID, $value));
 	}
-	
+
 	public function getParentListID()
 	{
-		return $this->get('ParentRef ListID');	
+		return $this->get('ParentRef ListID');
 	}
-	
+
 	public function getParentName()
 	{
 		return $this->get('ParentRef FullName');
 	}
-	
+
 	public function getParentApplicationID()
 	{
 		return $this->extractApplicationID($this->get('ParentRef ' . QUICKBOOKS_API_APPLICATIONID));
 	}
-	
+
 	public function setSalesTaxCodeListID($ListID)
 	{
 		return $this->set('SalesTaxCodeRef ListID', $ListID);
 	}
-	
+
 	public function setSalesTaxCodeName($name)
 	{
 		return $this->set('SalesTaxCodeRef FullName', $name);
 	}
-	
+
 	public function setSalesTaxCodeApplicationID($value)
 	{
 		return $this->set('SalesTaxCodeRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_SALESTAXCODE, QUICKBOOKS_LISTID, $value));
 	}
-	
+
 	public function getSalesTaxCodeListID()
 	{
 		return $this->get('SalesTaxCodeRef ListID');
 	}
-	
+
 	public function getSalesTaxCodeName()
 	{
 		return $this->get('SalesTaxCodeRef FullName');
 	}
-	
+
 	public function getSalesTaxCodeApplicationID()
 	{
 		return $this->extractApplicationID($this->get('SalesTaxCodeRef ' . QUICKBOOKS_API_APPLICATIONID));
 	}
-	
+
 	/**
 	 * Tell (and optionally set) whether or not this item is currently for Sale *and* Purchase
-	 * 
+	 *
 	 * @param boolean $enable
 	 * @return boolean
 	 */
 	public function isSalesAndPurchase($enable = null)
 	{
 		$current = $this->_is_sales_and_purchase;
-		
+
 		if (!is_null($enable))
 		{
 			$this->_is_sales_and_purchase = (boolean) $enable;
 		}
-		
+
 		return $current;
 	}
-	
+
 	/**
 	 * Tell (and optionall set) whether or not this item is currently for Sale *or* Purchase
-	 * 
+	 *
 	 * @param boolean $enable
 	 * @return boolean
 	 */
 	public function isSalesOrPurchase($enable = null)
 	{
 		$current = !$this->_is_sales_and_purchase;
-		
+
 		if (!is_null($enable))
 		{
 			$this->_is_sales_and_purchase = ! (boolean) $enable;
-		} 
-		
+		}
+
 		return $current;
 	}
-	
+
 	// Sales OR Purchase
-	
+
 	/**
 	 * Set the description of this item (Sales OR Purchase)
-	 * 
+	 *
 	 * @param string $descrip
 	 * @return boolean
 	 */
@@ -214,20 +214,20 @@ class QuickBooks_QBXML_Object_OtherChargeItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('SalesOrPurchase Desc');
 	}
-	
+
 	/**
 	 * Set the price for this item (Sales OR Purchase)
-	 * 
+	 *
 	 * @param string $price
 	 * @return boolean
 	 */
 	public function setPrice($price)
 	{
 		$this->remove('SalesOrPurchase PricePercent');
-		
+
 		return $this->set('SalesOrPurchase Price', (float) $price);
 	}
-	
+
 	/**
 	 * Get the price for this item (Sales OR Purchase)
 	 */
@@ -235,30 +235,30 @@ class QuickBooks_QBXML_Object_OtherChargeItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('SalesOrPurchase Price');
 	}
-	
+
 	/**
 	 * Set the price percent for this item (Sales OR Purchase)
 	 */
 	public function setPricePercent($percent)
 	{
 		$this->remove('SalesOrPurchase Price');
-		
+
 		return $this->set('SalesOrPurchase PricePercent', $percent);
 	}
-	
+
 	/**
 	 * Get the price percent for this item (Sales OR Purchase)
-	 * 
+	 *
 	 * @return float
 	 */
 	public function getPricePercent()
 	{
 		return $this->get('SalesOrPurchase PricePercent');
 	}
-	
+
 	/**
 	 * Set the account ListID for this item (Sales OR Purchase)
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return boolean
 	 */
@@ -266,10 +266,10 @@ class QuickBooks_QBXML_Object_OtherChargeItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('SalesOrPurchase AccountRef ListID', $ListID);
 	}
-	
+
 	/**
 	 * Set the account name for this item (Sales OR Purchase)
-	 * 
+	 *
 	 * @param string $name
 	 * @return boolean
 	 */
@@ -277,7 +277,7 @@ class QuickBooks_QBXML_Object_OtherChargeItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('SalesOrPurchase AccountRef FullName', $name);
 	}
-	
+
 	/**
 	 * (Sales OR Purchase)
 	 */
@@ -290,69 +290,69 @@ class QuickBooks_QBXML_Object_OtherChargeItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('SalesOrPurchase AccountRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	/**
 	 * Get the account ListID for this item (Sales OR Purchase)
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getAccountListID()
 	{
 		return $this->get('SalesOrPurchase AccountRef ListID');
 	}
-	
+
 	/**
 	 * Get the account name for this item (Sales OR Purchase)
-	 * 
-	 * @return string 
+	 *
+	 * @return string
 	 */
 	public function getAccountName()
 	{
 		return $this->get('SalesOrPurchase AccountRef FullName');
 	}
-	
+
 	// Sales AND Purchase
-	
+
 	public function setSalesDescription($descrip)
 	{
 		return $this->set('SalesAndPurchase SalesDesc', $descrip);
 	}
-	
+
 	public function getSalesDescription()
 	{
 		return $this->get('SalesAndPurchase SalesDesc');
 	}
-	
+
 	public function setSalesPrice($price)
 	{
 		return $this->set('SalesAndPurchase SalesPrice', (float) $price);
 	}
-	
+
 	public function getSalesPrice()
 	{
 		return $this->get('SalesAndPurchase SalesPrice');
 	}
-	
+
 	public function setIncomeAccountListID($ListID)
 	{
 		return $this->set('SalesAndPurchase IncomeAccountRef ListID', $ListID);
 	}
-	
+
 	public function getIncomeAccountListID()
 	{
 		return $this->get('SalesAndPurchase IncomeAccountRef ListID');
 	}
-	
+
 	public function setIncomeAccountName($name)
 	{
 		return $this->set('SalesAndPurchase IncomeAccountRef FullName', $name);
 	}
-	
+
 	public function getIncomeAccountName()
 	{
 		return $this->get('SalesAndPurchase IncomeAccountRef FullName');
 	}
-	
+
 	public function setIncomeAccountApplicationID($value)
 	{
 		return $this->set('SalesAndPurchase IncomeAccountRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_ACCOUNT, QUICKBOOKS_LISTID, $value));
@@ -362,37 +362,37 @@ class QuickBooks_QBXML_Object_OtherChargeItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('SalesAndPurchase IncomeAccountRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function setPurchaseDescription($descrip)
 	{
 		return $this->set('SalesAndPurchase PurchaseDesc', $descrip);
 	}
-	
+
 	public function getPurchaseDescription()
 	{
 		return $this->get('SalesAndPurchase PurchaseDesc');
 	}
-	
+
 	public function setPurchaseCost($cost)
 	{
 		return $this->set('SalesAndPurchase PurchaseCost', (int) $cost);
 	}
-	
+
 	public function getPurchaseCost()
 	{
 		return $this->get('SalesAndPurchase PurchaseCost');
 	}
-	
+
 	public function setExpenseAccountListID($ListID)
 	{
 		return $this->set('SalesAndPurchase ExpenseAccountRef ListID', $ListID);
 	}
-	
+
 	public function setExpenseAccountName($name)
 	{
 		return $this->set('SalesAndPurchase ExpenseAccountRef FullName', $name);
 	}
-	
+
 	public function setExpenseAccountApplicationID($value)
 	{
 		return $this->set('SalesAndPurchase ExpenseAccountRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_ACCOUNT, QUICKBOOKS_LISTID, $value));
@@ -402,27 +402,27 @@ class QuickBooks_QBXML_Object_OtherChargeItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('SalesAndPurchase ExpenseAccountRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function getExpenseAccountListID()
 	{
 		return $this->get('SalesAndPurchase ExpenseAccountRef ListID');
 	}
-	
+
 	public function getExpenseAccountName()
 	{
 		return $this->get('SalesAndPurchase ExpenseAccountRef FullName');
 	}
-	
+
 	public function setPreferredVendorListID($ListID)
 	{
 		return $this->set('SalesAndPurchase PrefVendorRef ListID', $ListID);
 	}
-	
+
 	public function setPreferredVendorName($name)
 	{
 		return $this->set('SalesAndPurchase PrefVendorRef FullName', $name);
 	}
-	
+
 	public function setPreferredVendorApplicationID($value)
 	{
 		return $this->set('SalesAndPurchase PrefVendorRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_VENDOR, QUICKBOOKS_LISTID, $value));
@@ -432,20 +432,20 @@ class QuickBooks_QBXML_Object_OtherChargeItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('SalesAndPurchase PrefVendorRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function getPreferredVendorListID()
 	{
 		return $this->get('SalesAndPurchase PrefVendorRef ListID');
 	}
-	
+
 	public function getPreferredVendorName()
 	{
 		return $this->get('SalesAndPurchase PrefVendorRef FullName');
 	}
-	
+
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 * @return boolean
 	 */
 	protected function _cleanup()
@@ -453,7 +453,7 @@ class QuickBooks_QBXML_Object_OtherChargeItem extends QuickBooks_QBXML_Object
 		if ($this->isSalesAndPurchase())
 		{
 			// Remove any SalesOrPurchase keys
-			
+
 			foreach ($this->getArray('SalesOrPurchase*') as $key => $value)
 			{
 				$this->remove($key);
@@ -466,39 +466,23 @@ class QuickBooks_QBXML_Object_OtherChargeItem extends QuickBooks_QBXML_Object
 				$this->remove($key);
 			}
 		}
-		
+
 		return true;
 	}
-	
+
 	/**
-	 * 
+	 *
 	 */
 	public function asArray($request, $nest = true)
 	{
 		$this->_cleanup();
-		
+
 		return parent::asArray($request, $nest);
 	}
-	
+
 	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
-	 * Tell what type of object this is 
-	 * 
+	 * Tell what type of object this is
+	 *
 	 * @return string
 	 */
 	public function object()

--- a/QuickBooks/QBXML/Object/PaymentItem.php
+++ b/QuickBooks/QBXML/Object/PaymentItem.php
@@ -2,12 +2,12 @@
 
 /**
  * QuickBooks OtherChargeItem object container
- * 
+ *
  * @todo FIX THIS FIX THIS FIX THIS!
- * 
+ *
  * @author Keith Palmer <keith@consolibyte.com>
- * @license LICENSE.txt 
- * 
+ * @license LICENSE.txt
+ *
  * @package QuickBooks
  * @subpackage Object
  */
@@ -18,7 +18,7 @@
 QuickBooks_Loader::load('/QuickBooks/QBXML/Object.php');
 
 /**
- * QuickBooks ServiceItem object 
+ * QuickBooks ServiceItem object
  */
 class QuickBooks_QBXML_Object_PaymentItem extends QuickBooks_QBXML_Object
 {
@@ -26,25 +26,25 @@ class QuickBooks_QBXML_Object_PaymentItem extends QuickBooks_QBXML_Object
 	 * Flag indicating whether or not this for sales *AND* purchase, or just sales *OR* purchase
 	 */
 	protected $_is_sales_and_purchase;
-	
+
 	/**
 	 * Create a new QuickBooks_Object_ServiceItem object (ServiceItem)
 	 */
 	public function __construct($arr = array(), $is_sales_and_purchase = false)
 	{
 		parent::__construct($arr);
-		
+
 		if (count($this->getArray('SalesAndPurchase')) > 0)
 		{
 			$is_sales_and_purchase = true;
 		}
-		
+
 		$this->_is_sales_and_purchase = $is_sales_and_purchase;
 	}
-	
+
 	/**
 	 * Set the ListID for this item
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return boolean
 	 */
@@ -52,20 +52,20 @@ class QuickBooks_QBXML_Object_PaymentItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('ListID', $ListID);
 	}
-	
+
 	/**
 	 * Get the ListID for this item
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getListID()
 	{
 		return $this->get('ListID');
 	}
-	
+
 	/**
 	 * Set the name for this item
-	 * 
+	 *
 	 * @param string $name
 	 * @return boolean
 	 */
@@ -73,137 +73,137 @@ class QuickBooks_QBXML_Object_PaymentItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('Name', $name);
 	}
-	
+
 	/**
 	 * Get the name for this item
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getName()
 	{
 		return $this->get('Name');
 	}
-	
+
 	public function setIsActive($active)
 	{
-		if (strtolower($active) == 'true' or 
+		if (strtolower($active) == 'true' or
 			(is_bool($active) and $active))
 		{
 			return $this->set('IsActive', 'true');
 		}
-		
+
 		return $this->set('IsActive', 'false');
 	}
-	
+
 	public function getIsActive()
 	{
 		$active = $this->get('IsActive');
-		
-		return strtolower($active) == 'true' or 
+
+		return strtolower($active) == 'true' or
 			(is_bool($active) and $active);
 	}
-	
+
 	public function setParentListID($ListID)
 	{
 		return $this->set('ParentRef ListID', $ListID);
 	}
-	
+
 	public function setParentName($name)
 	{
 		return $this->set('ParentRef FullName', $name);
 	}
-	
+
 	public function setParentApplicationID($value)
 	{
 		return $this->set('ParentRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_ITEM, QUICKBOOKS_LISTID, $value));
 	}
-	
+
 	public function getParentListID()
 	{
-		return $this->get('ParentRef ListID');	
+		return $this->get('ParentRef ListID');
 	}
-	
+
 	public function getParentName()
 	{
 		return $this->get('ParentRef FullName');
 	}
-	
+
 	public function getParentApplicationID()
 	{
 		return $this->extractApplicationID($this->get('ParentRef ' . QUICKBOOKS_API_APPLICATIONID));
 	}
-	
+
 	public function setSalesTaxCodeListID($ListID)
 	{
 		return $this->set('SalesTaxCodeRef ListID', $ListID);
 	}
-	
+
 	public function setSalesTaxCodeName($name)
 	{
 		return $this->set('SalesTaxCodeRef FullName', $name);
 	}
-	
+
 	public function setSalesTaxCodeApplicationID($value)
 	{
 		return $this->set('SalesTaxCodeRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_SALESTAXCODE, QUICKBOOKS_LISTID, $value));
 	}
-	
+
 	public function getSalesTaxCodeListID()
 	{
 		return $this->get('SalesTaxCodeRef ListID');
 	}
-	
+
 	public function getSalesTaxCodeName()
 	{
 		return $this->get('SalesTaxCodeRef FullName');
 	}
-	
+
 	public function getSalesTaxCodeApplicationID()
 	{
 		return $this->extractApplicationID($this->get('SalesTaxCodeRef ' . QUICKBOOKS_API_APPLICATIONID));
 	}
-	
+
 	/**
 	 * Tell (and optionally set) whether or not this item is currently for Sale *and* Purchase
-	 * 
+	 *
 	 * @param boolean $enable
 	 * @return boolean
 	 */
 	public function isSalesAndPurchase($enable = null)
 	{
 		$current = $this->_is_sales_and_purchase;
-		
+
 		if (!is_null($enable))
 		{
 			$this->_is_sales_and_purchase = (boolean) $enable;
 		}
-		
+
 		return $current;
 	}
-	
+
 	/**
 	 * Tell (and optionall set) whether or not this item is currently for Sale *or* Purchase
-	 * 
+	 *
 	 * @param boolean $enable
 	 * @return boolean
 	 */
 	public function isSalesOrPurchase($enable = null)
 	{
 		$current = !$this->_is_sales_and_purchase;
-		
+
 		if (!is_null($enable))
 		{
 			$this->_is_sales_and_purchase = ! (boolean) $enable;
-		} 
-		
+		}
+
 		return $current;
 	}
-	
+
 	// Sales OR Purchase
-	
+
 	/**
 	 * Set the description of this item (Sales OR Purchase)
-	 * 
+	 *
 	 * @param string $descrip
 	 * @return boolean
 	 */
@@ -216,20 +216,20 @@ class QuickBooks_QBXML_Object_PaymentItem extends QuickBooks_QBXML_Object
   {
 		return $this->get('SalesOrPurchase Desc');
   }
-	
+
 	/**
 	 * Set the price for this item (Sales OR Purchase)
-	 * 
+	 *
 	 * @param string $price
 	 * @return boolean
 	 */
 	public function setPrice($price)
 	{
 		$this->remove('SalesOrPurchase PricePercent');
-		
+
 		return $this->set('SalesOrPurchase Price', (float) $price);
 	}
-	
+
 	/**
 	 * Get the price for this item (Sales OR Purchase)
 	 */
@@ -237,30 +237,30 @@ class QuickBooks_QBXML_Object_PaymentItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('SalesOrPurchase Price');
 	}
-	
+
 	/**
 	 * Set the price percent for this item (Sales OR Purchase)
 	 */
 	public function setPricePercent($percent)
 	{
 		$this->remove('SalesOrPurchase Price');
-		
+
 		return $this->set('SalesOrPurchase PricePercent', $percent);
 	}
-	
+
 	/**
 	 * Get the price percent for this item (Sales OR Purchase)
-	 * 
+	 *
 	 * @return float
 	 */
 	public function getPricePercent()
 	{
 		return $this->get('SalesOrPurchase PricePercent');
 	}
-	
+
 	/**
 	 * Set the account ListID for this item (Sales OR Purchase)
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return boolean
 	 */
@@ -268,10 +268,10 @@ class QuickBooks_QBXML_Object_PaymentItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('SalesOrPurchase AccountRef ListID', $ListID);
 	}
-	
+
 	/**
 	 * Set the account name for this item (Sales OR Purchase)
-	 * 
+	 *
 	 * @param string $name
 	 * @return boolean
 	 */
@@ -279,7 +279,7 @@ class QuickBooks_QBXML_Object_PaymentItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('SalesOrPurchase AccountRef FullName', $name);
 	}
-	
+
 	/**
 	 * (Sales OR Purchase)
 	 */
@@ -292,69 +292,69 @@ class QuickBooks_QBXML_Object_PaymentItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('SalesOrPurchase AccountRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	/**
 	 * Get the account ListID for this item (Sales OR Purchase)
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getAccountListID()
 	{
 		return $this->get('SalesOrPurchase AccountRef ListID');
 	}
-	
+
 	/**
 	 * Get the account name for this item (Sales OR Purchase)
-	 * 
-	 * @return string 
+	 *
+	 * @return string
 	 */
 	public function getAccountName()
 	{
 		return $this->get('SalesOrPurchase AccountRef FullName');
 	}
-	
+
 	// Sales AND Purchase
-	
+
 	public function setSalesDescription($descrip)
 	{
 		return $this->set('SalesAndPurchase SalesDesc', $descrip);
 	}
-	
+
 	public function getSalesDescription()
 	{
 		return $this->get('SalesAndPurchase SalesDesc');
 	}
-	
+
 	public function setSalesPrice($price)
 	{
 		return $this->set('SalesAndPurchase SalesPrice', (float) $price);
 	}
-	
+
 	public function getSalesPrice()
 	{
 		return $this->get('SalesAndPurchase SalesPrice');
 	}
-	
+
 	public function setIncomeAccountListID($ListID)
 	{
 		return $this->set('SalesAndPurchase IncomeAccountRef ListID', $ListID);
 	}
-	
+
 	public function getIncomeAccountListID()
 	{
 		return $this->get('SalesAndPurchase IncomeAccountRef ListID');
 	}
-	
+
 	public function setIncomeAccountName($name)
 	{
 		return $this->set('SalesAndPurchase IncomeAccountRef FullName', $name);
 	}
-	
+
 	public function getIncomeAccountName()
 	{
 		return $this->get('SalesAndPurchase IncomeAccountRef FullName');
 	}
-	
+
 	public function setIncomeAccountApplicationID($value)
 	{
 		return $this->set('SalesAndPurchase IncomeAccountRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_ACCOUNT, QUICKBOOKS_LISTID, $value));
@@ -369,32 +369,32 @@ class QuickBooks_QBXML_Object_PaymentItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('SalesAndPurchase PurchaseDesc', $descrip);
 	}
-	
+
 	public function getPurchaseDescription()
 	{
 		return $this->get('SalesAndPurchase PurchaseDesc');
 	}
-	
+
 	public function setPurchaseCost($cost)
 	{
 		return $this->set('SalesAndPurchase PurchaseCost', (int) $cost);
 	}
-	
+
 	public function getPurchaseCost()
 	{
 		return $this->get('SalesAndPurchase PurchaseCost');
 	}
-	
+
 	public function setExpenseAccountListID($ListID)
 	{
 		return $this->set('SalesAndPurchase ExpenseAccountRef ListID', $ListID);
 	}
-	
+
 	public function setExpenseAccountName($name)
 	{
 		return $this->set('SalesAndPurchase ExpenseAccountRef FullName', $name);
 	}
-	
+
 	public function setExpenseAccountApplicationID($value)
 	{
 		return $this->set('SalesAndPurchase ExpenseAccountRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_ACCOUNT, QUICKBOOKS_LISTID, $value));
@@ -404,27 +404,27 @@ class QuickBooks_QBXML_Object_PaymentItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('SalesAndPurchase ExpenseAccountRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function getExpenseAccountListID()
 	{
 		return $this->get('SalesAndPurchase ExpenseAccountRef ListID');
 	}
-	
+
 	public function getExpenseAccountName()
 	{
 		return $this->get('SalesAndPurchase ExpenseAccountRef FullName');
 	}
-	
+
 	public function setPreferredVendorListID($ListID)
 	{
 		return $this->set('SalesAndPurchase PrefVendorRef ListID', $ListID);
 	}
-	
+
 	public function setPreferredVendorName($name)
 	{
 		return $this->set('SalesAndPurchase PrefVendorRef FullName', $name);
 	}
-	
+
 	public function setPreferredVendorApplicationID($value)
 	{
 		return $this->set('SalesAndPurchase PrefVendorRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_VENDOR, QUICKBOOKS_LISTID, $value));
@@ -434,20 +434,20 @@ class QuickBooks_QBXML_Object_PaymentItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('SalesAndPurchase PrefVendorRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function getPreferredVendorListID()
 	{
 		return $this->get('SalesAndPurchase PrefVendorRef ListID');
 	}
-	
+
 	public function getPreferredVendorName()
 	{
 		return $this->get('SalesAndPurchase PrefVendorRef FullName');
 	}
-	
+
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 * @return boolean
 	 */
 	protected function _cleanup()
@@ -455,7 +455,7 @@ class QuickBooks_QBXML_Object_PaymentItem extends QuickBooks_QBXML_Object
 		if ($this->isSalesAndPurchase())
 		{
 			// Remove any SalesOrPurchase keys
-			
+
 			foreach ($this->getArray('SalesOrPurchase*') as $key => $value)
 			{
 				$this->remove($key);
@@ -468,39 +468,23 @@ class QuickBooks_QBXML_Object_PaymentItem extends QuickBooks_QBXML_Object
 				$this->remove($key);
 			}
 		}
-		
+
 		return true;
 	}
-	
+
 	/**
-	 * 
+	 *
 	 */
 	public function asArray($request, $nest = true)
 	{
 		$this->_cleanup();
-		
+
 		return parent::asArray($request, $nest);
 	}
-	
+
 	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
-	 * Tell what type of object this is 
-	 * 
+	 * Tell what type of object this is
+	 *
 	 * @return string
 	 */
 	public function object()

--- a/QuickBooks/QBXML/Object/PaymentMethod.php
+++ b/QuickBooks/QBXML/Object/PaymentMethod.php
@@ -2,37 +2,37 @@
 
 /**
  * QuickBooks ShipMethod object container
- * 
+ *
  * @author Keith Palmer <keith@consolibyte.com>
  * @license LICENSE.txt
- * 
+ *
  * @package QuickBooks
  * @subpackage Object
  */
 
 /**
- * 
+ *
  */
 QuickBooks_Loader::load('/QuickBooks/QBXML/Object.php');
 
 /**
- * 
+ *
  */
 class QuickBooks_QBXML_Object_PaymentMethod extends QuickBooks_QBXML_Object
 {
 	/**
 	 * Create a new QuickBooks_Object_PaymentMethod object
-	 * 
+	 *
 	 * @param array $arr
 	 */
 	public function __construct($arr = array())
 	{
 		parent::__construct($arr);
 	}
-	
+
 	/**
 	 * Set the ListID
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return boolean
 	 */
@@ -40,20 +40,20 @@ class QuickBooks_QBXML_Object_PaymentMethod extends QuickBooks_QBXML_Object
 	{
 		return $this->set('ListID', $ListID);
 	}
-	
+
 	/**
 	 * Get the ListID
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getListID()
 	{
 		return $this->get('ListID');
 	}
-	
+
 	/**
 	 * Set the name
-	 * 
+	 *
 	 * @param string $name
 	 * @return boolean
 	 */
@@ -61,20 +61,20 @@ class QuickBooks_QBXML_Object_PaymentMethod extends QuickBooks_QBXML_Object
 	{
 		return $this->set('Name', $name);
 	}
-	
+
 	/**
 	 * Get the name
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getName()
 	{
 		return $this->get('Name');
 	}
-	
+
 	/**
 	 * Set this as active or not
-	 * 
+	 *
 	 * @param boolean $value
 	 * @return boolean
 	 */
@@ -85,62 +85,22 @@ class QuickBooks_QBXML_Object_PaymentMethod extends QuickBooks_QBXML_Object
 
 	/**
 	 * Tell whether or not this is active
-	 * 
+	 *
 	 * @return boolean
 	 */
 	public function getIsActive()
 	{
 		return $this->getBooleanType('IsActive');
 	}
-	
+
 	public function getPaymentMethodType()
 	{
 		return $this->get('PaymentMethodType');
 	}
-	
+
 	/**
-	 * Perform any needed clean-up of the object data members
-	 * 
-	 * @return boolean
-	 */
-	protected function _cleanup()
-	{
-		return true;
-	}
-	
-	/**
-	 * Get an array representation of this object
-	 * 
-	 * @param string $request
-	 * @param boolean $nest
-	 * @return array
-	 */
-	public function asArray($request, $nest = true)
-	{
-		$this->_cleanup();
-		
-		return parent::asArray($request, $nest);
-	}
-	
-	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
-	 * Tell what type of object this is 
-	 * 
+	 * Tell what type of object this is
+	 *
 	 * @return string
 	 */
 	public function object()

--- a/QuickBooks/QBXML/Object/ReceivePayment.php
+++ b/QuickBooks/QBXML/Object/ReceivePayment.php
@@ -2,10 +2,10 @@
 
 /**
  * QuickBooks ReceivePayment object container
- * 
+ *
  * @author Keith Palmer <keith@consolibyte.com>
- * @license LICENSE.txt 
- * 
+ * @license LICENSE.txt
+ *
  * @package QuickBooks
  * @subpackage Object
  */
@@ -21,23 +21,23 @@ QuickBooks_Loader::load('/QuickBooks/QBXML/Object.php');
 QuickBooks_Loader::load('/QuickBooks/QBXML/Object/ReceivePayment/AppliedToTxn.php');
 
 /**
- * QuickBooks ReceivePayment object 
+ * QuickBooks ReceivePayment object
  */
 class QuickBooks_QBXML_Object_ReceivePayment extends QuickBooks_QBXML_Object
 {
 	/**
 	 * Create a new QuickBooks_Object_ReceivePayment object
-	 * 
+	 *
 	 * @param array $arr
 	 */
 	public function __construct($arr = array())
 	{
 		parent::__construct($arr);
 	}
-	
+
 	/**
 	 * Set the TxnID of the Class
-	 * 
+	 *
 	 * @param string $TxnID
 	 * @return boolean
 	 */
@@ -45,7 +45,7 @@ class QuickBooks_QBXML_Object_ReceivePayment extends QuickBooks_QBXML_Object
 	{
 		return $this->set('TxnID', $TxnID);
 	}
-	
+
 	/**
 	 * Alias of {@link QuickBooks_Object_ReceivePayment::setTxnID()}
 	 */
@@ -53,17 +53,17 @@ class QuickBooks_QBXML_Object_ReceivePayment extends QuickBooks_QBXML_Object
 	{
 		return $this->setTxnID($TxnID);
 	}
-	
+
 	/**
 	 * Get the ListID of the Class
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getTxnID()
 	{
 		return $this->get('TxnID');
 	}
-	
+
 	/**
 	 * Alias of {@link QuickBooks_Object_ReceivePayment::getTxnID()}
 	 */
@@ -71,10 +71,10 @@ class QuickBooks_QBXML_Object_ReceivePayment extends QuickBooks_QBXML_Object
 	{
 		return $this->getTxnID();
 	}
-	
+
 	/**
 	 * Set the customer ListID
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return boolean
 	 */
@@ -82,10 +82,10 @@ class QuickBooks_QBXML_Object_ReceivePayment extends QuickBooks_QBXML_Object
 	{
 		return $this->set('CustomerRef ListID' , $ListID);
 	}
-	
+
 	/**
 	 * Set the customer ApplicationID (auto-replaced by the API with a ListID)
-	 * 
+	 *
 	 * @param mixed $value
 	 * @return boolean
 	 */
@@ -93,13 +93,13 @@ class QuickBooks_QBXML_Object_ReceivePayment extends QuickBooks_QBXML_Object
 	{
 		return $this->set('CustomerRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_CUSTOMER, QUICKBOOKS_LISTID, $value));
 	}
-	
-	
+
+
 	public function getCustomerApplicationID()
 	{
 		return $this->get('CustomerRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	/**
 	 * @deprecated
 	 */
@@ -107,22 +107,22 @@ class QuickBooks_QBXML_Object_ReceivePayment extends QuickBooks_QBXML_Object
 	{
 		return $this->set('CustomerRef FullName', $name);
 	}
-	
+
 	public function setCustomerFullName($name)
 	{
 		return $this->set('CustomerRef FullName', $name);
 	}
-	
+
 	/**
 	 * Get the customer ListID
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getCustomerListID()
 	{
 		return $this->get('CustomerRef ListID');
 	}
-	
+
 	/**
 	 * @deprecated
 	 */
@@ -130,15 +130,15 @@ class QuickBooks_QBXML_Object_ReceivePayment extends QuickBooks_QBXML_Object
 	{
 		return $this->get('CustomerRef FullName');
 	}
-	
+
 	public function getCustomerFullName()
 	{
 		return $this->get('CustomerRef FullName');
 	}
-	
+
 	/**
 	 * Set the transaction date
-	 * 
+	 *
 	 * @param string $date
 	 * @return boolean
 	 */
@@ -146,7 +146,7 @@ class QuickBooks_QBXML_Object_ReceivePayment extends QuickBooks_QBXML_Object
 	{
 		return $this->setDateType('TxnDate', $date);
 	}
-	
+
 	/**
 	 * Alias of {@link QuickBooks_Object_Invoice::setTxnDate()}
 	 */
@@ -154,22 +154,22 @@ class QuickBooks_QBXML_Object_ReceivePayment extends QuickBooks_QBXML_Object
 	{
 		return $this->setTxnDate($date);
 	}
-	
+
 	/**
 	 * Get the transaction date
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getTxnDate($format = 'Y-m-d')
 	{
 		return $this->getDateType('TxnDate');
 	}
-	
 
-	
+
+
 	/**
 	 * Set the reference number
-	 * 
+	 *
 	 * @param string $str
 	 * @return boolean
 	 */
@@ -177,17 +177,17 @@ class QuickBooks_QBXML_Object_ReceivePayment extends QuickBooks_QBXML_Object
 	{
 		return $this->set('RefNumber', $str);
 	}
-	
+
 	/**
 	 * Get the reference number
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getRefNumber()
 	{
 		return $this->get('RefNumber');
 	}
-	
+
 	/**
 	 * Alias of {@link QuickBooks_Object_ReceivePayment::addAppliedToTxn()}
 	 */
@@ -195,34 +195,34 @@ class QuickBooks_QBXML_Object_ReceivePayment extends QuickBooks_QBXML_Object
 	{
 		return $this->addAppliedToTxn($obj);
 	}
-	
+
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 */
 	public function addAppliedToTxn($obj)
 	{
 		/*
 		$lines = $this->get('AppliedToTxn');
-		
+
 		if (!is_array($lines))
 		{
 			$lines = array();
 		}
-		
+
 		//
 		$lines[] = $obj;
-		
+
 		return $this->set('AppliedToTxn', $lines);*/
-		
+
 		return $this->addListItem('AppliedToTxn', $obj);
 	}
-	
+
 	public function getAppliedToTxn($i)
 	{
 		return $this->getListItem('AppliedToTxn', $i);
 	}
-	
+
 	public function listAppliedToTxns()
 	{
 		return $this->getList('AppliedToTxn');
@@ -235,10 +235,10 @@ class QuickBooks_QBXML_Object_ReceivePayment extends QuickBooks_QBXML_Object
 	{
 		return $this->getDateType('TxnDate', $format);
 	}
-	
+
 	/**
 	 * Set the total amount of the received payment
-	 * 
+	 *
 	 * @param float $amount
 	 * @return boolean
 	 */
@@ -246,22 +246,22 @@ class QuickBooks_QBXML_Object_ReceivePayment extends QuickBooks_QBXML_Object
 	{
 		return $this->setAmountType('TotalAmount', $amount);
 	}
-	
+
 	/**
 	 * Get the total amount of the received payment
-	 * 
+	 *
 	 * @return float
 	 */
 	public function getTotalAmount()
 	{
 		return $this->getAmountType('TotalAmount');
 	}
-	
+
 	public function setARAccountListID($ListID)
 	{
 		return $this->set('ARAccountRef ListID', $ListID);
 	}
-	
+
 	/**
 	 * @deprecated
 	 */
@@ -274,7 +274,7 @@ class QuickBooks_QBXML_Object_ReceivePayment extends QuickBooks_QBXML_Object
 	{
 		return $this->set('ARAccountRef FullName', $name);
 	}
-	
+
 	public function setARAccountApplicationID($value)
 	{
 		return $this->set('ARAccountRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_ACCOUNT, QUICKBOOKS_LISTID, $value));
@@ -284,12 +284,12 @@ class QuickBooks_QBXML_Object_ReceivePayment extends QuickBooks_QBXML_Object
 	{
 		return $this->get('ARAccountRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function getARAccountListID()
 	{
 		return $this->get('ARAccountRef ListID');
 	}
-	
+
 	/**
 	 * @deprecated
 	 */
@@ -302,12 +302,12 @@ class QuickBooks_QBXML_Object_ReceivePayment extends QuickBooks_QBXML_Object
 	{
 		return $this->get('ARAccountRef FullName');
 	}
-	
+
 	public function setPaymentMethodListID($ListID)
 	{
 		return $this->set('PaymentMethodRef ListID', $ListID);
 	}
-	
+
 	/**
 	 * @deprecated
 	 */
@@ -315,12 +315,12 @@ class QuickBooks_QBXML_Object_ReceivePayment extends QuickBooks_QBXML_Object
 	{
 		return $this->set('PaymentMethodRef FullName', $name);
 	}
-	
+
 	public function setPaymentMethodFullName($name)
 	{
 		return $this->set('PaymentMethodRef FullName', $name);
 	}
-	
+
 	public function setPaymentMethodApplicationID($value)
 	{
 		return $this->set('PaymentMethodRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_PAYMENTMETHOD, QUICKBOOKS_LISTID, $value));
@@ -330,12 +330,12 @@ class QuickBooks_QBXML_Object_ReceivePayment extends QuickBooks_QBXML_Object
 	{
 		return $this->get('PaymentMethodRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function getPaymentMethodListID()
 	{
 		return $this->get('PaymentMethodRef ListID');
 	}
-	
+
 	/**
 	 * @deprecated
 	 */
@@ -343,17 +343,17 @@ class QuickBooks_QBXML_Object_ReceivePayment extends QuickBooks_QBXML_Object
 	{
 		return $this->get('PaymentMethodRef FullName');
 	}
-	
+
 	public function getPaymentMethodFullName()
 	{
 		return $this->get('PaymentMethodRef FullName');
 	}
-	
+
 	public function setDepositToAccountListID($ListID)
 	{
 		return $this->set('DepositToAccountRef ListID', $ListID);
 	}
-	
+
 	/**
 	 * @deprecated
 	 */
@@ -361,12 +361,12 @@ class QuickBooks_QBXML_Object_ReceivePayment extends QuickBooks_QBXML_Object
 	{
 		return $this->set('DepositToAccountRef FullName', $name);
 	}
-	
+
 	public function setDepositToAccountFullName($name)
 	{
 		return $this->set('DepositToAccountRef FullName', $name);
 	}
-	
+
 	public function setDepositToAccountApplicationID($value)
 	{
 		return $this->set('DepositToAccountRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_ACCOUNT, QUICKBOOKS_LISTID, $value));
@@ -376,12 +376,12 @@ class QuickBooks_QBXML_Object_ReceivePayment extends QuickBooks_QBXML_Object
 	{
 		return $this->get('DepositToAccountRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function getDepositToAccountListID()
 	{
 		return $this->get('DepositToAccountRef ListID');
 	}
-	
+
 	/**
 	 * @deprecated
 	 */
@@ -389,25 +389,25 @@ class QuickBooks_QBXML_Object_ReceivePayment extends QuickBooks_QBXML_Object
 	{
 		return $this->get('DepositToAccountRef FullName');
 	}
-	
+
 	public function getDepositToAccountFullName()
 	{
 		return $this->get('DepositToAccountRef FullName');
 	}
-	
+
 	public function setMemo($memo)
 	{
 		return $this->set('Memo', $memo);
 	}
-	
+
 	public function getMemo()
 	{
 		return $this->get('Memo');
 	}
-		
+
 	/**
 	 * Set whether or not this transaction is an auto-apply transaction
-	 * 
+	 *
 	 * @param boolean $isautoapply
 	 * @return boolean
 	 */
@@ -425,70 +425,46 @@ class QuickBooks_QBXML_Object_ReceivePayment extends QuickBooks_QBXML_Object
 
 	/**
 	 * Get whether or not this transaction is an auto-apply transaction
-	 * 
+	 *
 	 * @return boolean
 	 */
 	public function getIsAutoApply()
 	{
 		return $this->get('IsAutoApply') != 'false';
 	}
-	
-	/**
-	 * Perform any needed clean-up of the object data members
-	 * 
-	 * @return boolean
-	 */
-	protected function _cleanup()
-	{
-		return true;
-	}
-	
-	/**
-	 * Get an array representation of this Class object
-	 * 
-	 * @param string $request
-	 * @param boolean $nest
-	 * @return array
-	 */
-	/*public function asArray($request, $nest = true)
-	{
-		$this->_cleanup();
-		
-		return parent::asArray($request, $nest);
-	}*/
-	
+
 	public function asList($request)
 	{
 		switch ($request)
 		{
 			case 'ReceivePaymentAddRq':
-				
+
 				if (isset($this->_object['AppliedToTxn']))
 				{
 					$this->_object['AppliedToTxnAdd'] = $this->_object['AppliedToTxn'];
 				}
-				
+
 				break;
 			case 'ReceivePaymentModRq':
-				
+
 				if (isset($this->_object['AppliedToTxn']))
 				{
-					$this->_object['AppliedToTxnMod'] = $this->_object['AppliedToTxn'];	
+					$this->_object['AppliedToTxnMod'] = $this->_object['AppliedToTxn'];
 				}
-				
+
 				break;
 		}
-		
+
 		return parent::asList($request);
 	}
-	
+
 	public function asXML($root = null, $parent = null, $object = null)
 	{
 		if (is_null($object))
 		{
 			$object = $this->_object;
 		}
-				
+
 		switch ($root)
 		{
 			case QUICKBOOKS_ADD_RECEIVEPAYMENT:
@@ -500,7 +476,7 @@ class QuickBooks_QBXML_Object_ReceivePayment extends QuickBooks_QBXML_Object
 						$obj->setOverride('AppliedToTxnAdd');
 					}
 				}
-				
+
 				break;
 			case QUICKBOOKS_MOD_RECEIVEPAYMENT:
 
@@ -511,34 +487,16 @@ class QuickBooks_QBXML_Object_ReceivePayment extends QuickBooks_QBXML_Object
 						$obj->setOverride('AppliedToTxnMod');
 					}
 				}
-				
+
 				break;
 		}
-		
+
 		return parent::asXML($root, $parent, $object);
 	}
-	
+
 	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	/*
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	*/
-	
-	/**
-	 * Tell what type of object this is 
-	 * 
+	 * Tell what type of object this is
+	 *
 	 * @return string
 	 */
 	public function object()

--- a/QuickBooks/QBXML/Object/SalesOrder.php
+++ b/QuickBooks/QBXML/Object/SalesOrder.php
@@ -2,45 +2,45 @@
 
 /**
  * QuickBooks SalesOrder object container
- * 
+ *
  * @author Keith Palmer <keith@consolibyte.com>
- * @license LICENSE.txt 
- * 
+ * @license LICENSE.txt
+ *
  * @package QuickBooks
  * @subpackage Object
  */
 
 /**
- * 
+ *
  */
 QuickBooks_Loader::load('/QuickBooks/QBXML/Object.php');
 
 /**
- * 
+ *
  */
 QuickBooks_Loader::load('/QuickBooks/QBXML/Object/Generic.php');
 
 /**
- * 
+ *
  */
 QuickBooks_Loader::load('/QuickBooks/QBXML/Object/SalesOrder/SalesOrderLine.php');
 
 /**
- * 
- * 
+ *
+ *
  */
 class QuickBooks_QBXML_Object_SalesOrder extends QuickBooks_QBXML_Object
 {
 	/**
 	 * Create a new QuickBooks SalesOrder object
-	 * 
+	 *
 	 * @param array $arr
 	 */
 	public function __construct($arr = array())
 	{
 		parent::__construct($arr);
 	}
-	
+
 	/**
 	 * Alias of {@link QuickBooks_Object_SalesOrder::setTxnID()}
 	 */
@@ -53,10 +53,10 @@ class QuickBooks_QBXML_Object_SalesOrder extends QuickBooks_QBXML_Object
   {
     return $this->getTxnID();
   }
-	
+
 	/**
 	 * Set the transaction ID of the Invoice object
-	 * 
+	 *
 	 * @param string $TxnID
 	 * @return boolean
 	 */
@@ -69,10 +69,10 @@ class QuickBooks_QBXML_Object_SalesOrder extends QuickBooks_QBXML_Object
   {
     return $this->get('TxnID');
   }
-	
+
 	/**
 	 * Set the customer ListID
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return boolean
 	 */
@@ -80,10 +80,10 @@ class QuickBooks_QBXML_Object_SalesOrder extends QuickBooks_QBXML_Object
 	{
 		return $this->set('CustomerRef ListID' , $ListID);
 	}
-	
+
 	/**
 	 * Set the customer ApplicationID (auto-replaced by the API with a ListID)
-	 * 
+	 *
 	 * @param mixed $value
 	 * @return boolean
 	 */
@@ -96,10 +96,10 @@ class QuickBooks_QBXML_Object_SalesOrder extends QuickBooks_QBXML_Object
   {
     return $this->get('CustomerRef ' . QUICKBOOKS_API_APPLICATIONID);
   }
-	
+
 	/**
 	 * Set the customer name
-	 * 
+	 *
 	 * @param string $name
 	 * @return boolean
 	 */
@@ -107,32 +107,32 @@ class QuickBooks_QBXML_Object_SalesOrder extends QuickBooks_QBXML_Object
 	{
 		return $this->set('CustomerRef FullName', $name);
 	}
-	
+
 	/**
 	 * Get the customer ListID
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getCustomerListID()
 	{
 		return $this->get('CustomerRef ListID');
 	}
-	
+
 	/**
 	 * Get the customer name
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getCustomerName()
 	{
 		return $this->get('CustomerRef FullName');
 	}
-	
+
 	public function setClassListID($ListID)
 	{
 		return $this->set('ClassRef ListID', $ListID);
 	}
-	
+
 	public function setClassApplicationID($value)
 	{
 		return $this->set('ClassRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_CLASS, QUICKBOOKS_LISTID, $value));
@@ -142,22 +142,22 @@ class QuickBooks_QBXML_Object_SalesOrder extends QuickBooks_QBXML_Object
   {
 		return $this->get('ClassRef ' . QUICKBOOKS_API_APPLICATIONID);
   }
-	
+
 	public function setClassName($name)
 	{
 		return $this->set('ClassRef FullName', $name);
 	}
-	
+
 	public function getClassName()
 	{
 		return $this->get('ClassRef FullName');
 	}
-	
+
 	public function getClassListID()
 	{
 		return $this->get('ClassRef ListID');
 	}
-	
+
 	public function setARAccountApplicationID($value)
 	{
 		return $this->set('ARAccountRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_ACCOUNT, QUICKBOOKS_LISTID, $value));
@@ -167,27 +167,27 @@ class QuickBooks_QBXML_Object_SalesOrder extends QuickBooks_QBXML_Object
 	{
 		return $this->get('ARAccountRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function setARAccountListID($ListID)
 	{
 		return $this->set('ARAccountRef ListID', $ListID);
 	}
-	
+
 	public function setARAccountName($name)
 	{
 		return $this->set('ARAccountRef FullName', $name);
 	}
-	
+
 	public function getARAccountListID()
 	{
 		return $this->get('ARAccountRef ListID');
 	}
-	
+
 	public function getARAccountName()
 	{
 		return $this->get('ARAccountRef FullName');
 	}
-	
+
 	public function setTemplateApplicationID($value)
 	{
 		return $this->set('TemplateRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_TEMPLATE, QUICKBOOKS_LISTID, $value));
@@ -197,30 +197,30 @@ class QuickBooks_QBXML_Object_SalesOrder extends QuickBooks_QBXML_Object
 	{
 		return $this->get('TemplateRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function setTemplateName($name)
 	{
 		return $this->set('TemplateRef FullName', $name);
 	}
-	
+
 	public function setTemplateListID($ListID)
 	{
 		return $this->set('TemplateRef ListID', $ListID);
 	}
-	
+
 	public function getTemplateName()
 	{
 		return $this->get('TemplateRef FullName');
 	}
-	
+
 	public function getTemplateListID()
 	{
 		return $this->get('TemplateRef ListID');
 	}
-	
+
 	/**
 	 * Set the transaction date
-	 * 
+	 *
 	 * @param string $date
 	 * @return boolean
 	 */
@@ -228,7 +228,7 @@ class QuickBooks_QBXML_Object_SalesOrder extends QuickBooks_QBXML_Object
 	{
 		return $this->setDateType('TxnDate', $date);
 	}
-	
+
 	/**
 	 * Alias of {@link QuickBooks_Object_Invoice::setTxnDate()}
 	 */
@@ -236,17 +236,17 @@ class QuickBooks_QBXML_Object_SalesOrder extends QuickBooks_QBXML_Object
 	{
 		return $this->setTxnDate($date);
 	}
-	
+
 	/**
 	 * Get the transaction date
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getTxnDate($format = 'Y-m-d')
 	{
 		return $this->getDateType('TxnDate', $format);
 	}
-	
+
 	/**
 	 * Alias of {@link QuickBooks_Object_Invoice::getTxnDate()}
 	 */
@@ -254,10 +254,10 @@ class QuickBooks_QBXML_Object_SalesOrder extends QuickBooks_QBXML_Object
 	{
 		return $this->getTxnDate();
 	}
-	
+
 	/**
 	 * Set the reference number
-	 * 
+	 *
 	 * @param string $str
 	 * @return boolean
 	 */
@@ -265,20 +265,20 @@ class QuickBooks_QBXML_Object_SalesOrder extends QuickBooks_QBXML_Object
 	{
 		return $this->set('RefNumber', $str);
 	}
-	
+
 	/**
 	 * Get the reference number
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getRefNumber()
 	{
 		return $this->get('RefNumber');
 	}
-	
+
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 * @param string $part
 	 * @param array $defaults
 	 * @return array
@@ -289,13 +289,13 @@ class QuickBooks_QBXML_Object_SalesOrder extends QuickBooks_QBXML_Object
 		{
 			return $this->get('ShipAddress ' . $part);
 		}
-		
+
 		return $this->getArray('ShipAddress *', $defaults);
 	}
-	
+
 	/**
 	 * Set the shipping address for the invoice
-	 * 
+	 *
 	 * @param string $addr1
 	 * @param string $addr2
 	 * @param string $addr3
@@ -315,17 +315,17 @@ class QuickBooks_QBXML_Object_SalesOrder extends QuickBooks_QBXML_Object
 		{
 			$this->set('ShipAddress Addr' . $i, ${'addr' . $i});
 		}
-		
+
 		$this->set('ShipAddress City', $city);
 		$this->set('ShipAddress State', $state);
 		$this->set('ShipAddress PostalCode', $postalcode);
 		$this->set('ShipAddress Country', $country);
-		$this->set('ShipAddress Note', $note);  
+		$this->set('ShipAddress Note', $note);
 	}
-	
+
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 * @param string $part
 	 * @param array $defaults
 	 * @return array
@@ -336,13 +336,13 @@ class QuickBooks_QBXML_Object_SalesOrder extends QuickBooks_QBXML_Object
 		{
 			return $this->get('BillAddress ' . $part);
 		}
-		
+
 		return $this->getArray('BillAddress *', $defaults);
 	}
-	
+
 	/**
 	 * Set the billing address for the invoice
-	 * 
+	 *
 	 * @param string $addr1
 	 * @param string $addr2
 	 * @param string $addr3
@@ -361,23 +361,23 @@ class QuickBooks_QBXML_Object_SalesOrder extends QuickBooks_QBXML_Object
 		{
 			$this->set('BillAddress Addr' . $i, ${'addr' . $i});
 		}
-		
+
 		$this->set('BillAddress City', $city);
 		$this->set('BillAddress State', $state);
 		$this->set('BillAddress PostalCode', $postalcode);
 		$this->set('BillAddress Country', $country);
-		$this->set('BillAddress Note', $note);  
+		$this->set('BillAddress Note', $note);
 	}
-	
+
 	public function setIsPending($pending)
 	{
 		return $this->set('IsPending', (boolean) $pending);
 	}
-	
+
 	public function getIsPending()
 	{
 		if ($this->exists('IsPending'))
-		{ 
+		{
 			$pending = $this->get('IsPending');
 			if (is_bool($pending))
 			{
@@ -392,25 +392,25 @@ class QuickBooks_QBXML_Object_SalesOrder extends QuickBooks_QBXML_Object
 				return true;
 			}
 		}
-		
+
 		return null;
 	}
-	
+
 	public function setPONumber($num)
 	{
 		return $this->set('PONumber', $num);
 	}
-	
+
 	public function getPONumber()
 	{
 		return $this->get('PONumber');
 	}
-	
+
 	public function setTermsListID($ListID)
 	{
 		return $this->set('TermsRef ListID', $ListID);
 	}
-	
+
 	public function setTermsApplicationID($value)
 	{
 		return $this->set('TermsRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_TERMS, QUICKBOOKS_LISTID, $value));
@@ -420,192 +420,192 @@ class QuickBooks_QBXML_Object_SalesOrder extends QuickBooks_QBXML_Object
 	{
 		return $this->get('TermsRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function setTermsName($name)
 	{
 		return $this->set('TermsRef FullName', $name);
 	}
-	
+
 	public function getTermsName()
 	{
 		return $this->get('TermsRef FullName');
 	}
-	
+
 	public function getTermsListID()
 	{
 		return $this->get('TermsRef ListID');
 	}
-	
+
 	public function setDueDate($date)
 	{
 		return $this->setDateType('DueDate', $date);
 	}
-	
+
 	public function getDueDate($format = 'Y-m-d')
 	{
 		return $this->getDateType('DueDate', $format);
 	}
-	
+
 	public function setSalesRepName($name)
 	{
-		
+
 	}
-	
+
 	public function setSalesRepListID($ListID)
 	{
-		
+
 	}
-	
+
 	public function setSalesRepApplicationID($value)
 	{
-		
+
 	}
 
 	public function getSalesRepApplicationID()
 	{
-		
+
 	}
-	
+
 	public function getSalesRepName()
 	{
-		
+
 	}
-	
+
 	public function getSalesRepListID()
 	{
-		
+
 	}
-	
+
 	public function getFOB()
 	{
 		return $this->get('FOB');
 	}
-	
+
 	public function setFOB($fob)
 	{
 		return $this->set('FOB', $fob);
 	}
-	
+
 	public function setShipDate($date)
 	{
 		return $this->setDateType('ShipDate', $date);
 	}
-	
+
 	public function getShipDate($format = 'Y-m-d')
 	{
 		return $this->getDateType('ShipDate', $format);
 	}
-	
+
 	public function setShipMethodApplicationID()
 	{
-		
+
 	}
 
 	public function getShipMethodApplicationID()
 	{
-		
+
 	}
-	
+
 	public function setShipMethodName()
 	{
-		
+
 	}
-	
+
 	public function setShipMethodListID()
 	{
-		
+
 	}
-	
+
 	public function getShipMethodName()
 	{
-		
+
 	}
-	
+
 	public function getShipMethodListID()
 	{
-		
+
 	}
-	
+
 	public function setSalesTaxItemListID()
 	{
-		
+
 	}
-	
+
 	public function setSalesTaxItemApplicationID()
 	{
-		
+
 	}
 
 	public function getSalesTaxItemApplicationID()
 	{
-		
+
 	}
-	
+
 	public function setSalesTaxItemName()
 	{
-		
+
 	}
-	
+
 	public function getSalesTaxItemName()
 	{
-		
+
 	}
-	
+
 	public function getSalesTaxItemListID()
 	{
-		
+
 	}
-	
+
 	public function setMemo($memo)
 	{
 		return $this->set('Memo', $memo);
 	}
-	
+
 	public function getMemo()
 	{
 		return $this->get('Memo');
 	}
-	
+
 	public function setIsToBePrinted()
 	{
-		
+
 	}
-	
+
 	public function getIsToBePrinted()
 	{
-		
+
 	}
-	
+
 	public function setIsToBeEmailed()
 	{
-		
+
 	}
-	
+
 	public function getIsToBeEmailed()
 	{
-		
+
 	}
-	
+
 	public function setCustomerSalesTaxCodeListID()
 	{
-		
+
 	}
-	
+
 	public function setCustomerSalesTaxCodeName()
 	{
-		
+
 	}
-	
+
 	public function getCustomerSalesTaxCodeListID()
 	{
-		
+
 	}
-	
+
 	public function getCustomerSalesTaxCodeName()
 	{
-		
+
 	}
-	
+
 	public function setLinkToTxnID($TxnID)
 	{
 		return $this->set('LinkToTxnID', $TxnID);
@@ -615,48 +615,48 @@ class QuickBooks_QBXML_Object_SalesOrder extends QuickBooks_QBXML_Object
 	{
 		return $this->get('LinkToTxnID');
 	}
-	
+
 	/*
 	public function getInvoiceLines()
 	{
 		return $this->getList('InvoiceLine');
 	}
-	
+
 	public function getInvoiceLine($which)
 	{
 		$list = $this->getInvoiceLines();
-		
+
 		if (isset($list[$which]))
 		{
 			return $list[$which];
 		}
-		
+
 		return null;
 	}
 	*/
-	
+
 	/*
-	public function setInvoiceLine($i, 
+	public function setInvoiceLine($i,
 	{
-		
+
 	}
 	*/
-	
+
 	/**
-	 * 
-	 * 
-	 * @param 
+	 *
+	 *
+	 * @param
 	 */
 	public function addInvoiceLine($obj)
 	{
 		$lines = $this->get('InvoiceLine');
 		/*$lines[] = array(
-			'Quantity' => mt_rand(4, 8), 
-			'Amount' => mt_rand(255, 300), 
-			'ItemRef ListID' => 'test', 
+			'Quantity' => mt_rand(4, 8),
+			'Amount' => mt_rand(255, 300),
+			'ItemRef ListID' => 'test',
 			);
 		*/
-		
+
 		/*
 		$tmp = new QuickBooks_Object_Generic();
 		$tmp->set('Quantity', mt_rand(4, 8));
@@ -664,10 +664,10 @@ class QuickBooks_QBXML_Object_SalesOrder extends QuickBooks_QBXML_Object
 		$tmp->set('ItemRef ListID', 'test');
 		$lines[] = $tmp;
 		*/
-		
+
 		//
 		$lines[] = $obj;
-		
+
 		return $this->set('InvoiceLine', $lines);
 	}
 
@@ -687,71 +687,60 @@ class QuickBooks_QBXML_Object_SalesOrder extends QuickBooks_QBXML_Object
 	{
 		return $this->getListItem('SalesOrderLine', $i);
 	}
-	
+
 	public function setOther($other)
 	{
 		return $this->set('Other', $other);
 	}
-	
+
 	public function getOther()
 	{
 		return $this->get('Other');
 	}
-		
-	/**
-	 * 
-	 * 
-	 * @return boolean
-	 */
-	protected function _cleanup()
-	{
-		
-		return true;
-	}
-	
+
 	public function asList($request)
 	{
 		switch ($request)
 		{
 			case 'SalesOrderAddRq':
-				
+
 				if (isset($this->_object['SalesOrderLine']))
 				{
 					$this->_object['SalesOrderLineAdd'] = $this->_object['SalesOrderLine'];
 				}
-				
+
 				break;
 			case 'SalesOrderModRq':
-				
+
 				if (isset($this->_object['SalesOrderLine']))
 				{
 					$this->_object['SalesOrderLineMod'] = $this->_object['SalesOrderLine'];
 				}
-				
+
 				break;
 		}
-		
+
 		return parent::asList($request);
 	}
-	
+
 	public function asXML($root = null, $parent = null, $object = null)
 	{
 		if (is_null($object))
 		{
 			$object = $this->_object;
 		}
-		
+
 		switch ($root)
 		{
 			case QUICKBOOKS_ADD_SALESORDER:
-				
+
 				foreach ($object['SalesOrderLineAdd'] as $key => $obj)
 				{
 					$obj->setOverride('SalesOrderLineAdd');
 				}
-				
+
 				break;
-			
+
 			case QUICKBOOKS_MOD_SALESORDER:
 				if (isset($object['SalesOrderLine']))
 				{
@@ -759,42 +748,15 @@ class QuickBooks_QBXML_Object_SalesOrder extends QuickBooks_QBXML_Object
 				}
 				break;
 		}
-		
+
 		//print_r($this->_object);
-		
+
 		return parent::asXML($root, $parent, $object);
-	}
-	
-	/**
-	 * 
-	 */
-	public function asArray($request, $nest = true)
-	{
-		$this->_cleanup();
-		
-		return parent::asArray($request, $nest);
 	}
 
 	/**
-	 *
-	 *
-	 * @param        $request
-	 * @param null   $version
-	 * @param null   $locale
-	 * @param string $root
-	 *
-	 * @return string
-	 */
-	public function asQBXML($request, $version = null, $locale = null, $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $version, $locale, $root);
-	}
-	
-	/**
 	 * Tell the type of object this is
-	 * 
+	 *
 	 * @return string
 	 */
 	public function object()

--- a/QuickBooks/QBXML/Object/SalesReceipt.php
+++ b/QuickBooks/QBXML/Object/SalesReceipt.php
@@ -2,10 +2,10 @@
 
 /**
  * QuickBooks SalesReceipt object
- * 
+ *
  * @author Keith Palmer <keith@consolibyte.com>
- * @license LICENSE.txt 
- * 
+ * @license LICENSE.txt
+ *
  * @package QuickBooks
  * @subpackage Object
  */
@@ -46,20 +46,20 @@ QuickBooks_Loader::load('/QuickBooks/QBXML/Object/SalesReceipt/SalesTaxLine.php'
  * Sales receipts are like invoices and payments combined together, and are
  * usually used in cases where the purchase and payment are made at the same
  * time (store front purchases, shopping cart purchases by credit card, etc.)
- * 
+ *
  */
 class QuickBooks_QBXML_Object_SalesReceipt extends QuickBooks_QBXML_Object
 {
 	/**
 	 * Create a new QuickBooks SalesReceipt object
-	 * 
+	 *
 	 * @param array $arr
 	 */
 	public function __construct($arr = array())
 	{
 		parent::__construct($arr);
 	}
-	
+
 	/**
 	 * Alias of {@link QuickBooks_Object_SalesReceipt::setTxnID()}
 	 */
@@ -72,10 +72,10 @@ class QuickBooks_QBXML_Object_SalesReceipt extends QuickBooks_QBXML_Object
   {
     return $this->getTxnID();
   }
-	
+
 	/**
 	 * Set the transaction ID of the SalesReceipt object
-	 * 
+	 *
 	 * @param string $TxnID
 	 * @return boolean
 	 */
@@ -88,10 +88,10 @@ class QuickBooks_QBXML_Object_SalesReceipt extends QuickBooks_QBXML_Object
   {
     return $this->get('TxnID');
   }
-	
+
 	/**
 	 * Set the customer ListID
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return boolean
 	 */
@@ -99,10 +99,10 @@ class QuickBooks_QBXML_Object_SalesReceipt extends QuickBooks_QBXML_Object
 	{
 		return $this->set('CustomerRef ListID' , $ListID);
 	}
-	
+
 	/**
 	 * Set the customer ApplicationID (auto-replaced by the API with a ListID)
-	 * 
+	 *
 	 * @param mixed $value
 	 * @return boolean
 	 */
@@ -110,10 +110,10 @@ class QuickBooks_QBXML_Object_SalesReceipt extends QuickBooks_QBXML_Object
 	{
 		return $this->set('CustomerRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_CUSTOMER, QUICKBOOKS_LISTID, $value));
 	}
-	
+
 	/**
 	 * Set the customer name
-	 * 
+	 *
 	 * @param string $name
 	 * @return boolean
 	 */
@@ -121,84 +121,84 @@ class QuickBooks_QBXML_Object_SalesReceipt extends QuickBooks_QBXML_Object
 	{
 		return $this->set('CustomerRef FullName', $name);
 	}
-	
+
 	public function setCustomerFullName($FullName)
 	{
 		return $this->setFullNameType('CustomerRef FullName', null, null, $FullName);
 	}
-	
+
 	/**
 	 * Get the customer ListID
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getCustomerListID()
 	{
 		return $this->get('CustomerRef ListID');
 	}
-	
+
 	/**
 	 * Get the customer name
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getCustomerName()
 	{
 		return $this->get('CustomerRef FullName');
 	}
-	
+
 	/**
 	 * Get the customer application ID
-	 * 
+	 *
 	 * @return mixed
 	 */
 	public function getCustomerApplicationID()
 	{
 		return $this->extractApplicationID($this->get('CustomerRef ' . QUICKBOOKS_API_APPLICATIONID));
 	}
-	
+
 	/*
 	public function setDiscountLineAmount($amount)
 	{
 		return $this->set('DiscountLine
 	}
-	
+
 	public function setDiscountLineAccountName($name)
 	{
-		
+
 	}
-	
+
 	public function setShippingLineAmount($amount)
 	{
-		
+
 	}
-	
+
 	public function setShippingLineAccountName($name)
 	{
-		
+
 	}
-	
+
 	public function setSalesTaxLineAmount($amount)
 	{
-		
+
 	}
-	
+
 	public function setSalesTaxLineAccountName($name)
 	{
-		
+
 	}
 	*/
-	
+
 	public function setSalesTaxItemFullName($FullName)
 	{
 		return $this->setItemSalesTaxFullName($FullName);
 	}
-	
+
 	public function setItemSalesTaxFullName($FullName)
 	{
 		return $this->setFullNameType('ItemSalesTaxRef FullName', null, null, $FullName);
 	}
-	
+
 	public function setClassListID($ListID)
 	{
 		return $this->set('ClassRef ListID', $ListID);
@@ -208,7 +208,7 @@ class QuickBooks_QBXML_Object_SalesReceipt extends QuickBooks_QBXML_Object
 	{
 		return $this->get('ClassRef ListID');
 	}
-	
+
 	public function setClassApplicationID($value)
 	{
 		return $this->set('ClassRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_CLASS, QUICKBOOKS_LISTID, $value));
@@ -223,7 +223,7 @@ class QuickBooks_QBXML_Object_SalesReceipt extends QuickBooks_QBXML_Object
 
 	/**
 	 * Set the application ID for the shipping method
-	 * 
+	 *
 	 * @param mixed $value		The shipping method primary key from your application
 	 * @return 					boolean
 	 */
@@ -231,30 +231,30 @@ class QuickBooks_QBXML_Object_SalesReceipt extends QuickBooks_QBXML_Object
 	{
 		return $this->set('ShipMethodRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_SHIPMETHOD, QUICKBOOKS_LISTID, $value));
 	}
-	
+
 	public function setShipMethodName($name)
 	{
 		return $this->set('ShipMethodRef FullName', $name);
 	}
-	
+
 	public function setShipMethodListID($ListID)
 	{
 		return $this->set('ShipMethodRef ListID', $ListID);
 	}
-	
+
 	public function getShipMethodName()
 	{
 		return $this->get('ShipMethodRef FullName');
 	}
-	
+
 	public function getShipMethodListID()
 	{
 		return $this->get('ShipMethodRef ListID');
 	}
-	
-	/** 
+
+	/**
 	 * Set an invoice as pending
-	 * 
+	 *
 	 * @param boolean $pending
 	 * @return boolean
 	 */
@@ -262,22 +262,22 @@ class QuickBooks_QBXML_Object_SalesReceipt extends QuickBooks_QBXML_Object
 	{
 		return $this->setBooleanType('IsPending', $pending);
 	}
-	
+
 	public function getIsPending()
 	{
 		return $this->getBooleanType('IsPending');
 	}
-	
+
 	public function setCheckNumber($check)
 	{
 		return $this->set('CheckNumber', $check);
 	}
-	
+
 	public function getCheckNumber()
 	{
 		return $this->get('CheckNumber');
 	}
-	
+
 	public function setPaymentMethodApplicationID($value)
 	{
 		return $this->set('PaymentMethodRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_PAYMENTMETHOD, QUICKBOOKS_LISTID, $value));
@@ -287,37 +287,37 @@ class QuickBooks_QBXML_Object_SalesReceipt extends QuickBooks_QBXML_Object
 	{
 		return $this->get('PaymentMethodRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function setPaymentMethodListID($ListID)
 	{
 		return $this->set('PaymentMethodRef ListID', $ListID);
 	}
-	
+
 	public function setPaymentMethodName($name)
 	{
 		return $this->set('PaymentMethodRef FullName', $name);
 	}
-	
+
 	public function getPaymentMethodListID()
 	{
 		return $this->get('PaymentMethodRef ListID');
 	}
-	
+
 	public function getPaymentMethodName()
 	{
 		return $this->get('PaymentMethodRef FullName');
 	}
-	
+
 	public function setDueDate($date)
 	{
 		return $this->setDateType('DueDate', $date);
 	}
-	
+
 	public function getDueDate($format = null)
 	{
 		return $this->getDateType('DueDate', $format);
 	}
-	
+
 	public function setSalesRepApplicationID($value)
 	{
 		return $this->set('SalesRepRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_SALESREP, QUICKBOOKS_LISTID, $value));
@@ -327,97 +327,97 @@ class QuickBooks_QBXML_Object_SalesReceipt extends QuickBooks_QBXML_Object
 	{
 		return $this->get('SalesRepRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function setSalesRepListID($ListID)
 	{
 		return $this->set('SalesRepRef ListID', $ListID);
 	}
-	
+
 	public function setSalesRepName($name)
 	{
 		return $this->set('SalesRepRef FullName', $name);
 	}
-	
+
 	public function getSalesRepListID()
 	{
 		return $this->get('SalesRepRef ListID');
 	}
-	
+
 	public function getSalesRepName()
 	{
 		return $this->get('SalesRepRef FullName');
-	}	
-	
-	
-	
+	}
+
+
+
 	public function setIsToBePrinted($printed)
 	{
 		return $this->setBooleanType('IsToBePrinted', $printed);
 	}
-	
+
 	public function getIsToBePrinted()
 	{
 		return $this->getBooleanType('IsToBePrinted');
 	}
-	
+
 	public function setIsToBeEmailed($emailed)
 	{
 		return $this->setBooleanType('IsToBeEmailed', $emailed);
 	}
-	
+
 	public function getIsToBeEmailed()
 	{
 		return $this->getBooleanType('IsToBeEmailed');
 	}
-	
+
 	/**
 	 * Get the ship method application ID
-	 * 
+	 *
 	 * @return value
 	 */
 	public function getShipMethodApplicationID()
 	{
 		return $this->extractApplicationID($this->get('ShipMethodRef ' . QUICKBOOKS_API_APPLICATIONID));
 	}
-	
+
 	public function setDepositToAccountApplicationID($value)
 	{
 		return $this->set('DepositToAccountRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_ACCOUNT, QUICKBOOKS_LISTID, $value));
 	}
-	
+
 	public function setDepositToAccountListID($ListID)
 	{
 		return $this->set('DepositToAccountRef ListID', $ListID);
 	}
-	
+
 	public function setDepositToAccountName($name)
 	{
 		return $this->set('DepositToAccountRef FullName', $name);
 	}
-	
+
 	public function getDepositToAccountListID()
 	{
 		return $this->get('DepositToAccountRef ListID');
 	}
-	
+
 	public function getDepositToAccountName()
 	{
 		return $this->get('DepositToAccountRef FullName');
 	}
-	
+
 	/**
 	 * Get the ARAccount application ID
-	 * 
+	 *
 	 * @return value
 	 */
 	public function getDepositToAccountApplicationID()
 	{
 		return $this->extractApplicationID($this->get('DepositToAccountRef ' . QUICKBOOKS_API_APPLICATIONID));
-	}	
-	
+	}
+
 	/**
 	 * Set the transaction date
-	 * 
+	 *
 	 * @param string $date
 	 * @return boolean
 	 */
@@ -428,13 +428,13 @@ class QuickBooks_QBXML_Object_SalesReceipt extends QuickBooks_QBXML_Object
 		{
 			$date = date('Y-m-d', strtotime($date));
 		}
-		
+
 		return $this->set('TxnDate', $date);
 		*/
-		
+
 		return $this->setDateType('TxnDate', $date);
 	}
-	
+
 	/**
 	 * Alias of {@link QuickBooks_Object_Invoice::setTxnDate()}
 	 */
@@ -447,7 +447,7 @@ class QuickBooks_QBXML_Object_SalesReceipt extends QuickBooks_QBXML_Object
 	{
 		return $this->getDateType('TxnDate', $format);
 	}
-	
+
 	public function getTransactionDate($format = null)
 	{
 		return $this->getTxnDate($format);
@@ -455,7 +455,7 @@ class QuickBooks_QBXML_Object_SalesReceipt extends QuickBooks_QBXML_Object
 
 	/**
 	 * Set the shipping date
-	 * 
+	 *
 	 * @param string $date
 	 * @return boolean
 	 */
@@ -466,29 +466,29 @@ class QuickBooks_QBXML_Object_SalesReceipt extends QuickBooks_QBXML_Object
 		{
 			$date = date('Y-m-d', strtotime($date));
 		}
-		
+
 		return $this->set('ShipDate', $date);
 		*/
-		
+
 		return $this->setDateType('ShipDate', $date);
 	}
-		
+
 	/**
 	 * Get the shipping date
-	 * 
+	 *
 	 * @param string $format	The format you want the date in (as for {@link http://www.php.net/date})
 	 * @return string
 	 */
 	public function getShipDate($format = null)
 	{
 		//return date($format, strtotime($this->get('ShipDate')));
-		
+
 		return $this->getDateType('ShipDate', $format);
 	}
-	
+
 	/**
 	 * Set the reference number
-	 * 
+	 *
 	 * @param string $str
 	 * @return boolean
 	 */
@@ -499,34 +499,34 @@ class QuickBooks_QBXML_Object_SalesReceipt extends QuickBooks_QBXML_Object
 
 	/**
 	 * Get the reference number
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getRefNumber()
 	{
 		return $this->get('RefNumber');
 	}
-		
+
 	public function setMemo($memo)
 	{
 		return $this->set('Memo', $memo);
 	}
-	
+
 	public function getMemo()
 	{
 		return $this->get('Memo');
 	}
-	
+
 	public function getFOB()
 	{
 		return $this->get('FOB');
 	}
-	
+
 	public function setFOB($fob)
 	{
 		return $this->set('FOB', $fob);
 	}
-	
+
 	public function setLinkToTxnID($TxnID)
 	{
 		return $this->set('LinkToTxnID', $TxnID);
@@ -536,39 +536,39 @@ class QuickBooks_QBXML_Object_SalesReceipt extends QuickBooks_QBXML_Object
   {
     return $this->get('LinkToTxnID');
   }
-	
+
 	/**
-	 * 
-	 * 
-	 * @param 
+	 *
+	 *
+	 * @param
 	 */
 	public function addSalesReceiptLine($obj)
 	{
 		$lines = $this->get('SalesReceiptLine');
 		$lines[] = $obj;
-		
+
 		return $this->set('SalesReceiptLine', $lines);
 	}
-	
+
 	/**
-	 * 
+	 *
 	 */
 	public function getSalesReceiptLines()
 	{
 		return $this->getList('SalesReceiptLine');
 	}
-	
+
 	/**
-	 * 
+	 *
 	 */
 	public function getSalesReceiptLine($i)
 	{
 		return $this->getListItem('SalesReceiptLine', $i);
 	}
-	
+
 	/**
 	 * Add a discount line (only supported by Online Edition as of 8.0)
-	 * 
+	 *
 	 * @param QuickBooks_Object_SalesReceipt_DiscountLine
 	 * @return boolean
 	 */
@@ -579,7 +579,7 @@ class QuickBooks_QBXML_Object_SalesReceipt extends QuickBooks_QBXML_Object
 
 	/**
 	 * Add a shipping line (only supported by Online Edition as of 8.0)
-	 * 
+	 *
 	 * @param QuickBooks_Object_SalesReceipt_SalesTaxLine
 	 * @return boolean
 	 */
@@ -587,10 +587,10 @@ class QuickBooks_QBXML_Object_SalesReceipt extends QuickBooks_QBXML_Object
 	{
 		return $this->addListItem('SalesTaxLine', $obj);
 	}
-	
+
 	/**
 	 * Add a shipping line (only supported by Online Edition as of 8.0)
-	 * 
+	 *
 	 * @param QuickBooks_Object_SalesReceipt_ShippingLine
 	 * @return boolean
 	 */
@@ -598,10 +598,10 @@ class QuickBooks_QBXML_Object_SalesReceipt extends QuickBooks_QBXML_Object
 	{
 		return $this->addListItem('ShippingLine', $obj);
 	}
-		
+
 	/**
 	 * Get an shipping address as an array (or a specific portion of the address as a string)
-	 * 
+	 *
 	 * @param string $part			A specific portion of the address to get (i.e. "Addr1" or "State")
 	 * @param array $defaults		Default values if a value isn't filled in
 	 * @return array				The address
@@ -612,13 +612,13 @@ class QuickBooks_QBXML_Object_SalesReceipt extends QuickBooks_QBXML_Object
 		{
 			return $this->get('ShipAddress ' . $part);
 		}
-		
+
 		return $this->getArray('ShipAddress *', $defaults);
 	}
-	
+
 	/**
 	 * Set the shipping address for the invoice
-	 * 
+	 *
 	 * @param string $addr1			Address line 1
 	 * @param string $addr2			Address line 2
 	 * @param string $addr3			Address line 3
@@ -638,18 +638,18 @@ class QuickBooks_QBXML_Object_SalesReceipt extends QuickBooks_QBXML_Object
 		{
 			$this->set('ShipAddress Addr' . $i, ${'addr' . $i});
 		}
-		
+
 		$this->set('ShipAddress City', $city);
 		$this->set('ShipAddress State', $state);
 		$this->set('ShipAddress Province', $province);
 		$this->set('ShipAddress PostalCode', $postalcode);
 		$this->set('ShipAddress Country', $country);
-		$this->set('ShipAddress Note', $note);  
+		$this->set('ShipAddress Note', $note);
 	}
-	
+
 	/**
-	 * Get the billing address 
-	 * 
+	 * Get the billing address
+	 *
 	 * @param string $part			A specific portion of the address to get (i.e. "Addr1" or "State")
 	 * @param array $defaults		Default values if a value isn't filled in
 	 * @return array				The address
@@ -660,13 +660,13 @@ class QuickBooks_QBXML_Object_SalesReceipt extends QuickBooks_QBXML_Object
 		{
 			return $this->get('BillAddress ' . $part);
 		}
-		
+
 		return $this->getArray('BillAddress *', $defaults);
 	}
-	
+
 	/**
 	 * Set the billing address for the invoice
-	 * 
+	 *
 	 * @param string $addr1			Address line 1
 	 * @param string $addr2			Address line 2
 	 * @param string $addr3			Address line 3
@@ -686,101 +686,90 @@ class QuickBooks_QBXML_Object_SalesReceipt extends QuickBooks_QBXML_Object
 		{
 			$this->set('BillAddress Addr' . $i, ${'addr' . $i});
 		}
-		
+
 		$this->set('BillAddress City', $city);
 		$this->set('BillAddress State', $state);
 		$this->set('BillAddress Province', $province);
 		$this->set('BillAddress PostalCode', $postalcode);
 		$this->set('BillAddress Country', $country);
-		$this->set('BillAddress Note', $note);  
+		$this->set('BillAddress Note', $note);
 	}
-		
+
 	public function setOther($other)
 	{
 		return $this->set('Other', $other);
 	}
-	
+
 	public function getOther()
 	{
 		return $this->get('Other');
 	}
-		
-	/**
-	 * 
-	 * 
-	 * @return boolean
-	 */
-	protected function _cleanup()
-	{
-		
-		return true;
-	}
-	
+
 	public function asList($request)
 	{
 		switch ($request)
 		{
 			case 'SalesReceiptAddRq':
-				
+
 				if (isset($this->_object['SalesReceiptLine']))
 				{
 					$this->_object['SalesReceiptLineAdd'] = $this->_object['SalesReceiptLine'];
 				}
-				
+
 				if (isset($this->_object['ShippingLine']))
 				{
 					$this->_object['ShippingLineAdd'] = $this->_object['ShippingLine'];
-				}				
+				}
 
 				if (isset($this->_object['SalesTaxLine']))
 				{
 					$this->_object['SalesTaxLineAdd'] = $this->_object['SalesTaxLine'];
-				}				
+				}
 
 				if (isset($this->_object['DiscountLine']))
 				{
 					$this->_object['DiscountLineAdd'] = $this->_object['DiscountLine'];
-				}				
-				
+				}
+
 				break;
 			case 'SalesReceiptModRq':
-				
+
 				if (isset($this->_object['SalesReceiptLine']))
 				{
-					$this->_object['SalesReceiptLineMod'] = $this->_object['SalesReceiptLine'];	
+					$this->_object['SalesReceiptLineMod'] = $this->_object['SalesReceiptLine'];
 				}
-				
+
 				break;
 		}
-		
+
 		return parent::asList($request);
 	}
-	
+
 	public function asXML($root = null, $parent = null, $object = null)
 	{
 		//print('INVOICE got called asXML: ' . $root . ', ' . $parent . "\n");
 		//print('sales receipt got called as: {' . $root . '}, {' . QUICKBOOKS_ADD_SALESRECEIPT . "}\n");
 		//exit;
-		
+
 		if (is_null($object))
 		{
 			$object = $this->_object;
 		}
-		
+
 		switch ($root)
 		{
 			case QUICKBOOKS_ADD_SALESRECEIPT:
-				
+
 				//if (isset($this->_object['InvoiceLine']))
 				//{
 				//	$this->_object['InvoiceLineAdd'] = $this->_object['InvoiceLine'];
 				//}
-				
+
 				foreach ($object['SalesReceiptLineAdd'] as $key => $obj)
 				{
 					$obj->setOverride('SalesReceiptLineAdd');
 				}
-			
+
 				if (!empty($object['ShippingLineAdd']))
 				{
 					foreach ($object['ShippingLineAdd'] as $key => $obj)
@@ -788,7 +777,7 @@ class QuickBooks_QBXML_Object_SalesReceipt extends QuickBooks_QBXML_Object
 						$obj->setOverride('ShippingLineAdd');
 					}
 				}
-				
+
 				if (!empty($object['DiscountLineAdd']))
 				{
 					foreach ($object['DiscountLineAdd'] as $key => $obj)
@@ -796,7 +785,7 @@ class QuickBooks_QBXML_Object_SalesReceipt extends QuickBooks_QBXML_Object
 						$obj->setOverride('DiscountLineAdd');
 					}
 				}
-				
+
 				if (!empty($object['SalesTaxLineAdd']))
 				{
 					foreach ($object['SalesTaxLineAdd'] as $key => $obj)
@@ -804,7 +793,7 @@ class QuickBooks_QBXML_Object_SalesReceipt extends QuickBooks_QBXML_Object
 						$obj->setOverride('SalesTaxLineAdd');
 					}
 				}
-				
+
 				break;
 			case QUICKBOOKS_MOD_SALESRECEIPT:
 				if (isset($object['SalesReceiptLine']))
@@ -813,40 +802,15 @@ class QuickBooks_QBXML_Object_SalesReceipt extends QuickBooks_QBXML_Object
 				}
 				break;
 		}
-		
+
 		//print_r($this->_object);
-		
+
 		return parent::asXML($root, $parent, $object);
 	}
-	
-	/**
-	 * 
-	 */
-	public function asArray($request, $nest = true)
-	{
-		$this->_cleanup();
-		
-		return parent::asArray($request, $nest);
-	}
-	
-	/**
-	 * 
-	 * 
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $version = null, $locale = null, $root = null, $parent = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $version, $locale, $root);
-	}
-	
+
 	/**
 	 * Tell the type of object this is
-	 * 
+	 *
 	 * @return string
 	 */
 	public function object()

--- a/QuickBooks/QBXML/Object/SalesRep.php
+++ b/QuickBooks/QBXML/Object/SalesRep.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * QuickBooks SalesRep object container
- * 
+ *
  * @author Adam Heinz <amh@metricwise.net>
  * @license LICENSE.txt
- * 
+ *
  * @package QuickBooks
  * @subpackage Object
  */
@@ -21,7 +21,7 @@ class QuickBooks_QBXML_Object_SalesRep extends QuickBooks_QBXML_Object
 {
 	/**
 	 * Create a new QuickBooks_Object_SalesRep object
-	 * 
+	 *
 	 * @param array $arr
 	 */
 	public function __construct($arr = array())
@@ -39,7 +39,7 @@ class QuickBooks_QBXML_Object_SalesRep extends QuickBooks_QBXML_Object
 	{
 		return $this->set('Initial', $value);
 	}
-	
+
 	/**
 	 * Get the initials of this sales rep
 	 *
@@ -49,7 +49,7 @@ class QuickBooks_QBXML_Object_SalesRep extends QuickBooks_QBXML_Object
 	{
 		return $this->get('Initial');
 	}
-	
+
 	/**
 	 * Set this sales rep active or not
 	 *
@@ -60,7 +60,7 @@ class QuickBooks_QBXML_Object_SalesRep extends QuickBooks_QBXML_Object
 	{
 		return $this->set('IsActive', (boolean) $value);
 	}
-	
+
 	/**
 	 * Get whether or not this sales rep is active
 	 *
@@ -79,7 +79,7 @@ class QuickBooks_QBXML_Object_SalesRep extends QuickBooks_QBXML_Object
 	{
 		return $this->set('SalesRepEntityRef ListID', $lid);
 	}
-	
+
 	/**
 	 * @param string $name
 	 * @return boolean
@@ -90,36 +90,8 @@ class QuickBooks_QBXML_Object_SalesRep extends QuickBooks_QBXML_Object
 	}
 
 	/**
-	 * Returns the sales rep object as an array
+	 * Tell what type of object this is
 	 *
-	 * @return array
-	 */
-	public function asArray($request, $nest = true)
-	{
-		$this->_cleanup();
-		
-		return parent::asArray($request, $nest);
-	}
-	
-	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $version = null, $locale = null, $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $version = null, $locale = null, $root);
-	}
-	
-	/**
-	 * Tell what type of object this is 
-	 * 
 	 * @return string
 	 */
 	public function object()

--- a/QuickBooks/QBXML/Object/SalesTaxGroupItem.php
+++ b/QuickBooks/QBXML/Object/SalesTaxGroupItem.php
@@ -2,48 +2,48 @@
 
 /**
  * QuickBooks ServiceItem object container
- * 
+ *
  * @author Keith Palmer <keith@consolibyte.com>
- * @license LICENSE.txt 
- * 
+ * @license LICENSE.txt
+ *
  * @package QuickBooks
  * @subpackage Object
  */
 
 /**
- * 
+ *
  */
 QuickBooks_Loader::load('/QuickBooks/QBXML/Object.php');
 
 /**
- * 
+ *
  */
 QuickBooks_Loader::load('/QuickBooks/QBXML/Object/SalesTaxGroupItem/ItemSalesTaxRef.php');
 
 /**
- * 
+ *
  */
 class QuickBooks_QBXML_Object_SalesTaxGroupItem extends QuickBooks_QBXML_Object
 {
 	public function __construct($arr = array())
 	{
 		parent::__construct($arr);
-		
+
 		// These two things occur because it's a repeatable element who name doesn't do the *Add, *Mod, *Ret thing, trash these
 		if (isset($this->_object['ItemSalesTaxRef FullName']))
 		{
 			unset($this->_object['ItemSalesTaxRef FullName']);
 		}
-		
+
 		if (isset($this->_object['ItemSalesTaxRef ListID']))
 		{
 			unset($this->_object['ItemSalesTaxRef ListID']);
 		}
 	}
-	
+
 	/**
 	 * Set the ListID for this item
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return boolean
 	 */
@@ -51,20 +51,20 @@ class QuickBooks_QBXML_Object_SalesTaxGroupItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('ListID', $ListID);
 	}
-	
+
 	/**
 	 * Get the ListID for this item
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getListID()
 	{
 		return $this->get('ListID');
 	}
-	
+
 	/**
 	 * Set the name for this item
-	 * 
+	 *
 	 * @param string $name
 	 * @return boolean
 	 */
@@ -72,42 +72,42 @@ class QuickBooks_QBXML_Object_SalesTaxGroupItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('Name', $name);
 	}
-	
+
 	public function getIsActive()
 	{
 		return $this->getBooleanType('IsActive', true);
 	}
-	
+
 	public function setIsActive($IsActive)
 	{
 		return $this->setBooleanType('IsActive', $IsActive);
 	}
-		
+
 	/**
 	 * Get the name for this item
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getName()
 	{
 		return $this->get('Name');
 	}
-	
+
 	public function setItemDesc($desc)
 	{
 		return $this->set('ItemDesc', $desc);
 	}
-	
+
 	public function getItemDesc($desc)
 	{
 		return $this->get('ItemDesc', $desc);
 	}
-	
+
 	public function setDescription($desc)
 	{
 		return $this->set('ItemDesc', $desc);
 	}
-	
+
 	public function getDescription()
 	{
 		return $this->get('ItemDesc');
@@ -117,34 +117,20 @@ class QuickBooks_QBXML_Object_SalesTaxGroupItem extends QuickBooks_QBXML_Object
 	{
 		return $this->addListItem('ItemSalesTaxRef', $obj);
 	}
-	
+
 	public function getItemSalesTaxRef($i)
 	{
 		return $this->getListItem('ItemSalesTaxRef', $i);
 	}
-	
+
 	public function listItemSalesTaxRefs()
 	{
 		return $this->getList('ItemSalesTaxRef');
 	}
-	
+
 	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $version = null, $locale = null, $root = null)
-	{
-		return parent::asQBXML($request, $version, $locale, $root);
-	}
-	
-	/**
-	 * Tell what type of object this is 
-	 * 
+	 * Tell what type of object this is
+	 *
 	 * @return string
 	 */
 	public function object()

--- a/QuickBooks/QBXML/Object/SalesTaxItem.php
+++ b/QuickBooks/QBXML/Object/SalesTaxItem.php
@@ -2,26 +2,26 @@
 
 /**
  * QuickBooks ServiceItem object container
- * 
- * NOTE: By default, ServiceItems are created as SalesOrPurchase items, and are 
- * thus *NOT* created as SalesAndPurchase items. If you want to create an item 
+ *
+ * NOTE: By default, ServiceItems are created as SalesOrPurchase items, and are
+ * thus *NOT* created as SalesAndPurchase items. If you want to create an item
  * that is sold *and* purchased, you'll need to set the type with the method:
  * 	-> {@link QuickBooks_Object_ServiceItem::isSalesAndPurchase()}
- * 
+ *
  * @author Keith Palmer <keith@consolibyte.com>
- * @license LICENSE.txt 
- * 
+ * @license LICENSE.txt
+ *
  * @package QuickBooks
  * @subpackage Object
  */
 
 /**
- * 
+ *
  */
 QuickBooks_Loader::load('/QuickBooks/QBXML/Object.php');
 
 /**
- * 
+ *
  */
 class QuickBooks_QBXML_Object_SalesTaxItem extends QuickBooks_QBXML_Object
 {
@@ -29,10 +29,10 @@ class QuickBooks_QBXML_Object_SalesTaxItem extends QuickBooks_QBXML_Object
 	{
 		parent::__construct($arr);
 	}
-	
+
 	/**
 	 * Set the ListID for this item
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return boolean
 	 */
@@ -40,20 +40,20 @@ class QuickBooks_QBXML_Object_SalesTaxItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('ListID', $ListID);
 	}
-	
+
 	/**
 	 * Get the ListID for this item
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getListID()
 	{
 		return $this->get('ListID');
 	}
-	
+
 	/**
 	 * Set the name for this item
-	 * 
+	 *
 	 * @param string $name
 	 * @return boolean
 	 */
@@ -61,63 +61,63 @@ class QuickBooks_QBXML_Object_SalesTaxItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('Name', $name);
 	}
-	
+
 	public function getIsActive()
 	{
 		return $this->getBooleanType('IsActive', true);
 	}
-	
+
 	public function setIsActive($IsActive)
 	{
 		return $this->setBooleanType('IsActive', $IsActive);
 	}
-	
+
 	/**
 	 * Get the name for this item
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getName()
 	{
 		return $this->get('Name');
 	}
-	
+
 	public function setTaxRate($rate)
 	{
 		return $this->set('TaxRate', (float) $rate);
 	}
-	
+
 	public function getTaxRate()
 	{
 		return $this->get('TaxRate');
 	}
-	
+
 	public function setDescription($desc)
 	{
 		return $this->set('ItemDesc', $desc);
 	}
-	
+
 	public function getDescription()
 	{
 		return $this->get('ItemDesc');
 	}
-	
+
 	public function setTaxVendorListID($ListID)
 	{
 		return $this->set('TaxVendorRef ListID', $ListID);
 	}
-	
+
 	public function setTaxVendorName($name)
 	{
 		return $this->set('TaxVendorRef FullName', $name);
 	}
-	
+
 	// @todo Make sure these are ->setFullNameType instead of just ->set
 	public function setTaxVendorFullName($FullName)
 	{
 		return $this->set('TaxVendorRef FullName', $FullName);
 	}
-	
+
 	public function setTaxVendorApplicationID($value)
 	{
 		return $this->set('TaxVendorRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_VENDOR, QUICKBOOKS_LISTID, $value));
@@ -127,63 +127,25 @@ class QuickBooks_QBXML_Object_SalesTaxItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('TaxVendorRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function getTaxVendorListID()
 	{
 		return $this->get('TaxVendorRef ListID');
 	}
-	
+
 	public function getTaxVendorName()
 	{
 		return $this->get('TaxVendorRef FullName');
 	}
-	
+
 	public function getTaxVendorFullName()
 	{
 		return $this->get('TaxVendorRef FullName');
 	}
-	
+
 	/**
-	 * 
-	 * 
-	 * @return boolean
-	 */
-	protected function _cleanup()
-	{
-		
-		
-		return true;
-	}
-	
-	/**
-	 * 
-	 */
-	public function asArray($request, $nest = true)
-	{
-		$this->_cleanup();
-		
-		return parent::asArray($request, $nest);
-	}
-	
-	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
-	 * Tell what type of object this is 
-	 * 
+	 * Tell what type of object this is
+	 *
 	 * @return string
 	 */
 	public function object()

--- a/QuickBooks/QBXML/Object/ServiceItem.php
+++ b/QuickBooks/QBXML/Object/ServiceItem.php
@@ -2,15 +2,15 @@
 
 /**
  * QuickBooks ServiceItem object container
- * 
- * NOTE: By default, ServiceItems are created as SalesOrPurchase items, and are 
- * thus *NOT* created as SalesAndPurchase items. If you want to create an item 
+ *
+ * NOTE: By default, ServiceItems are created as SalesOrPurchase items, and are
+ * thus *NOT* created as SalesAndPurchase items. If you want to create an item
  * that is sold *and* purchased, you'll need to set the type with the method:
  * 	-> {@link QuickBooks_Object_ServiceItem::isSalesAndPurchase()}
- * 
+ *
  * @author Keith Palmer <keith@consolibyte.com>
- * @license LICENSE.txt 
- * 
+ * @license LICENSE.txt
+ *
  * @package QuickBooks
  * @subpackage Object
  */
@@ -21,7 +21,7 @@
 QuickBooks_Loader::load('/QuickBooks/QBXML/Object.php');
 
 /**
- * QuickBooks ServiceItem object 
+ * QuickBooks ServiceItem object
  */
 class QuickBooks_QBXML_Object_ServiceItem extends QuickBooks_QBXML_Object
 {
@@ -29,25 +29,25 @@ class QuickBooks_QBXML_Object_ServiceItem extends QuickBooks_QBXML_Object
 	 * Flag indicating whether or not this for sales *AND* purchase, or just sales *OR* purchase
 	 */
 	protected $_is_sales_and_purchase;
-	
+
 	/**
 	 * Create a new QuickBooks_Object_ServiceItem object (ServiceItem)
 	 */
 	public function __construct($arr = array(), $is_sales_and_purchase = false)
 	{
 		parent::__construct($arr);
-		
+
 		if (count($this->getArray('SalesAndPurchase')) > 0)
 		{
 			$is_sales_and_purchase = true;
 		}
-		
+
 		$this->_is_sales_and_purchase = $is_sales_and_purchase;
 	}
-	
+
 	/**
 	 * Set the ListID for this item
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return boolean
 	 */
@@ -55,20 +55,20 @@ class QuickBooks_QBXML_Object_ServiceItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('ListID', $ListID);
 	}
-	
+
 	/**
 	 * Get the ListID for this item
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getListID()
 	{
 		return $this->get('ListID');
 	}
-	
+
 	/**
 	 * Set the name for this item
-	 * 
+	 *
 	 * @param string $name
 	 * @return boolean
 	 */
@@ -76,101 +76,101 @@ class QuickBooks_QBXML_Object_ServiceItem extends QuickBooks_QBXML_Object
 	{
 		return $this->setNameType('Name', $name);
 	}
-	
+
 	/**
 	 * Get the name for this item
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getName()
 	{
 		return $this->get('Name');
 	}
-	
+
 	public function setFullName($fullname)
 	{
 		return $this->setFullNameType('FullName', 'Name', 'ParentRef FullName', $fullname);
 	}
-	
+
 	public function getFullName()
 	{
 		return $this->getFullNameType('FullName', 'Name', 'ParentRef FullName');
 	}
-	
+
 	public function setIsActive($active)
 	{
-		if (strtolower($active) == 'true' or 
+		if (strtolower($active) == 'true' or
 			(is_bool($active) and $active))
 		{
 			return $this->set('IsActive', 'true');
 		}
-		
+
 		return $this->set('IsActive', 'false');
 	}
-	
+
 	public function getIsActive()
 	{
 		$active = $this->get('IsActive');
-		
-		return strtolower($active) == 'true' or 
+
+		return strtolower($active) == 'true' or
 			(is_bool($active) and $active);
 	}
-	
+
 	public function setParentListID($ListID)
 	{
 		return $this->set('ParentRef ListID', $ListID);
 	}
-	
+
 	public function setParentName($name)
 	{
 		return $this->set('ParentRef FullName', $name);
 	}
-	
+
 	public function setParentApplicationID($value)
 	{
 		return $this->set('ParentRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_ITEM, QUICKBOOKS_LISTID, $value));
 	}
-	
+
 	public function getParentListID()
 	{
-		return $this->get('ParentRef ListID');	
+		return $this->get('ParentRef ListID');
 	}
-	
+
 	public function getParentName()
 	{
 		return $this->get('ParentRef FullName');
 	}
-	
+
 	public function getParentApplicationID()
 	{
 		return $this->extractApplicationID($this->get('ParentRef ' . QUICKBOOKS_API_APPLICATIONID));
 	}
-	
+
 	public function setSalesTaxCodeListID($ListID)
 	{
 		return $this->set('SalesTaxCodeRef ListID', $ListID);
 	}
-	
+
 	public function setSalesTaxCodeName($name)
 	{
 		return $this->set('SalesTaxCodeRef FullName', $name);
 	}
-	
+
 	public function setSalesTaxCodeApplicationID($value)
 	{
 		return $this->set('SalesTaxCodeRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_SALESTAXCODE, QUICKBOOKS_LISTID, $value));
 	}
-	
+
 	public function getSalesTaxCodeListID()
 	{
 		return $this->get('SalesTaxCodeRef ListID');
 	}
-	
+
 	public function getSalesTaxCodeName()
 	{
 		return $this->get('SalesTaxCodeRef FullName');
 	}
-	
+
 	public function getSalesTaxCodeApplicationID()
 	{
 		return $this->extractApplicationID($this->get('SalesTaxCodeRef ' . QUICKBOOKS_API_APPLICATIONID));
@@ -180,53 +180,53 @@ class QuickBooks_QBXML_Object_ServiceItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('UnitOfMeasureSetRef ListID');
 	}
-	
+
 	public function getUnitOfMeasureSetFullName()
 	{
 		return $this->get('UnitOfMeasureSetRef FullName');
 	}
-	
+
 	/**
 	 * Tell (and optionally set) whether or not this item is currently for Sale *and* Purchase
-	 * 
+	 *
 	 * @param boolean $enable
 	 * @return boolean
 	 */
 	public function isSalesAndPurchase($enable = null)
 	{
 		$current = $this->_is_sales_and_purchase;
-		
+
 		if (!is_null($enable))
 		{
 			$this->_is_sales_and_purchase = (boolean) $enable;
 		}
-		
+
 		return $current;
 	}
-	
+
 	/**
 	 * Tell (and optionall set) whether or not this item is currently for Sale *or* Purchase
-	 * 
+	 *
 	 * @param boolean $enable
 	 * @return boolean
 	 */
 	public function isSalesOrPurchase($enable = null)
 	{
 		$current = !$this->_is_sales_and_purchase;
-		
+
 		if (!is_null($enable))
 		{
 			$this->_is_sales_and_purchase = ! (boolean) $enable;
-		} 
-		
+		}
+
 		return $current;
 	}
-	
+
 	// Sales OR Purchase
-	
+
 	/**
 	 * Set the description of this item (Sales OR Purchase)
-	 * 
+	 *
 	 * @param string $descrip
 	 * @return boolean
 	 */
@@ -239,20 +239,20 @@ class QuickBooks_QBXML_Object_ServiceItem extends QuickBooks_QBXML_Object
   {
     return $this->get('SalesOrPurchase Desc');
   }
-	
+
 	/**
 	 * Set the price for this item (Sales OR Purchase)
-	 * 
+	 *
 	 * @param string $price
 	 * @return boolean
 	 */
 	public function setPrice($price)
 	{
 		$this->remove('SalesOrPurchase PricePercent');
-		
+
 		return $this->set('SalesOrPurchase Price', sprintf('%01.2f', (float) $price));
 	}
-	
+
 	/**
 	 * Get the price for this item (Sales OR Purchase)
 	 */
@@ -260,30 +260,30 @@ class QuickBooks_QBXML_Object_ServiceItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('SalesOrPurchase Price');
 	}
-	
+
 	/**
 	 * Set the price percent for this item (Sales OR Purchase)
 	 */
 	public function setPricePercent($percent)
 	{
 		$this->remove('SalesOrPurchase Price');
-		
+
 		return $this->set('SalesOrPurchase PricePercent', $percent);
 	}
-	
+
 	/**
 	 * Get the price percent for this item (Sales OR Purchase)
-	 * 
+	 *
 	 * @return float
 	 */
 	public function getPricePercent()
 	{
 		return $this->get('SalesOrPurchase PricePercent');
 	}
-	
+
 	/**
 	 * Set the account ListID for this item (Sales OR Purchase)
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return boolean
 	 */
@@ -291,10 +291,10 @@ class QuickBooks_QBXML_Object_ServiceItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('SalesOrPurchase AccountRef ListID', $ListID);
 	}
-	
+
 	/**
 	 * Set the account name for this item (Sales OR Purchase)
-	 * 
+	 *
 	 * @param string $name
 	 * @return boolean
 	 */
@@ -302,12 +302,12 @@ class QuickBooks_QBXML_Object_ServiceItem extends QuickBooks_QBXML_Object
 	{
 		return $this->set('SalesOrPurchase AccountRef FullName', $name);
 	}
-	
+
 	public function setAccountFullName($name)
 	{
 		return $this->set('SalesOrPurchase AccountRef FullName', $name);
 	}
-	
+
 	/**
 	 * (Sales OR Purchase)
 	 */
@@ -320,17 +320,17 @@ class QuickBooks_QBXML_Object_ServiceItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('SalesOrPurchase AccountRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	/**
 	 * Get the account ListID for this item (Sales OR Purchase)
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getAccountListID()
 	{
 		return $this->get('SalesOrPurchase AccountRef ListID');
 	}
-	
+
 	/**
 	 * @deprecated
 	 */
@@ -341,46 +341,46 @@ class QuickBooks_QBXML_Object_ServiceItem extends QuickBooks_QBXML_Object
 
 	/**
 	 * Get the account name for this item (Sales OR Purchase)
-	 * 
-	 * @return string 
+	 *
+	 * @return string
 	 */
 	public function getAccountFullName()
 	{
 		return $this->get('SalesOrPurchase AccountRef FullName');
 	}
-	
+
 	// Sales AND Purchase
-	
+
 	public function setSalesDescription($descrip)
 	{
 		return $this->set('SalesAndPurchase SalesDesc', $descrip);
 	}
-	
+
 	public function getSalesDescription()
 	{
 		return $this->get('SalesAndPurchase SalesDesc');
 	}
-	
+
 	public function setSalesPrice($price)
 	{
 		return $this->set('SalesAndPurchase SalesPrice', sprintf('%01.2f', (float) $price));
 	}
-	
+
 	public function getSalesPrice()
 	{
 		return $this->get('SalesAndPurchase SalesPrice');
 	}
-	
+
 	public function setIncomeAccountListID($ListID)
 	{
 		return $this->set('SalesAndPurchase IncomeAccountRef ListID', $ListID);
 	}
-	
+
 	public function getIncomeAccountListID()
 	{
 		return $this->get('SalesAndPurchase IncomeAccountRef ListID');
 	}
-	
+
 	/**
 	 * @deprecated
 	 */
@@ -393,7 +393,7 @@ class QuickBooks_QBXML_Object_ServiceItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('SalesAndPurchase IncomeAccountRef FullName');
 	}
-	
+
 	/**
 	 * @deprecated
 	 */
@@ -401,7 +401,7 @@ class QuickBooks_QBXML_Object_ServiceItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('SalesAndPurchase IncomeAccountRef FullName');
 	}
-	
+
 	public function setIncomeAccountApplicationID($value)
 	{
 		return $this->set('SalesAndPurchase IncomeAccountRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_ACCOUNT, QUICKBOOKS_LISTID, $value));
@@ -411,37 +411,37 @@ class QuickBooks_QBXML_Object_ServiceItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('SalesAndPurchase IncomeAccountRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function setPurchaseDescription($descrip)
 	{
 		return $this->set('SalesAndPurchase PurchaseDesc', $descrip);
 	}
-	
+
 	public function getPurchaseDescription()
 	{
 		return $this->get('SalesAndPurchase PurchaseDesc');
 	}
-	
+
 	public function setPurchaseCost($cost)
 	{
 		return $this->set('SalesAndPurchase PurchaseCost', sprintf('%01.2f', (float) $cost));
 	}
-	
+
 	public function getPurchaseCost()
 	{
 		return $this->get('SalesAndPurchase PurchaseCost');
 	}
-	
+
 	public function setExpenseAccountListID($ListID)
 	{
 		return $this->set('SalesAndPurchase ExpenseAccountRef ListID', $ListID);
 	}
-	
+
 	public function setExpenseAccountName($name)
 	{
 		return $this->set('SalesAndPurchase ExpenseAccountRef FullName', $name);
 	}
-	
+
 	public function setExpenseAccountApplicationID($value)
 	{
 		return $this->set('SalesAndPurchase ExpenseAccountRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_ACCOUNT, QUICKBOOKS_LISTID, $value));
@@ -451,27 +451,27 @@ class QuickBooks_QBXML_Object_ServiceItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('SalesAndPurchase ExpenseAccountRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function getExpenseAccountListID()
 	{
 		return $this->get('SalesAndPurchase ExpenseAccountRef ListID');
 	}
-	
+
 	public function getExpenseAccountName()
 	{
 		return $this->get('SalesAndPurchase ExpenseAccountRef FullName');
 	}
-	
+
 	public function setPreferredVendorListID($ListID)
 	{
 		return $this->set('SalesAndPurchase PrefVendorRef ListID', $ListID);
 	}
-	
+
 	public function setPreferredVendorName($name)
 	{
 		return $this->set('SalesAndPurchase PrefVendorRef FullName', $name);
 	}
-	
+
 	public function setPreferredVendorApplicationID($value)
 	{
 		return $this->set('SalesAndPurchase PrefVendorRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_VENDOR, QUICKBOOKS_LISTID, $value));
@@ -481,20 +481,20 @@ class QuickBooks_QBXML_Object_ServiceItem extends QuickBooks_QBXML_Object
 	{
 		return $this->get('SalesAndPurchase PrefVendorRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	public function getPreferredVendorListID()
 	{
 		return $this->get('SalesAndPurchase PrefVendorRef ListID');
 	}
-	
+
 	public function getPreferredVendorName()
 	{
 		return $this->get('SalesAndPurchase PrefVendorRef FullName');
 	}
-	
+
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 * @return boolean
 	 */
 	protected function _cleanup()
@@ -502,7 +502,7 @@ class QuickBooks_QBXML_Object_ServiceItem extends QuickBooks_QBXML_Object
 		if ($this->isSalesAndPurchase())
 		{
 			// Remove any SalesOrPurchase keys
-			
+
 			foreach ($this->getArray('SalesOrPurchase*') as $key => $value)
 			{
 				$this->remove($key);
@@ -515,39 +515,23 @@ class QuickBooks_QBXML_Object_ServiceItem extends QuickBooks_QBXML_Object
 				$this->remove($key);
 			}
 		}
-		
+
 		return true;
 	}
-	
+
 	/**
-	 * 
+	 *
 	 */
 	public function asArray($request, $nest = true)
 	{
 		$this->_cleanup();
-		
+
 		return parent::asArray($request, $nest);
 	}
-	
+
 	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $version = null, $locale = null, $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $version, $locale, $root);
-	}
-	
-	/**
-	 * Tell what type of object this is 
-	 * 
+	 * Tell what type of object this is
+	 *
 	 * @return string
 	 */
 	public function object()

--- a/QuickBooks/QBXML/Object/ShipMethod.php
+++ b/QuickBooks/QBXML/Object/ShipMethod.php
@@ -2,37 +2,37 @@
 
 /**
  * QuickBooks ShipMethod object container
- * 
+ *
  * @author Keith Palmer <keith@consolibyte.com>
  * @license LICENSE.txt
- * 
+ *
  * @package QuickBooks
  * @subpackage Object
  */
 
 /**
- * 
+ *
  */
 QuickBooks_Loader::load('/QuickBooks/QBXML/Object.php');
 
 /**
- * 
+ *
  */
 class QuickBooks_QBXML_Object_ShipMethod extends QuickBooks_QBXML_Object
 {
 	/**
 	 * Create a new QuickBooks_Object_ShipMethod object
-	 * 
+	 *
 	 * @param array $arr
 	 */
 	public function __construct($arr = array())
 	{
 		parent::__construct($arr);
 	}
-	
+
 	/**
 	 * Set the ListID of the shipping method
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return boolean
 	 */
@@ -40,20 +40,20 @@ class QuickBooks_QBXML_Object_ShipMethod extends QuickBooks_QBXML_Object
 	{
 		return $this->set('ListID', $ListID);
 	}
-	
+
 	/**
 	 * Get the ListID of the shipping method
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getListID()
 	{
 		return $this->get('ListID');
 	}
-	
+
 	/**
 	 * Set the name of the shipping method
-	 * 
+	 *
 	 * @param string $name
 	 * @return boolean
 	 */
@@ -61,20 +61,20 @@ class QuickBooks_QBXML_Object_ShipMethod extends QuickBooks_QBXML_Object
 	{
 		return $this->set('Name', $name);
 	}
-	
+
 	/**
 	 * Get the name of the shipping method
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getName()
 	{
 		return $this->get('Name');
 	}
-	
+
 	/**
 	 * Set this shipping method as active or not
-	 * 
+	 *
 	 * @param boolean $value
 	 * @return boolean
 	 */
@@ -82,93 +82,53 @@ class QuickBooks_QBXML_Object_ShipMethod extends QuickBooks_QBXML_Object
 	{
 		return $this->setBooleanType('IsActive', $value);
 	}
-	
+
 	/**
 	 * Tell whether or not this shipping method is active
-	 * 
+	 *
 	 * @return boolean
 	 */
 	public function getIsActive()
 	{
 		return $this->getBooleanType('IsActive');
 	}
-	
+
 	/**
-	 * 
+	 *
 	 */
 	public function setParentListID($ListID)
 	{
 		return $this->set('ParentRef ListID', $ListID);
 	}
-	
+
 	public function getParentListID()
 	{
 		return $this->get('ParentRef ListID');
 	}
-	
+
 	public function setParentFullName($value)
 	{
 		return $this->set('ParentRef FullName', $value);
 	}
-	
+
 	public function getParentFullName()
 	{
 		return $this->get('ParentRef FullName');
 	}
-	
+
 	public function setParentApplicationID($value)
 	{
 		return $this->set('ParentRef ' . QUICKBOOKS_API_APPLICATIONID, $this->encodeApplicationID(QUICKBOOKS_OBJECT_ACCOUNT, QUICKBOOKS_LISTID, $value));
 	}
-	
+
 	public function getParentApplicationID()
 	{
 		return $this->get('ParentRef ' . QUICKBOOKS_API_APPLICATIONID);
 	}
-	
+
 	/**
-	 * Perform any needed clean-up of the object data members
-	 * 
-	 * @return boolean
-	 */
-	protected function _cleanup()
-	{
-		return true;
-	}
-	
-	/**
-	 * Get an array representation of this shipping method object
-	 * 
-	 * @param string $request
-	 * @param boolean $nest
-	 * @return array
-	 */
-	public function asArray($request, $nest = true)
-	{
-		$this->_cleanup();
-		
-		return parent::asArray($request, $nest);
-	}
-	
-	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $version = null, $locale = null, $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $version = null, $locale = null, $root);
-	}
-	
-	/**
-	 * Tell what type of object this is 
-	 * 
+	 * Tell what type of object this is
+	 *
 	 * @return string
 	 */
 	public function object()

--- a/QuickBooks/QBXML/Object/StandardTerms.php
+++ b/QuickBooks/QBXML/Object/StandardTerms.php
@@ -2,10 +2,10 @@
 
 /**
  * QuickBooks StandardTerms object container
- * 
+ *
  * @author Keith Palmer <keith@consolibyte.com>
  * @license LICENSE.txt
- * 
+ *
  * @package QuickBooks
  * @subpackage Object
  */
@@ -22,17 +22,17 @@ class QuickBooks_QBXML_Object_StandardTerms extends QuickBooks_QBXML_Object
 {
 	/**
 	 * Create a new QuickBooks_Object_StandardTerms object
-	 * 
+	 *
 	 * @param array $arr
 	 */
 	public function __construct($arr = array())
 	{
 		parent::__construct($arr);
 	}
-	
+
 	/**
 	 * Set the ListID of the termspwd
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return boolean
 	 */
@@ -40,20 +40,20 @@ class QuickBooks_QBXML_Object_StandardTerms extends QuickBooks_QBXML_Object
 	{
 		return $this->set('ListID', $ListID);
 	}
-	
+
 	/**
 	 * Get the ListID of the terms
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getListID()
 	{
 		return $this->get('ListID');
 	}
-	
+
 	/**
 	 * Set the name of the terms
-	 * 
+	 *
 	 * @param string $name
 	 * @return boolean
 	 */
@@ -61,20 +61,20 @@ class QuickBooks_QBXML_Object_StandardTerms extends QuickBooks_QBXML_Object
 	{
 		return $this->set('Name', $name);
 	}
-	
+
 	/**
 	 * Get the name of these terms
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getName()
 	{
 		return $this->get('Name');
 	}
-	
+
 	/**
 	 * Set this as active or not
-	 * 
+	 *
 	 * @param boolean $value
 	 * @return boolean
 	 */
@@ -82,27 +82,27 @@ class QuickBooks_QBXML_Object_StandardTerms extends QuickBooks_QBXML_Object
 	{
 		return $this->set('IsActive', (boolean) $value);
 	}
-	
+
 	/**
 	 * Tell whether or not this class object is active
-	 * 
+	 *
 	 * @return boolean
 	 */
 	public function getIsActive()
 	{
 		return $this->get('IsActive');
 	}
-	
+
 	/**
 	 * Get the number of days until payment is due
-	 * 
+	 *
 	 * @return integer
 	 */
 	public function getStdDueDays()
 	{
 		return $this->get('StdDueDays');
 	}
-	
+
 	/**
 	 * Alias of QuickBooks_Object_StandardTerms::getStdDueDays()
 	 */
@@ -110,7 +110,7 @@ class QuickBooks_QBXML_Object_StandardTerms extends QuickBooks_QBXML_Object
 	{
 		return $this->getStdDueDays();
 	}
-	
+
 	/**
 	 * Set the number of days until payment is due
 	 *
@@ -121,7 +121,7 @@ class QuickBooks_QBXML_Object_StandardTerms extends QuickBooks_QBXML_Object
 	{
 		return $this->set('StdDueDays', (int) $days);
 	}
-	
+
 	/**
 	 * Alias of QuickBooks_Object_StandardTerms::setStdDueDays()
 	 */
@@ -129,93 +129,53 @@ class QuickBooks_QBXML_Object_StandardTerms extends QuickBooks_QBXML_Object
 	{
 		return $this->setStdDueDays($days);
 	}
-	
+
 	/**
-	 * 
+	 *
 	 */
 	public function getStdDiscountDays()
 	{
 		return $this->get('StdDiscountDays');
 	}
-	
+
 	public function getStandardDiscountDays()
 	{
 		return $this->getStdDiscountDays();
 	}
-	
+
 	public function setStdDiscountDays($days)
 	{
 		return $this->set('StdDiscountDays', (int) $days);
 	}
-	
+
 	public function setStandardDiscountDays($days)
 	{
 		return $this->setStdDiscountDays($days);
 	}
-	
+
 	public function getDiscountPct()
 	{
 		return $this->get('DiscountPct');
 	}
-	
+
 	public function getDiscountPercent()
 	{
 		return $this->getDiscountPct();
 	}
-	
+
 	public function setDiscountPercent($percent)
 	{
 		return $this->setDiscountPct($percent);
 	}
-	
+
 	public function setDiscountPct($percent)
 	{
 		return $this->set('DiscountPct', (float) $percent);
-	}	
-	
-	/**
-	 * Perform any needed clean-up of the object data members
-	 * 
-	 * @return boolean
-	 */
-	protected function _cleanup()
-	{
-		return true;
 	}
-	
+
 	/**
-	 * Get an array representation of this Class object
-	 * 
-	 * @param string $request
-	 * @param boolean $nest
-	 * @return array
-	 */
-	public function asArray($request, $nest = true)
-	{
-		$this->_cleanup();
-		
-		return parent::asArray($request, $nest);
-	}
-	
-	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
-	 * Tell what type of object this is 
-	 * 
+	 * Tell what type of object this is
+	 *
 	 * @return string
 	 */
 	public function object()

--- a/QuickBooks/QBXML/Object/Vendor.php
+++ b/QuickBooks/QBXML/Object/Vendor.php
@@ -2,37 +2,37 @@
 
 /**
  * QuickBooks Vendor object container
- * 
+ *
  * @author Keith Palmer <keith@consolibyte.com>
- * @license LICENSE.txt 
- * 
+ * @license LICENSE.txt
+ *
  * @package QuickBooks
  * @subpackage Object
  */
 
 /**
- * 
+ *
  */
 QuickBooks_Loader::load('/QuickBooks/QBXML/Object.php');
 
 /**
- * 
+ *
  */
 class QuickBooks_QBXML_Object_Vendor extends QuickBooks_QBXML_Object
 {
 	/**
 	 * Create a new QuickBooks_Object_Account object
-	 * 
+	 *
 	 * @param array $arr
 	 */
 	public function __construct($arr = array())
 	{
 		parent::__construct($arr);
 	}
-	
+
 	/**
 	 * Set the ListID of the Class
-	 * 
+	 *
 	 * @param string $ListID
 	 * @return boolean
 	 */
@@ -40,20 +40,20 @@ class QuickBooks_QBXML_Object_Vendor extends QuickBooks_QBXML_Object
 	{
 		return $this->set('ListID', $ListID);
 	}
-	
+
 	/**
 	 * Get the ListID of the Class
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getListID()
 	{
 		return $this->get('ListID');
 	}
-	
+
 	/**
 	 * Set the name of the class
-	 * 
+	 *
 	 * @param string $name
 	 * @return boolean
 	 */
@@ -61,19 +61,19 @@ class QuickBooks_QBXML_Object_Vendor extends QuickBooks_QBXML_Object
 	{
 		return $this->set('Name', $name);
 	}
-	
+
 	/**
 	 * Get the name of the class
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getName()
 	{
 		return $this->get('Name');
 	}
-	
+
 	/**
-	 * 
+	 *
 	 */
 	public function getFullName()
 	{
@@ -84,10 +84,10 @@ class QuickBooks_QBXML_Object_Vendor extends QuickBooks_QBXML_Object
 	{
 		return $this->set('FullName', $name);
 	}
-	
+
 	/**
 	 * Set this Class active or not
-	 * 
+	 *
 	 * @param boolean $value
 	 * @return boolean
 	 */
@@ -95,30 +95,30 @@ class QuickBooks_QBXML_Object_Vendor extends QuickBooks_QBXML_Object
 	{
 		return $this->set('IsActive', (boolean) $value);
 	}
-	
+
 	/**
 	 * Tell whether or not this class object is active
-	 * 
+	 *
 	 * @return boolean
 	 */
 	public function getIsActive()
 	{
 		return $this->get('IsActive');
 	}
-	
+
 	public function setCompanyName($name)
 	{
 		return $this->set('CompanyName', $name);
 	}
-	
+
 	public function getCompanyName()
 	{
 		return $this->get('CompanyName');
 	}
-	
+
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 * @param string $name
 	 * @return boolean
 	 */
@@ -126,20 +126,20 @@ class QuickBooks_QBXML_Object_Vendor extends QuickBooks_QBXML_Object
 	{
 		return $this->set('FirstName', $fname);
 	}
-	
+
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 * @return string
 	 */
 	public function getFirstName()
 	{
 		return $this->get('FirstName');
 	}
-	
+
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 * @param string $lname
 	 * @return boolean
 	 */
@@ -147,56 +147,56 @@ class QuickBooks_QBXML_Object_Vendor extends QuickBooks_QBXML_Object
 	{
 		return $this->set('LastName', $lname);
 	}
-	
+
 	public function getLastName()
 	{
 		return $this->get('LastName');
 	}
-	
+
 	public function setMiddleName($mname)
 	{
 		return $this->set('MiddleName', $mname);
 	}
-	
+
 	public function getMiddleName()
 	{
 		return $this->get('MiddleName');
 	}
-	
+
 	public function getVendorAddress($part = null, $defaults = array())
 	{
 		return $this->_getXYZAddress('Vendor', '', $part, $defaults);
 	}
-	
+
 	public function setVendorAddress($addr1, $addr2 = '', $addr3 = '', $addr4 = '', $addr5 = '', $city = '', $state = '', $postalcode = '', $country = '', $note = '')
 	{
-		return $this->_setXYZAddress('Vendor', '', $addr1, $addr2, $addr3, $addr4, $addr5, $city, $state, $postalcode, $country, $note);	
+		return $this->_setXYZAddress('Vendor', '', $addr1, $addr2, $addr3, $addr4, $addr5, $city, $state, $postalcode, $country, $note);
 	}
-	
+
 	protected function _setXYZAddress($pre, $post, $addr1, $addr2, $addr3, $addr4, $addr5, $city, $state, $postalcode, $country, $note)
 	{
 		for ($i = 1; $i <= 5; $i++)
 		{
 			$this->set($pre . 'Address' . $post . ' Addr' . $i, ${'addr' . $i});
 		}
-		
+
 		$this->set($pre . 'Address' . $post . ' City', $city);
 		$this->set($pre . 'Address' . $post . ' State', $state);
 		$this->set($pre . 'Address' . $post . ' PostalCode', $postalcode);
 		$this->set($pre . 'Address' . $post . ' Country', $country);
-		$this->set($pre . 'Address' . $post . ' Note', $note);		
+		$this->set($pre . 'Address' . $post . ' Note', $note);
 	}
-	
+
 	protected function _getXYZAddress($pre, $post, $part = null, $defaults = array())
 	{
 		if (!is_null($part))
 		{
 			return $this->get($pre . 'Address' . $post . ' ' . $part);
 		}
-		
+
 		return $this->getArray($pre . 'Address' . $post . ' *', $defaults);
 	}
-	
+
 	public function setPhone($phone)
 	{
 		return $this->set('Phone', $phone);
@@ -206,10 +206,10 @@ class QuickBooks_QBXML_Object_Vendor extends QuickBooks_QBXML_Object
 	{
 		return $this->get('Phone');
 	}
-	
+
 	/**
 	 * Set the alternate phone number for this customer
-	 * 
+	 *
 	 * @param string $phone
 	 * @return boolean
 	 */
@@ -225,15 +225,15 @@ class QuickBooks_QBXML_Object_Vendor extends QuickBooks_QBXML_Object
 
 	/**
 	 * Set the fax number for this customer
-	 * 
+	 *
 	 * @param string $fax
-	 * @return boolean 
+	 * @return boolean
 	 */
 	public function setFax($fax)
 	{
 		return $this->set('Fax', $fax);
 	}
-	
+
 	public function getFax()
 	{
 		return $this->get('Fax');
@@ -241,7 +241,7 @@ class QuickBooks_QBXML_Object_Vendor extends QuickBooks_QBXML_Object
 
 	/**
 	 * Set the e-mail address for this customer
-	 * 
+	 *
 	 * @param string $email
 	 * @return boolean
 	 */
@@ -254,10 +254,10 @@ class QuickBooks_QBXML_Object_Vendor extends QuickBooks_QBXML_Object
 	{
 		return $this->get('Email');
 	}
-	
+
 	/**
 	 * Set the contact person for this customer
-	 * 
+	 *
 	 * @param string $contact
 	 * @return boolean
 	 */
@@ -270,10 +270,10 @@ class QuickBooks_QBXML_Object_Vendor extends QuickBooks_QBXML_Object
 	{
 		return $this->get('Contact');
 	}
-	
+
 	/**
 	 * Set the alternate contact for this customer
-	 * 
+	 *
 	 * @param string $contact
 	 * @return boolean
 	 */
@@ -286,10 +286,10 @@ class QuickBooks_QBXML_Object_Vendor extends QuickBooks_QBXML_Object
 	{
 		return $this->get('AltContact');
 	}
-	
+
 	/**
 	 * Set the salutation for this customer
-	 * 
+	 *
 	 * @param string $salut
 	 * @return boolean
 	 */
@@ -297,60 +297,20 @@ class QuickBooks_QBXML_Object_Vendor extends QuickBooks_QBXML_Object
 	{
 		return $this->set('Salutation', $salut);
 	}
-	
+
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 * @return string
 	 */
 	public function getSalutation()
 	{
 		return $this->get('Salutation');
 	}
-	
+
 	/**
-	 * Perform any needed clean-up of the object data members
-	 * 
-	 * @return boolean
-	 */
-	protected function _cleanup()
-	{
-		return true;
-	}
-	
-	/**
-	 * Get an array representation of this Class object
-	 * 
-	 * @param string $request
-	 * @param boolean $nest
-	 * @return array
-	 */
-	public function asArray($request, $nest = true)
-	{
-		$this->_cleanup();
-		
-		return parent::asArray($request, $nest);
-	}
-	
-	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
-	 * Tell what type of object this is 
-	 * 
+	 * Tell what type of object this is
+	 *
 	 * @return string
 	 */
 	public function object()


### PR DESCRIPTION
… the calling sequence of

QuickBooks_QBXML_Object::asQBXML() recently changed, and a constant was moved:
QUICKBOOKS_OBJECT_XML_DROP -> QuickBooks_XML::XML_DROP.  However, QuickBooks_QBXML_Object_Vendor::asQBXML
still had the old definition and referenced the old constant, which no longer existed, resulting
in an error (which would have been ignored in environments with STRICT error reporting off).  Upon
further examination I realized that the asQBXML, asArray, and _cleanup methods in
QuickBooks_QBXML_Object_Vendor actually didn't do anything anyway but just deferred everything
to the parent.  As a result, I fixed this by simply removing all three method from QuickBooks_QBXML_Object_Vendor.
I checked and noticed that many classes had this same problem, so I went through all of them and removed
asQBXML, asArray, and _cleanup only when I could safely do so (i.e. only when they had no functionality of their
own and were simply deferring to the parent class).

It doesn't look like you have any tests to run to make sure I didn't accidentally break anything, and
I don't have any quick ways to check all of these methods.  However I went through my changes carefully,
so hopefully this commit will work without issue for you: please double check my work.

Also, I realized at push time that my editor was still configured to automatically strip extraneous whitespace from the end of lines.  This is why so many lines are changed.  If this is a problem I can re-apply my changes without the auto-trimming of whitespace.