### PR TITLE
Fixed bug in sqlite3::initialized where it always returned false because of checks for non-existing tables

### DIFF
--- a/QuickBooks/Driver/Sql/Sqlite3.php
+++ b/QuickBooks/Driver/Sql/Sqlite3.php
@@ -248,15 +248,12 @@ class QuickBooks_Driver_Sql_Sqlite3 extends QuickBooks_Driver_Sql
     protected function _initialized()
     {
         $required = array(
-            $this->_mapTableName(QUICKBOOKS_DRIVER_SQL_IDENTTABLE) => false,
             $this->_mapTableName(QUICKBOOKS_DRIVER_SQL_TICKETTABLE) => false,
             $this->_mapTableName(QUICKBOOKS_DRIVER_SQL_USERTABLE) => false,
             $this->_mapTableName(QUICKBOOKS_DRIVER_SQL_RECURTABLE) => false,
             $this->_mapTableName(QUICKBOOKS_DRIVER_SQL_QUEUETABLE) => false,
             $this->_mapTableName(QUICKBOOKS_DRIVER_SQL_LOGTABLE) => false,
             $this->_mapTableName(QUICKBOOKS_DRIVER_SQL_CONFIGTABLE) => false,
-            $this->_mapTableName(QUICKBOOKS_DRIVER_SQL_NOTIFYTABLE) => false,
-            $this->_mapTableName(QUICKBOOKS_DRIVER_SQL_CONNECTIONTABLE) => false,
         );
 
         $errnum = 0;


### PR DESCRIPTION
The method `sqlite3::initialized` always returned false because it was checking for non-existing tables. So let's make things consistent.