### PR TITLE
Avoid naming conflict with other package

### DIFF
--- a/QuickBooks/Loader.php
+++ b/QuickBooks/Loader.php
@@ -98,7 +98,7 @@ class QuickBooks_Loader
 	 */
 	static public function __autoload($name)
 	{
-		if (substr($name, 0, 10) == 'QuickBooks')
+		if (substr($name, 0, 10) == 'QuickBooks' && substr($name, 0, 16) != 'QuickBooksOnline')
 		{
 			$file = '/' . str_replace('_', DIRECTORY_SEPARATOR, $name) . '.php';
 			QuickBooks_Loader::load($file, false);


### PR DESCRIPTION
The autoloader currently tries to load files from [another package](https://github.com/intuit/QuickBooks-V3-PHP-SDK) which is namespaced `QuickBooksOnline`.

This patch guarantees that the loader will only load files from this package.