### PR TITLE
allow specifying which QBXML errors should be fatal

### DIFF
--- a/QuickBooks/WebConnector/Handlers.php
+++ b/QuickBooks/WebConnector/Handlers.php
@@ -320,6 +320,8 @@ class QuickBooks_WebConnector_Handlers
 			'deny_reallyfast_timeout' => 600,
 
 			'masking' => true,
+
+			'status_error_threshold' => 1, // the lowest status code considered an error
 			);
 
 		$config = array_merge($defaults, $config);
@@ -346,6 +348,8 @@ class QuickBooks_WebConnector_Handlers
 
 		$config['deny_reallyfast_logins'] = (boolean) $config['deny_reallyfast_logins'];
 		$config['deny_reallyfast_timeout'] = (int) max(1, $config['deny_reallyfast_timeout']);
+
+		$config['status_error_threshold'] = (int) max(1, $config['status_error_threshold']);
 
 		return $config;
 	}
@@ -1287,8 +1291,9 @@ class QuickBooks_WebConnector_Handlers
 			$this->_log('Incoming XML response: ' . $obj->response, $obj->ticket, QUICKBOOKS_LOG_DEBUG);
 
 			// Check if we got a error message...
-			if (strlen($obj->message) or
-				$this->_extractStatusCode($obj->response)) // or an error code
+			if (strlen($obj->message) or 
+				$this->_extractStatusCode($obj->response)
+					>= $this->_config['status_error_threshold']) // or an error code
 			{
 				//$this->_log('Extracted code[' . $this->_extractStatusCode($obj->response) . ']', $obj->ticket, QUICKBOOKS_LOG_DEBUG);
 


### PR DESCRIPTION
Currently any nonzero status code received in the XML sent to `receiveResponseXML` is considered a fatal error and the QBWC session is torn down. That's incorrect according to the QBXML documentation, which says that codes 1-499 are informational and 500-999 are warnings. This adds a new configuration key, `status_error_threshold`, which is the minimum status code which should be considered a fatal error. To preserve reverse compatibility the default is set to 1.