### PR TITLE
Case of class names should match files names.

### DIFF
--- a/QuickBooks/Adapter/Server/Php.php
+++ b/QuickBooks/Adapter/Server/Php.php
@@ -24,7 +24,7 @@ QuickBooks_Loader::load('/QuickBooks/Adapter/Server.php');
 /**
  * 
  */
-class QuickBooks_Adapter_Server_PHP implements QuickBooks_Adapter_Server
+class QuickBooks_Adapter_Server_Php implements QuickBooks_Adapter_Server
 {
 	protected $_server;
 	

--- a/QuickBooks/Encryption/Aes.php
+++ b/QuickBooks/Encryption/Aes.php
@@ -20,7 +20,7 @@ QuickBooks_Loader::load('/QuickBooks/Encryption.php');
 /**
  * 
  */
-class QuickBooks_Encryption_AES extends QuickBooks_Encryption
+class QuickBooks_Encryption_Aes extends QuickBooks_Encryption
 {
 	static function encrypt($key, $plain, $salt = null)
 	{

--- a/QuickBooks/Map/Qbxml.php
+++ b/QuickBooks/Map/Qbxml.php
@@ -15,7 +15,7 @@ QuickBooks_Loader::load('/QuickBooks/Map.php');
 
 QuickBooks_Loader::load('/QuickBooks/Driver/Factory.php');
 
-class QuickBooks_Map_QBXML extends QuickBooks_Map
+class QuickBooks_Map_Qbxml extends QuickBooks_Map
 {
 	protected $_driver;
 	


### PR DESCRIPTION
Fixes three cases where the class name does not match the file structure.

Solves Issue https://github.com/consolibyte/quickbooks-php/issues/170 and PR https://github.com/consolibyte/quickbooks-php/pull/180 (The 2nd commit on PR 180 is already in tree via https://github.com/consolibyte/quickbooks-php/commit/e164cffbf8e31c77c40a3ffb57a753f2c4f8d238).
