### PR TITLE
fixes: Parameter must be an array or an object that implements Countable

### DIFF
--- a/QuickBooks/HTTP.php
+++ b/QuickBooks/HTTP.php
@@ -479,7 +479,7 @@ class QuickBooks_HTTP
 		}
 
 		$query = '';
-		if (count($this->_get))
+		if (isset($this->_get) && count($this->_get))
 		{
 			$query = '?' . http_build_query($this->_get);
 		}


### PR DESCRIPTION
fixes the warning:

`Parameter must be an array or an object that implements Countable`

Thanks,
Kim