### PR TITLE
Serialize if not array or object so error_log doesn't fire off.

### DIFF
--- a/QuickBooks/Driver/Sql.php
+++ b/QuickBooks/Driver/Sql.php
@@ -1051,7 +1051,7 @@ abstract class QuickBooks_Driver_Sql extends QuickBooks_Driver
 			}
 		}
 
-		if ($extra)
+		if (is_array($extra) || is_object($extra))
 		{
 			$extra = serialize($extra);
 		}


### PR DESCRIPTION
$extra is false if it's an empty array, so this never fires off and _escape complains that it's an array.