### PR TITLE
Missing arguments in enableUser and disableUser.

### DIFF
--- a/QuickBooks/Driver/Sql.php
+++ b/QuickBooks/Driver/Sql.php
@@ -676,7 +676,7 @@ abstract class QuickBooks_Driver_Sql extends QuickBooks_Driver
 				status = '" . QUICKBOOKS_USER_ENABLED . "',
 				touch_datetime = '" . date('Y-m-d H:i:s') . "'
 			WHERE
-				qb_username = '" . $this->_escape($username) . "' ");
+				qb_username = '" . $this->_escape($username) . "' ", $errnum, $errmsg);
 	}
 
 	/**
@@ -697,7 +697,7 @@ abstract class QuickBooks_Driver_Sql extends QuickBooks_Driver
 				status = '" . QUICKBOOKS_USER_DISABLED . "',
 				touch_datetime = '" . date('Y-m-d H:i:s') . "'
 			WHERE
-				qb_username = '" . $this->_escape($username) . "' ");
+				qb_username = '" . $this->_escape($username) . "' ", $errnum, $errmsg);
 	}
 
 	/**


### PR DESCRIPTION
The _query method requires references to $errnum and $errmsg in addition to the sql.