### PR TITLE
Update IPP.php for math error, README_OAUTHV1_TO_OAUTHV2.md additions

### DIFF
--- a/QuickBooks/IPP.php
+++ b/QuickBooks/IPP.php
@@ -875,7 +875,7 @@ class QuickBooks_IPP
 		if (!$attempted_renew and
 			is_object($this->_driver) and
 			$this->_authmode == QuickBooks_IPP::AUTHMODE_OAUTHV2 and
-			strtotime($this->_authcred['oauth_access_expiry']) + 60 < time())
+			strtotime($this->_authcred['oauth_access_expiry']) - 60 < time())
 		{
 			$attempted_renew = true;
 

--- a/README_OAUTHV1_TO_OAUTHV2.md
+++ b/README_OAUTHV1_TO_OAUTHV2.md
@@ -23,11 +23,13 @@ Anywhere you see this:
 new QuickBooks_IPP_IntuitAnywhere($dsn, $encryption_key, $oauth_consumer_key, $oauth_consumer_secret, $quickbooks_oauth_url, $quickbooks_success_url);
 ```
 
-Needs to change to this (note hte new parameters):
+Needs to change to this (note the new parameters):
 
 ```
 new QuickBooks_IPP_IntuitAnywhere(QuickBooks_IPP_IntuitAnywhere::OAUTH_V2, $sandbox, $scope, $dsn, $encryption_key, $oauth_client_id, $oauth_client_secret, $quickbooks_oauth_url, $quickbooks_success_url);
 ```
+
+`$scope` can be 'com.intuit.quickbooks.accounting', 'com.intuit.quickbooks.payment', or 'com.intuit.quickbooks.accounting com.intuit.quickbooks.payment' for access to both.
 
 ## Database changes
 
@@ -85,7 +87,7 @@ if ($IntuitAnywhere->check($the_username, $the_tenant)
 To this:
 
 ```
-if ($IntuitAnywhere->check($the_username, $the_tenant)
+if ($IntuitAnywhere->check($the_tenant)
 ```
 
 ## Code change - IntuitAnywhere->test(...)
@@ -93,7 +95,7 @@ if ($IntuitAnywhere->check($the_username, $the_tenant)
 The `->test(...)` method has changed, dropping the `$the_username` parameter. Change:
 
 ```
-$IntuitAnywhere->test($the_tenant))
+$IntuitAnywhere->test($the_username, $the_tenant))
 ```
 
 To this:
@@ -101,6 +103,24 @@ To this:
 ```
 $IntuitAnywhere->test($the_tenant))
 ```
+
+## Code change - IntuitAnywhere->handle(...)
+
+The `->handle(...)` method has changed, dropping the `$the_username` parameter. Change:
+
+```
+$IntuitAnywhere->handle($the_username, $the_tenant))
+```
+
+To this:
+
+```
+$IntuitAnywhere->handle($the_tenant))
+```
+
+## Code change - IntuitAnywhere->expiry(...), IntuitAnywhere->reconnect(...), IntuitAnywhere->disconnect(...)
+
+Calls to the `->expiry(...)`, `->reconnect(...)`, and `->disconnect(...)` methods are no longer necessary. OAuthV2 token refreshes are done automatically before every API call if the time-to-live of the Access Token is less than 60 seconds. Also, calls to these methods will fail, as they call the old `->oauthLoad(...)` method, which no longer exists in the drivers (it has been updated to `->oauthLoadV1(...)` and `->oauthLoadV2(...)`). See #269 and #271 for discussion.
 
 ## Code change - IPP->authMode(...)
 


### PR DESCRIPTION
In IPP.php:
Fixed sign (+ to -) bug for token renewal/expiry calculation. With + , token would need to be expired for 61 seconds before it will be renewed, not 60 seconds left, as intended.

In README:
Fixed a typo and a copy/paste error.
Added a line about what the value of $scope can be.
Added section about parameter change for IntuitAnywhere->handle(...)
Added section about calls to IntuitAnywhere->expiry(...), IntuitAnywhere->reconnect(...), IntuitAnywhere->disconnect(...) no longer being necessary.
