### PR TITLE
Fix charset in Content-Type header on php>5.6

### DIFF
--- a/QuickBooks/WebConnector/Server.php
+++ b/QuickBooks/WebConnector/Server.php
@@ -312,6 +312,10 @@ class QuickBooks_WebConnector_Server
 	 */
 	protected function _headers()
 	{
+		// php > 5.6 automatically adds charset=UTF-8 to content-type header which breaks web connector
+		// We need to make sure default_charset is null
+		$defaultCharset = ini_get('default_charset');
+		ini_set('default_charset', null);
 		if ($_SERVER['REQUEST_METHOD'] == 'POST')
 		{
 			header('Content-Type: text/xml');
@@ -324,6 +328,9 @@ class QuickBooks_WebConnector_Server
 		{
 			header('Content-Type: text/plain');
 		}
+		
+		ini_set('default_charset', $defaultCharset);
+
 		
 		return true;
 	}


### PR DESCRIPTION
Quickbooks webconnector will not accept any Content-Type header other than 'text/xml' without this change or updating php.ini web connector fails with expecting 'text/xml' got 'text/xml;charset=UTF-8'

See https://www.saotn.org/php-56-default_charset-change-may-break-html-output/ for more info about the change in php