### PR TITLE
Remove Curly Braces

### DIFF
--- a/QuickBooks/Cast.php
+++ b/QuickBooks/Cast.php
@@ -1,14 +1,14 @@
 <?php
 
-/** 
+/**
  * Casts to cast data types to QuickBooks qbXML values and fit values in qbXML fields
- * 
+ *
  * Copyright (c) 2010 Keith Palmer / ConsoliBYTE, LLC.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.opensource.org/licenses/eclipse-1.0.php
- * 
+ *
  * @package QuickBooks
  * @subpackage Cast
  */
@@ -20,25 +20,25 @@ class QuickBooks_Cast
 {
 	static public function datatype($type_or_action, $field)
 	{
-		
+
 	}
-	
+
 	static public function maxlength($type_or_action, $field)
 	{
-		
+
 	}
-	
+
 	/**
 	 * Make sure all characters are ASCII (and thus will work with UTF-8)
-	 * 
-	 * We have a lot of content that gets pasted in from Microsoft Word, which 
-	 * often generates some very wierd characters, which seem to not always 
-	 * convert correctly to UTF-8 and then get rejected by the QuickBooks Web 
-	 * Connector. This method tries to make sure that everything that should 
-	 * get converted gets converted, and gets converted cleanly. 
-	 * 
-	 * There is probably a better way to do this...  
-	 *  
+	 *
+	 * We have a lot of content that gets pasted in from Microsoft Word, which
+	 * often generates some very wierd characters, which seem to not always
+	 * convert correctly to UTF-8 and then get rejected by the QuickBooks Web
+	 * Connector. This method tries to make sure that everything that should
+	 * get converted gets converted, and gets converted cleanly.
+	 *
+	 * There is probably a better way to do this...
+	 *
 	 * @param string $str	The string to convert to ASCII
 	 * @return string
 	 */
@@ -47,145 +47,145 @@ class QuickBooks_Cast
 	{
 		// These extended ASCII characters get mapped to things in the normal ASCII character set
 		$replace = array(
-			chr(129) => 'u', 
-			chr(130) => 'e', 
-			chr(131) => 'a', 
-			chr(132) => 'a', 
+			chr(129) => 'u',
+			chr(130) => 'e',
+			chr(131) => 'a',
+			chr(132) => 'a',
 			chr(133) => 'a',
 			chr(134) => 'a',
-			chr(136) => 'e', 
-			chr(137) => 'e', 
-			chr(138) => 'e', 
-			chr(139) => 'i', 
-			chr(140) => 'i', 
-			chr(141) => 'i', 
-			chr(142) => 'A', 
-			chr(143) => 'A', 
-			chr(144) => 'E', 
-			chr(145) => 'ae', 
-			chr(146) => 'AE', 
-			chr(147) => 'o', 
-			chr(148) => 'o', 
-			chr(149) => 'o', 
-			chr(150) => 'u', 
-			chr(151) => 'u', 
-			chr(152) => '_', 
-			chr(153) => 'O', 
-			chr(154) => 'U', 
-			chr(158) => '_', 
-			chr(160) => 'a', 
-			chr(161) => 'i', 
-			chr(162) => 'o', 
-			chr(163) => 'u', 
-			chr(164) => 'n', 
-			chr(165) => 'N', 
-			chr(173) => 'i', 
-			chr(174) => '<', 
-			chr(175) => '>', 
-			chr(179) => '|', 
-			chr(196) => '-', 
-			chr(242) => '>=', 
-			chr(243) => '<=', 
-			chr(246) => '/', 
-			chr(247) => '~', 
-			chr(249) => '.', 
-			chr(250) => '.', 
-			chr(252) => '_', 
+			chr(136) => 'e',
+			chr(137) => 'e',
+			chr(138) => 'e',
+			chr(139) => 'i',
+			chr(140) => 'i',
+			chr(141) => 'i',
+			chr(142) => 'A',
+			chr(143) => 'A',
+			chr(144) => 'E',
+			chr(145) => 'ae',
+			chr(146) => 'AE',
+			chr(147) => 'o',
+			chr(148) => 'o',
+			chr(149) => 'o',
+			chr(150) => 'u',
+			chr(151) => 'u',
+			chr(152) => '_',
+			chr(153) => 'O',
+			chr(154) => 'U',
+			chr(158) => '_',
+			chr(160) => 'a',
+			chr(161) => 'i',
+			chr(162) => 'o',
+			chr(163) => 'u',
+			chr(164) => 'n',
+			chr(165) => 'N',
+			chr(173) => 'i',
+			chr(174) => '<',
+			chr(175) => '>',
+			chr(179) => '|',
+			chr(196) => '-',
+			chr(242) => '>=',
+			chr(243) => '<=',
+			chr(246) => '/',
+			chr(247) => '~',
+			chr(249) => '.',
+			chr(250) => '.',
+			chr(252) => '_',
 			);
-		
+
 		$count = strlen($str);
 		for ($i = 0; $i < $count; $i++)
 		{
-			$ord = ord($str{$i});
-			
-			if ($ord != ord("\t") and 
-				$ord != ord("\n") and 
-				$ord != ord("\r") and 
-				($ord < 32 or $ord > 126)) 
+			$ord = ord($str[$i]);
+
+			if ($ord != ord("\t") and
+				$ord != ord("\n") and
+				$ord != ord("\r") and
+				($ord < 32 or $ord > 126))
 			{
 				if (isset($replace[$ord]))
 				{
-					$str{$i} = $replace[$ord];
+					$str[$i] = $replace[$ord];
 				}
 				else
 				{
-					$str{$i} = ' ';
+					$str[$i] = ' ';
 				}
 			}
 		}
-		
+
 		return $str;
 	}
 	*/
-	
+
 	/**
 	 * Convert certain strings to their abbreviations
-	 * 
-	 * QuickBooks often uses unusually short field lengths. This function will 
-	 * convert common long words to shorter abbreviations in an attempt to make 
+	 *
+	 * QuickBooks often uses unusually short field lengths. This function will
+	 * convert common long words to shorter abbreviations in an attempt to make
 	 * a string fit cleanly into the very short fields.
-	 * 
+	 *
 	 * @param string $value		The value to apply the abbreviations to
 	 * @return string
 	 */
 	static protected function _castAbbreviations($value)
 	{
 		$abbrevs = array(
-			'Administration' => 'Admin.', 
-			'Academic' => 'Acad.', 
-			'Academy' => 'Acad.', 
+			'Administration' => 'Admin.',
+			'Academic' => 'Acad.',
+			'Academy' => 'Acad.',
 			'Association' => 'Assn.',
-			'Boulevard' => 'Blvd.', 
-			'Building' => 'Bldg.', 
-			'College' => 'Coll.', 
-			'Company' => 'Co.', 
-			'Consolidated' => 'Consol.', 
-			'Corporation' => 'Corp.', 
-			'Incorporated' => 'Inc.', 
-			'Department' => 'Dept.', 
-			'Division' => 'Div.', 
-			'District' => 'Dist.', 
-			'Eastern' => 'E.', 
-			'Government' => 'Govt.', 
-			'International' => 'Intl.', 
-			'Institute' => 'Inst.', 
-			'Institution' => 'Inst.', 
+			'Boulevard' => 'Blvd.',
+			'Building' => 'Bldg.',
+			'College' => 'Coll.',
+			'Company' => 'Co.',
+			'Consolidated' => 'Consol.',
+			'Corporation' => 'Corp.',
+			'Incorporated' => 'Inc.',
+			'Department' => 'Dept.',
+			'Division' => 'Div.',
+			'District' => 'Dist.',
+			'Eastern' => 'E.',
+			'Government' => 'Govt.',
+			'International' => 'Intl.',
+			'Institute' => 'Inst.',
+			'Institution' => 'Inst.',
 			'Laboratory' => 'Lab.',
-			'Liberty' => 'Lib.', 
-			'Library' => 'Lib.', 
-			'Limited' => 'Ltd.', 
-			'Manufacturing' => 'Mfg.', 
-			'Manufacturer' => 'Mfr.', 
-			'Miscellaneous' => 'Misc.', 
-			'Museum' => 'Mus.', 
-			'Northern' => 'N.', 
+			'Liberty' => 'Lib.',
+			'Library' => 'Lib.',
+			'Limited' => 'Ltd.',
+			'Manufacturing' => 'Mfg.',
+			'Manufacturer' => 'Mfr.',
+			'Miscellaneous' => 'Misc.',
+			'Museum' => 'Mus.',
+			'Northern' => 'N.',
 			'Northeastern' => 'NE', // This is *before* Northeast so we don't get "NEern"
-			'Northeast' => 'NE', 
-			'Regional' => 'Reg.', // This is *before* Region so we don't get "Reg.al" 
-			'Region' => 'Reg.', 
+			'Northeast' => 'NE',
+			'Regional' => 'Reg.', // This is *before* Region so we don't get "Reg.al"
+			'Region' => 'Reg.',
 			'School' => 'Sch.',
-			'Services' => 'Svcs.', // This is *before* Service so that we don't get "Svc.s"			
-			'Service' => 'Svc.', 
-			'Southern' => 'S.', 
-			'Southeastern' => 'SE', 
-			'Southeast' => 'SE', 
-			'University' => 'Univ.', 
-			'Western' => 'W.', 
+			'Services' => 'Svcs.', // This is *before* Service so that we don't get "Svc.s"
+			'Service' => 'Svc.',
+			'Southern' => 'S.',
+			'Southeastern' => 'SE',
+			'Southeast' => 'SE',
+			'University' => 'Univ.',
+			'Western' => 'W.',
 			);
-			
+
 		return str_ireplace(array_keys($abbrevs), array_values($abbrevs), $value);
 	}
-	
+
 	/**
 	 * Shorten a string to a specific length by truncating or abbreviating the string
-	 * 
-	 * QuickBooks often uses unusually short field lengths. This function can 
-	 * be used to try to make long strings fit cleanly into the QuickBooks 
+	 *
+	 * QuickBooks often uses unusually short field lengths. This function can
+	 * be used to try to make long strings fit cleanly into the QuickBooks
 	 * fields. It tries to do a few things:
 	 * 	- Convert long words to shorter abbreviations
 	 * 	- Remove non-ASCII characters
 	 * 	- Truncate the string if it's still too long
-	 * 
+	 *
 	 * @param string $value				The string to shorten
 	 * @param integer $length			The max. length the string should be
 	 * @param boolean $with_abbrevs		Whether or not to abbreviate some long words to shorten the string
@@ -194,49 +194,49 @@ class QuickBooks_Cast
 	static protected function _castTruncate($value, $length, $with_abbrevs = true)
 	{
 		//$value = QuickBooks_Cast::_castCharset($value);
-		
+
 		if (strlen($value) > $length)
 		{
 			if ($with_abbrevs)
 			{
 				$value = QuickBooks_Cast::_castAbbreviations($value);
 			}
-			
+
 			if (strlen($value) > $length)
 			{
 				$value = substr($value, 0, $length);
 			}
 		}
-		
+
 		// This breaks the UTF8 encoding
 		//return utf8_encode($value);
-		
+
 		// Just return the data
 		return $value;
 	}
-	
+
 	/**
-	 * 
-	 * 
-	 * 
+	 *
+	 *
+	 *
 	 */
 	static protected function _fnmatch($pattern, $str)
 	{
 		$arr = array(
-			'\*' => '.*', 
+			'\*' => '.*',
 			'\?' => '.'
 			);
 		return preg_match('#^' . strtr(preg_quote($pattern, '#'), $arr) . '$#i', $str);
 	}
-	
+
 	/**
 	 * Cast a value to ensure that it will fit in a particular field within QuickBooks
-	 * 
-	 * QuickBooks has some strange length limits on some fields (the max. 
-	 * length of the CompanyName field for Customers is only 41 characters, 
-	 * etc.) so this method provides an easy way to cast the data type and data 
+	 *
+	 * QuickBooks has some strange length limits on some fields (the max.
+	 * length of the CompanyName field for Customers is only 41 characters,
+	 * etc.) so this method provides an easy way to cast the data type and data
 	 * length of a value to the correct type and length for a specific field.
-	 * 
+	 *
 	 * @param string $object_type	The QuickBooks object type (Customer, Invoice, etc.)
 	 * @param string $field_name	The QuickBooks field name (these correspond to the qbXML field names: Addr1, Name, CompanyName, etc.)
 	 * @param mixed $value			The value you want to cast
@@ -247,85 +247,85 @@ class QuickBooks_Cast
 	static public function cast($type_or_action, $field, $value, $use_abbrevs = true, $htmlspecialchars = true)
 	{
 		$type_or_action = strtolower($type_or_action);
-		
+
 		static $files = array();
-		
+
 		if (!count($files))
 		{
 			$dh = opendir(dirname(__FILE__) . '/QBXML/Schema/Object');
 			while (false !== ($file = readdir($dh)))
 			{
-				if ($file{0} == '.' or substr($file, -6, 6) != 'Rq.php')
+				if ($file[0] == '.' or substr($file, -6, 6) != 'Rq.php')
 				{
 					continue;
 				}
-				
+
 				$files[] = $file;
 			}
-			
+
 			sort($files);
 		}
-		
+
 		/*
 		if ($htmlspecialchars)
-		{			
+		{
 			$entities = array(
-				'&' => '&amp;', 
-				'<' => '&lt;', 
+				'&' => '&amp;',
+				'<' => '&lt;',
 				'>' => '&gt;',
-				//'\'' => '&apos;', 
-				'"' => '&quot;', 
+				//'\'' => '&apos;',
+				'"' => '&quot;',
 				);
-			
+
 			// First, *unreplace* things so that we don't double escape them
 			$value = str_replace(array_values($entities), array_keys($entities), $value);
-			
+
 			// Then, replace XML entities
 			$value = str_replace(array_keys($entities), array_values($entities), $value);
-			
+
 			//$value = htmlspecialchars($value, ENT_QUOTES, null, false);
-		}		
+		}
 		*/
-		
+
 		$types = array();
 		$types3 = array();
 		$types5 = array();
-		
-		reset($files);		
+
+		reset($files);
 		foreach ($files as $file)
 		{
 			$substr = substr($file, 0, -4);
 			$substrlower = strtolower($substr);
-			
+
 			$types[$substrlower] = $substr;
-			
+
 			$substr3 = substr($file, 0, -3 + -3);
 			$substr3lower = strtolower($substr3);
-			
+
 			$substr5 = substr($file, 0, -3 + -6);
 			$substr5lower = strtolower($substr5);
-			
+
 			if (!isset($types3[$substr3lower]))
 			{
 				$types3[$substr3lower] = $substr;
 			}
-			
+
 			if (!isset($types5[$substr5lower]))
 			{
 				$types5[$substr5lower] = $substr;
 			}
 		}
-		
+
 		/*
 		print('	looking for schema: ' . $type_or_action . "\n");
 		print_r($types);
 		print_r($types3);
 		print_r($types5);
 		*/
-		
+
 		$class = null;
 		$schema = null;
-		
+
 		if (isset($types[$type_or_action]))
 		{
 			QuickBooks_Loader::load('/QuickBooks/QBXML/Schema/Object/' . $types[$type_or_action] . '.php');
@@ -348,33 +348,33 @@ class QuickBooks_Cast
 		//{
 		//	return $value;
 		//}
-		
+
 		//print('	casting using schema: ' . get_class($schema) . "\n");
-		
+
 		if ($class and $schema)
 		{
 			if (!$schema->exists($field) and false !== strpos($field, '_'))
 			{
 				$field = str_replace('_', ' ', $field);
 			}
-			
+
 			if ($schema->exists($field))
 			{
 				switch ($schema->dataType($field))
 				{
 					case QUICKBOOKS_DATATYPE_STRING:
-						
+
 						$maxlength = $schema->maxLength($field);
-						
+
 						// Use only ASCII characters
 						//$value = QuickBooks_Cast::_castCharset($value);
-						
+
 						// Make sure it'll fit in the allocated field length
 						if (is_int($maxlength) and $maxlength > 0)
 						{
 							$value = QuickBooks_Cast::_castTruncate($value, $maxlength, $use_abbrevs);
 						}
-						
+
 						break;
 					case QUICKBOOKS_DATATYPE_DATE:
 						if ($value)
@@ -398,7 +398,7 @@ class QuickBooks_Cast
 						$value = (float) $value;
 						break;
 					case QUICKBOOKS_DATATYPE_BOOLEAN:
-						
+
 						if ($value and $value !== 'false')
 						{
 							$value = 'true';
@@ -407,111 +407,111 @@ class QuickBooks_Cast
 						{
 							$value = 'false';
 						}
-						
+
 						break;
 					case QUICKBOOKS_DATATYPE_INTEGER:
 						$value = (int) $value;
 						break;
-				}			
+				}
 			}
 		}
-			
+
 		/*
 		if ($htmlspecialchars)
-		{			
+		{
 			$entities = array(
-				'&' => '&amp;', 
-				'<' => '&lt;', 
+				'&' => '&amp;',
+				'<' => '&lt;',
 				'>' => '&gt;',
-				//'\'' => '&apos;', 
-				'"' => '&quot;', 
+				//'\'' => '&apos;',
+				'"' => '&quot;',
 				);
-			
+
 			// First, *unreplace* things so that we don't double escape them
 			$value = str_replace(array_values($entities), array_keys($entities), $value);
-			
+
 			// Then, replace XML entities
 			$value = str_replace(array_keys($entities), array_values($entities), $value);
-			
+
 			//$value = htmlspecialchars($value, ENT_QUOTES, null, false);
 		}
 		*/
-		
+
 		if ($htmlspecialchars)
 		{
 			//print("DECODING");
-			
+
 			$entities = array(
-				'&' => '&amp;', 
-				'<' => '&lt;', 
+				'&' => '&amp;',
+				'<' => '&lt;',
 				'>' => '&gt;',
-				//'\'' => '&apos;', 
-				'"' => '&quot;', 
+				//'\'' => '&apos;',
+				'"' => '&quot;',
 				);
-			
+
 			// First, *unreplace* things so that we don't double escape them
 			$value = str_replace(array_values($entities), array_keys($entities), $value);
-			
+
 			// Then, replace XML entities
 			$value = str_replace(array_keys($entities), array_values($entities), $value);
-			
+
 			//$value = htmlspecialchars($value, ENT_QUOTES, null, false);
-			
+
 			//print($value . "\n\n\n");
-		
+
 			// UTF8 character handling, decode UTF8 to character decimal codes
 			$value = QuickBooks_Cast::_decodeUTF8($value);
-			
+
 			//die($value . "\n\n");
 		}
-		
+
 		return $value;
 	}
-		
+
 	/**
 	 * Test a string to see if it has 8 bit symbols in it
 	 *
 	 * @param string $string
 	 * @param string $charset
-	 * @return bool 
+	 * @return bool
 	 */
-	static protected function _is8Bit($string, $charset = '') 
+	static protected function _is8Bit($string, $charset = '')
 	{
-		if (preg_match("/^iso-8859/i", $charset)) 
+		if (preg_match("/^iso-8859/i", $charset))
 		{
 			$needle = '/\240|[\241-\377]/';
-		} 
-		else 
+		}
+		else
 		{
 			$needle = '/[\200-\237]|\240|[\241-\377]/';
 		}
-		
+
 		return preg_match("$needle", $string);
 	}
-		
+
 	/**
 	 * Converts string from an encoded string to UTF8
-	 * 
+	 *
 	 * @param string $string 		Text with numeric unicode entities
 	 * @return string 				UTF-8 text
 	 */
-	static protected function _encodeUTF8($string) 
+	static protected function _encodeUTF8($string)
 	{
 		// Don't run encoding function, if there is no encoded characters
-		if (!preg_match("'&#[0-9]+;'", $string)) 
+		if (!preg_match("'&#[0-9]+;'", $string))
 		{
 			return $string;
 		}
-		
+
 		$string = preg_replace("/&#([0-9]+);/e", "QuickBooks_Cast_unicodetoutf8('\\1')", $string);
 		// $string=preg_replace("/&#[xX]([0-9A-F]+);/e","unicodetoutf8(hexdec('\\1'))",$string);
-		
+
 		return $string;
 	}
-	
+
 	/**
 	 * Decode a UTF-8 string to an entity encoded string
-	 * 
+	 *
 	 * @param string $string 	Encoded string
 	 * @return string 			Decoded string
 	 */
@@ -522,7 +522,7 @@ class QuickBooks_Cast
 		{
 			return $string;
 		}
-		
+
 		// decode four byte unicode characters
 		$string = preg_replace_callback("/([\360-\367])([\200-\277])([\200-\277])([\200-\277])/",
 		function($arr)
@@ -530,8 +530,8 @@ class QuickBooks_Cast
 		    $val = ((ord($arr[1])-240)*262144+(ord($arr[2])-128)*4096+(ord($arr[3])-128)*64+(ord($arr[4])-128));
 		    return "&#" . $val . ";";
 		}, $string);
-			
-	
+
+
 		// decode three byte unicode characters
 		$string = preg_replace_callback("/([\340-\357])([\200-\277])([\200-\277])/",
 		function($arr)
@@ -539,8 +539,8 @@ class QuickBooks_Cast
 		    $val = ((ord($arr[1])-224)*4096+(ord($arr[2])-128)*64+(ord($arr[3])-128));
 		    return "&#" . $val . ";";
 		}, $string);
-			
-	
+
+
 		// decode two byte unicode characters
 		$string = preg_replace_callback("/([\300-\337])([\200-\277])/",
 		function($arr)
@@ -548,10 +548,10 @@ class QuickBooks_Cast
 		    $val = ((ord($arr[1])-192)*64+(ord($arr[2])-128));
 		    return "&#" . $val . ";";
 		}, $string);
-	
+
 		// remove broken unicode
 		$string = preg_replace("/[\200-\237]|\240|[\241-\377]/", '?', $string);
-	
+
 		return $string;
 	}
 }
@@ -562,13 +562,13 @@ class QuickBooks_Cast
  * @param int $var		Decimal unicode value
  * @return string		UTF-8 character
  */
-function QuickBooks_Cast_unicodetoutf8($var) 
+function QuickBooks_Cast_unicodetoutf8($var)
 {
-	if ($var < 128) 
+	if ($var < 128)
 	{
 		$ret = chr ($var);
-	} 
-	else if ($var < 2048) 
+	}
+	else if ($var < 2048)
 	{
 		// Two byte utf-8
 		$binVal = str_pad (decbin ($var), 11, '0', STR_PAD_LEFT);
@@ -578,8 +578,8 @@ function QuickBooks_Cast_unicodetoutf8($var)
 		$char1 = chr (192 + bindec ($binPart1));
 		$char2 = chr (128 + bindec ($binPart2));
 		$ret = $char1 . $char2;
-	} 
-	else if ($var < 65536) 
+	}
+	else if ($var < 65536)
 	{
 		// Three byte utf-8
 		$binVal = str_pad (decbin ($var), 16, '0', STR_PAD_LEFT);
@@ -591,8 +591,8 @@ function QuickBooks_Cast_unicodetoutf8($var)
 		$char2 = chr (128 + bindec ($binPart2));
 		$char3 = chr (128 + bindec ($binPart3));
 		$ret = $char1 . $char2 . $char3;
-	} 
-	else if ($var < 2097152) 
+	}
+	else if ($var < 2097152)
 	{
 		// Four byte utf-8
 		$binVal = str_pad (decbin ($var), 21, '0', STR_PAD_LEFT);
@@ -606,8 +606,8 @@ function QuickBooks_Cast_unicodetoutf8($var)
 		$char3 = chr (128 + bindec ($binPart3));
 		$char4 = chr (128 + bindec ($binPart4));
 		$ret = $char1 . $char2 . $char3 . $char4;
-	} 
-	else if ($var < 67108864) 
+	}
+	else if ($var < 67108864)
 	{
 		// Five byte utf-8
 		$binVal = str_pad (decbin ($var), 26, '0', STR_PAD_LEFT);
@@ -623,8 +623,8 @@ function QuickBooks_Cast_unicodetoutf8($var)
 		$char4 = chr (128 + bindec ($binPart4));
 		$char5 = chr (128 + bindec ($binPart5));
 		$ret = $char1 . $char2 . $char3 . $char4 . $char5;
-	} 
-	else if ($var < 2147483648) 
+	}
+	else if ($var < 2147483648)
 	{
 		// Six byte utf-8
 		$binVal = str_pad(decbin($var), 31, '0', STR_PAD_LEFT);
@@ -642,13 +642,13 @@ function QuickBooks_Cast_unicodetoutf8($var)
 		$char5 = chr(128 + bindec($binPart5));
 		$char6 = chr(128 + bindec($binPart6));
 		$ret = $char1 . $char2 . $char3 . $char4 . $char5 . $char6;
-	} 
-	else 
+	}
+	else
 	{
 		// there is no such symbol in utf-8
 		$ret = '?';
 	}
-	
+
 	return $ret;
 }
 

--- a/QuickBooks/Driver/Sql.php
+++ b/QuickBooks/Driver/Sql.php
@@ -3254,7 +3254,7 @@ abstract class QuickBooks_Driver_Sql extends QuickBooks_Driver
 			$dh = opendir($defaults['quickbooks_sql_schema']);
 			while (false !== ($file = readdir($dh)))
 			{
-				if ($file{0} == '.' or is_dir($defaults['quickbooks_sql_schema'] . '/' . $file))
+				if ($file[0] == '.' or is_dir($defaults['quickbooks_sql_schema'] . '/' . $file))
 				{
 					continue;
 				}

--- a/QuickBooks/IPP/Object.php
+++ b/QuickBooks/IPP/Object.php
@@ -8,9 +8,9 @@
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.opensource.org/licenses/eclipse-1.0.php
- * 
+ *
  * @author Keith Palmer <keith@ConsoliBYTE.com>
- * 
+ *
  * @package QuickBooks
  * @subpackage IPP
  */
@@ -25,58 +25,58 @@ class QuickBooks_IPP_Object
 	 * @var array
 	 */
 	protected $_data;
-	
+
 	/**
 	 * Create a new object
-	 * 
+	 *
 	 *
 	 */
 	public function __construct($data = array())
 	{
 		$this->_data = $data;
 	}
-	
+
 	/**
 	 *
-	 * 
-	 * NOTE: This only works for SimpleXML... should probably be changed so 
-	 * that this calls the QuickBooks_XML_Node class and then calls an XPath
-	 * method within that... *sigh* 
 	 *
-	 */ 
+	 * NOTE: This only works for SimpleXML... should probably be changed so
+	 * that this calls the QuickBooks_XML_Node class and then calls an XPath
+	 * method within that... *sigh*
+	 *
+	 */
 	public function getXPath($xpath)
 	{
 		$str = $this->asIDSXML();
-		
+
 		//print('[[' . $str . ']]');
-		
+
 		$XML = new SimpleXMLElement($str);
-		
+
 		$retr = $XML->xpath($xpath);
 
 		//print_r($retr);
-		
+
 		// This is our node value
 		$cur = current($retr);
 
 		//print_r($cur);
-		
+
 		if (is_object($cur))
 		{
 			// Check if it's an id type, in which case we need to build an IdType return string
 			$attrs = $cur->attributes();
-			
+
 			if (isset($attrs['idDomain']))
 			{
 				return QuickBooks_IPP_IDS::buildIdType($attrs['idDomain'], $cur . '');
 			}
-			
+
 			return $cur . '';
 		}
-		
+
 		return null;
 	}
-	
+
 	public function get($field)
 	{
 		/*
@@ -85,20 +85,20 @@ class QuickBooks_IPP_Object
 			return $this->_data[$field];
 		}
 		*/
-		
+
 		$args = func_get_args();
 		array_shift($args);
-		
+
 		return $this->__call('get' . $field, $args);
 	}
-	
+
 	public function set($field, $value)
 	{
 		//$this->_data[$field] = $value;
-		
+
 		return $this->__call('set' . $field, array( $value ));
 	}
-	
+
 	public function setDateType($field, $value)
 	{
 		if ((string) ((float) $value) == $value)
@@ -110,20 +110,20 @@ class QuickBooks_IPP_Object
 			return $this->set($field, date('Y-m-d', strtotime($value)));
 		}
 	}
-	
+
 	public function getDateType($field, $format = 'Y-m-d')
 	{
 		// This fixes a problem with PHP interpreting dates in the format "2012-01-02T00:00:00Z" as being from the day previous
 		$value = str_replace('T00:00:00Z', '', $this->get($field));
-		
+
 		return date($format, strtotime($value));
 	}
-	
+
 	public function setAmountType($field, $value)
 	{
 		return $this->set($field, sprintf('%01.2f', $value));
 	}
-	
+
 	public function remove($field)
 	{
 		if (isset($this->_data[$field]))
@@ -131,15 +131,15 @@ class QuickBooks_IPP_Object
 			unset($this->_data[$field]);
 		}
 	}
-	
+
 	public function __call($name, $args)
 	{
 		if (substr($name, 0, 3) == 'set')
 		{
 			//print('called: ' . $name . ' with args: ' . print_r($args, true) . "\n");
-			
+
 			$field = substr($name, 3);
-			
+
 			$tmp = null;
 			if (count($args) == 1)
 			{
@@ -148,22 +148,22 @@ class QuickBooks_IPP_Object
 			}
 			else
 			{
-				
+
 			}
-			
+
 			return $tmp;
 		}
 		else if (substr($name, 0, 3) == 'get')
 		{
 			$field = substr($name, 3);
-			
+
 			//print('getting field: [' . $field . ']' . "\n");
 			//print_r($this->_data);
-			
-			
+
+
 			if (isset($this->_data[$field]))
 			{
-				if (isset($args[0]) and 
+				if (isset($args[0]) and
 					is_numeric($args[0]))
 				{
 					// Trying to fetch a repeating element
@@ -171,14 +171,14 @@ class QuickBooks_IPP_Object
 					{
 						return $this->_data[$field][$args[0]];
 					}
-					
+
 					return null;
 				}
-				else if (!count($args) and 
-					isset($this->_data[$field]) and 
+				else if (!count($args) and
+					isset($this->_data[$field]) and
 					is_array($this->_data[$field]))
 				{
-					return $this->_data[$field][0]; 
+					return $this->_data[$field][0];
 				}
 				else
 				{
@@ -186,14 +186,14 @@ class QuickBooks_IPP_Object
 					return $this->_data[$field];
 				}
 			}
-			
+
 			return null;
 		}
 		else if (substr($name, 0, 5) == 'count')
 		{
 			$field = substr($name, 5);
-			
-			if (isset($this->_data[$field]) and 
+
+			if (isset($this->_data[$field]) and
 				is_array($this->_data[$field]))
 			{
 				return count($this->_data[$field]);
@@ -210,24 +210,24 @@ class QuickBooks_IPP_Object
 		else if (substr($name, 0, 3) == 'add')
 		{
 			$field = substr($name, 3);
-			
+
 			if (!isset($this->_data[$field]))
 			{
 				$this->_data[$field] = array();
 			}
-			
+
 			$tmp = current($args);
 			$this->_data[$field][] = $tmp;
-			
+
 			return $tmp;
 		}
 		else if (substr($name, 0, 5) == 'unset')
 		{
 			$field = substr($name, 5);
-			
+
 			if (isset($this->_data[$field]))
 			{
-				if (isset($args[0]) and 
+				if (isset($args[0]) and
 					is_numeric($args[0]))
 				{
 					// Trying to fetch a repeating element
@@ -235,7 +235,7 @@ class QuickBooks_IPP_Object
 					{
 						unset($this->_data[$field][$args[0]]);
 					}
-					
+
 					return true;
 				}
 				else
@@ -250,37 +250,37 @@ class QuickBooks_IPP_Object
 			return false;
 		}
 	}
-	
+
 	public function resource()
 	{
 		$split = explode('_', get_class($this));
 		return end($split);
 	}
-	
+
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 */
 	protected function _defaults()
 	{
 		return array();
 	}
-	
+
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 */
 	protected function _order()
 	{
 		return array();
 	}
-	
+
 	protected function _reorder($data, $base = '')
 	{
 		$order = $this->_order();
-		
+
 		$retr = array();
-		
+
 		foreach ($order as $path => $null)
 		{
 			if (array_key_exists($path, $data))
@@ -288,29 +288,29 @@ class QuickBooks_IPP_Object
 				$retr[$path] = $data[$path];
 			}
 		}
-		
+
 		$diff = array_diff_key($data, $order);
-		
+
 		if (count($diff))
 		{
 			// Some keys got left behind!
 			$retr = array_merge($retr, $diff);
 		}
-		
+
 		return $retr;
 	}
-	
-	
+
+
 	/**
 	 * Apply a user-defined function to every single data field in the object
 	 *
-	 * @param string $callback		The callback function 
+	 * @param string $callback		The callback function
 	 */
 	public function walk($callback)
 	{
 		//print_r($this->_data);
 		//exit;
-		
+
 		foreach ($this->_data as $key => $value)
 		{
 			if (is_object($value))
@@ -337,7 +337,7 @@ class QuickBooks_IPP_Object
 			}
 		}
 	}
-	
+
 	public function asXML($indent = 0, $parent = null, $optype = null, $flavor = null, $version = QuickBooks_IPP_IDS::VERSION_3)
 	{
 		if ($version == QuickBooks_IPP_IDS::VERSION_3)
@@ -356,7 +356,7 @@ class QuickBooks_IPP_Object
 		$data = $this->_reorder($data);
 
 		$xml = str_repeat("\t", $indent) . '<' . $this->resource() . ' xmlns="http://schema.intuit.com/finance/v3">' . QUICKBOOKS_CRLF;
-		
+
 		// Go through the data, creating XML out of it
 		foreach ($data as $key => $value)
 		{
@@ -370,7 +370,7 @@ class QuickBooks_IPP_Object
 				foreach ($value as $skey => $svalue)
 				{
 					//print('converting array: [' . $key . ' >> ' . $skey . ']');
-					
+
 					if (is_object($svalue))
 					{
 						$xml .= $svalue->_asXML_v3($indent + 1, $key, null, $flavor);
@@ -378,9 +378,9 @@ class QuickBooks_IPP_Object
 					/*else if (substr($key, -2, 2) == 'Id')
 					{
 						$for_qbxml = false;
-						
+
 						$tmp = QuickBooks_IPP_IDS::parseIdType($svalue);
-						
+
 						if ($tmp[0])
 						{
 							$xml .= str_repeat("\t", $indent + 1) . '<' . $key . ' idDomain="' . $tmp[0] . '">';
@@ -389,9 +389,9 @@ class QuickBooks_IPP_Object
 						{
 							$xml .= str_repeat("\t", $indent + 1) . '<' . $key . '>';
 						}
-						
+
 						$xml .= QuickBooks_XML::encode($tmp[1], $for_qbxml);
-						$xml .= '</' . $key . '>' . QUICKBOOKS_CRLF;						
+						$xml .= '</' . $key . '>' . QUICKBOOKS_CRLF;
 					}*/
 					else
 					{
@@ -400,20 +400,20 @@ class QuickBooks_IPP_Object
 						//$xml .= str_repeat("\t", $indent + 1) . '<' . $key . '>';
 						//$xml .= QuickBooks_XML::encode($value, $for_qbxml);
 						//$xml .= '</' . $key . '>' . QUICKBOOKS_CRLF;
-						
-						if (substr($key, -3, 3) == 'Ref' and $svalue{0} == '{')
+
+						if (substr($key, -3, 3) == 'Ref' and $svalue[0] == '{')
 						{
 							$svalue = trim($svalue, '{}-');
 						}
-						else if ($key == 'Id' and $svalue{0} == '{')
-						{
-							$svalue = trim($svalue, '{}-');	
-						}
-						else if ($key == 'DefinitionId' and $svalue{0} == '{')
+						else if ($key == 'Id' and $svalue[0] == '{')
 						{
 							$svalue = trim($svalue, '{}-');
 						}
-						else if ($key == 'TxnId' and $svalue{0} == '{')
+						else if ($key == 'DefinitionId' and $svalue[0] == '{')
+						{
+							$svalue = trim($svalue, '{}-');
+						}
+						else if ($key == 'TxnId' and $svalue[0] == '{')
 						{
 							$svalue = trim($svalue, '{}-');
 						}
@@ -425,9 +425,9 @@ class QuickBooks_IPP_Object
 			/*else if (substr($key, -2, 2) == 'Id')
 			{
 				$for_qbxml = false;
-				
+
 				$tmp = QuickBooks_IPP_IDS::parseIdType($value);
-				
+
 				if ($tmp[0])
 				{
 					$xml .= str_repeat("\t", $indent + 1) . '<' . $key . ' idDomain="' . $tmp[0] . '">';
@@ -436,52 +436,52 @@ class QuickBooks_IPP_Object
 				{
 					$xml .= str_repeat("\t", $indent + 1) . '<' . $key . '>';
 				}
-				
+
 				$xml .= QuickBooks_XML::encode($tmp[1], $for_qbxml);
 				$xml .= '</' . $key . '>' . QUICKBOOKS_CRLF;
 			}*/
 			else
 			{
 				$for_qbxml = false;
-				
-				if (substr($key, -3, 3) == 'Ref' and $value{0} == '{')
+
+				if (substr($key, -3, 3) == 'Ref' and $value[0] == '{')
 				{
 					$value = trim($value, '{}-');
 				}
-				else if ($key == 'Id' and $value{0} == '{')
-				{
-					$value = trim($value, '{}-');	
-				}
-				else if ($key == 'DefinitionId' and $value{0} == '{')
+				else if ($key == 'Id' and $value[0] == '{')
 				{
 					$value = trim($value, '{}-');
 				}
-				else if ($key == 'TxnId' and $value{0} == '{')
+				else if ($key == 'DefinitionId' and $value[0] == '{')
 				{
 					$value = trim($value, '{}-');
 				}
-				
+				else if ($key == 'TxnId' and $value[0] == '{')
+				{
+					$value = trim($value, '{}-');
+				}
+
 				$xml .= str_repeat("\t", $indent + 1) . '<' . $key . '>';
 				$xml .= QuickBooks_XML::encode($value, $for_qbxml);
 				$xml .= '</' . $key . '>' . QUICKBOOKS_CRLF;
 			}
 		}
-		
+
 		$xml .= str_repeat("\t", $indent) . '</' . $this->resource() . '>' . QUICKBOOKS_CRLF;
-		
+
 		return $xml;
 	}
-	
+
 	public function asIDSXML($indent = 0, $parent = null, $optype = null, $flavor = null)
 	{
 		// We're not going to actually change the data, just change a copy of it
 		$data = $this->_data;
-		
+
 		if (!$parent)
 		{
 			$parent = $this->resource();
 		}
-		
+
 		if ($optype == QuickBooks_IPP_IDS::OPTYPE_ADD or $optype == QuickBooks_IPP_IDS::OPTYPE_MOD)
 		{
 			if ($flavor == QuickBooks_IPP_IDS::FLAVOR_ONLINE)
@@ -492,7 +492,7 @@ class QuickBooks_IPP_Object
 			{
 				$xml = str_repeat("\t", $indent) . '<Object xsi:type="' . $this->resource() . '">' . QUICKBOOKS_CRLF;
 			}
-			
+
 			// Merge in the defaults for this object type
 			$data = array_merge($this->_defaults(), $data);
 		}
@@ -504,10 +504,10 @@ class QuickBooks_IPP_Object
 		{
 			$xml = str_repeat("\t", $indent) . '<' . $parent . '>' . QUICKBOOKS_CRLF;
 		}
-		
+
 		// Re-order is correctly
 		$data = $this->_reorder($data);
-		
+
 		// Go through the data, creating XML out of it
 		foreach ($data as $key => $value)
 		{
@@ -521,7 +521,7 @@ class QuickBooks_IPP_Object
 				foreach ($value as $skey => $svalue)
 				{
 					//print('converting array: [' . $key . ' >> ' . $skey . ']');
-					
+
 					if (is_object($svalue))
 					{
 						$xml .= $svalue->asIDSXML($indent + 1, $key, null, $flavor);
@@ -529,9 +529,9 @@ class QuickBooks_IPP_Object
 					else if (substr($key, -2, 2) == 'Id')
 					{
 						$for_qbxml = false;
-						
+
 						$tmp = QuickBooks_IPP_IDS::parseIdType($svalue);
-						
+
 						if ($tmp[0])
 						{
 							$xml .= str_repeat("\t", $indent + 1) . '<' . $key . ' idDomain="' . $tmp[0] . '">';
@@ -540,9 +540,9 @@ class QuickBooks_IPP_Object
 						{
 							$xml .= str_repeat("\t", $indent + 1) . '<' . $key . '>';
 						}
-						
+
 						$xml .= QuickBooks_XML::encode($tmp[1], $for_qbxml);
-						$xml .= '</' . $key . '>' . QUICKBOOKS_CRLF;						
+						$xml .= '</' . $key . '>' . QUICKBOOKS_CRLF;
 					}
 					else
 					{
@@ -551,7 +551,7 @@ class QuickBooks_IPP_Object
 						//$xml .= str_repeat("\t", $indent + 1) . '<' . $key . '>';
 						//$xml .= QuickBooks_XML::encode($value, $for_qbxml);
 						//$xml .= '</' . $key . '>' . QUICKBOOKS_CRLF;
-						
+
 						$xml .= str_repeat("\t", $indent + 1) . '<' . $key . '>' . QuickBooks_XML::encode($svalue, false) . '</' . $key . '>' . QUICKBOOKS_CRLF;
 					}
 				}
@@ -559,9 +559,9 @@ class QuickBooks_IPP_Object
 			else if (substr($key, -2, 2) == 'Id')
 			{
 				$for_qbxml = false;
-				
+
 				$tmp = QuickBooks_IPP_IDS::parseIdType($value);
-				
+
 				if ($tmp[0])
 				{
 					$xml .= str_repeat("\t", $indent + 1) . '<' . $key . ' idDomain="' . $tmp[0] . '">';
@@ -570,20 +570,20 @@ class QuickBooks_IPP_Object
 				{
 					$xml .= str_repeat("\t", $indent + 1) . '<' . $key . '>';
 				}
-				
+
 				$xml .= QuickBooks_XML::encode($tmp[1], $for_qbxml);
 				$xml .= '</' . $key . '>' . QUICKBOOKS_CRLF;
 			}
 			else
 			{
 				$for_qbxml = false;
-				
+
 				$xml .= str_repeat("\t", $indent + 1) . '<' . $key . '>';
 				$xml .= QuickBooks_XML::encode($value, $for_qbxml);
 				$xml .= '</' . $key . '>' . QUICKBOOKS_CRLF;
 			}
 		}
-		
+
 		if ($optype == QuickBooks_IPP_IDS::OPTYPE_ADD or $optype == QuickBooks_IPP_IDS::OPTYPE_MOD)
 		{
 			if ($flavor == QuickBooks_IPP_IDS::FLAVOR_ONLINE)
@@ -599,7 +599,7 @@ class QuickBooks_IPP_Object
 		{
 			$xml .= str_repeat("\t", $indent) . '</' . $parent . '>' . QUICKBOOKS_CRLF;
 		}
-		
+
 		return $xml;
 	}
 }

--- a/QuickBooks/MerchantService/CheckingAccount.php
+++ b/QuickBooks/MerchantService/CheckingAccount.php
@@ -2,97 +2,97 @@
 
 /**
  * Checking account object
- * 
+ *
  * Copyright (c) {2010-04-16} {Keith Palmer / ConsoliBYTE, LLC.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.opensource.org/licenses/eclipse-1.0.php
- * 
+ *
  *
  * @author Keith Palmer Jr. <keith@ConsoliBYTE.com>
  *
  * @package QuickBooks
- * @subpackage MerchantService 
+ * @subpackage MerchantService
  */
 
 /**
- * 
- * 
+ *
+ *
  */
 class QuickBooks_MerchantService_CheckingAccount
 {
 	const INFO_PERSONAL = 'personal';
 	const INFO_BUSINESS = 'business';
-	
+
 	const TYPE_CHECKING = 'Checking';
 	const TYPE_SAVINGS = 'Savings';
-	
+
 	protected $_routing;
 	protected $_account;
-	
+
 	protected $_info;
 	protected $_type;
 	protected $_first_name;
 	protected $_last_name;
 	protected $_phone;
-	
+
 	/**
 	 * Create a new checking account object
-	 * 
-	 * @param 
+	 *
+	 * @param
 	 */
 	public function __construct($routing, $account, $info, $type, $first_name, $last_name, $phone)
 	{
 		$this->_routing = $routing;
 		$this->_account = $account;
-		
+
 		$this->_info = $info;
 		$this->_type = $type;
-		
+
 		$this->_first_name = $first_name;
 		$this->_last_name = $last_name;
-		
+
 		$phone = trim(str_replace(array('(', ')', '+', ' ', '.', '-'), '', $phone));
-		if (strlen($phone) == 11 and 
-			$phone{0} == '1')
+		if (strlen($phone) == 11 and
+			$phone[0] == '1')
 		{
 			$phone = substr($phone, 1);
 		}
-		
-		$this->_phone = $phone; 
+
+		$this->_phone = $phone;
 	}
-	
+
 	public function getRoutingNumber()
 	{
 		return $this->_routing;
 	}
-	
+
 	public function getAccountNumber()
 	{
 		return $this->_account;
 	}
-	
+
 	public function getInfo()
 	{
 		return $this->_info;
 	}
-	
+
 	public function getType()
 	{
 		return $this->_type;
 	}
-	
+
 	public function getFirstName()
 	{
 		return $this->_first_name;
 	}
-	
+
 	public function getLastName()
 	{
 		return $this->_last_name;
 	}
-	
+
 	public function getPhone()
 	{
 		return $this->_phone;

--- a/QuickBooks/Utilities.php
+++ b/QuickBooks/Utilities.php
@@ -2,16 +2,16 @@
 
 /**
  * Various QuickBooks related utility methods
- * 
+ *
  * Copyright (c) 2010-04-16 Keith Palmer / ConsoliBYTE, LLC.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.opensource.org/licenses/eclipse-1.0.php
- * 
+ *
  * @author Keith Palmer <keith@consolibyte.com>
  * @license LICENSE.txt
- * 
+ *
  * @package QuickBooks
  */
 
@@ -22,40 +22,40 @@ QuickBooks_Loader::load('/QuickBooks/Driver/Factory.php');
 
 /**
  * Various QuickBooks related utilities
- * 
+ *
  * All methods are static
  */
 class QuickBooks_Utilities
 {
 	/**
-	 * Parse a DSN style connection string 
-	 * 
+	 * Parse a DSN style connection string
+	 *
 	 * @param string $dsn		The DSN connection string
 	 * @param string $part		If you want just a specific part of the string, choose which part here: scheme, host, port, user, pass, query, fragment
-	 * @return mixed 			An array or a string, depending on if you wanted the whole thing parsed or just a piece of it 
+	 * @return mixed 			An array or a string, depending on if you wanted the whole thing parsed or just a piece of it
 	 */
 	static public function parseDSN($dsn, $defaults = array(), $part = null)
 	{
 		// Some DSN strings look like this:		filesystem:///path/to/file
 		//	parse_url() will not parse this *unless* we provide some sort of hostname (in this case, null)
 		$dsn = str_replace(':///', '://null/', $dsn);
-			
+
 		$defaults = array_merge(array(
-			'scheme' => '', 
-			'host' => '', 
-			'port' => 0, 
-			'user' => '', 
+			'scheme' => '',
+			'host' => '',
+			'port' => 0,
+			'user' => '',
 			'pass' => '',
-			'path' => '', 
+			'path' => '',
 			'query' => '',
-			'fragment' => '',   
+			'fragment' => '',
 			), $defaults);
-			
+
 		$parse = array_merge($defaults, parse_url($dsn));
-		
+
 		$parse['user'] = urldecode($parse['user']);
 		$parse['pass'] = urldecode($parse['pass']);
-		
+
 		if (is_null($part))
 		{
 			return $parse;
@@ -64,43 +64,43 @@ class QuickBooks_Utilities
 		{
 			return $parse[$part];
 		}
-			
+
 		return null;
 	}
-	
+
 	/**
-	 * Mask certain sensitive data from occuring in output/logs 
-	 * 
+	 * Mask certain sensitive data from occuring in output/logs
+	 *
 	 * @param string $message
 	 * @returns string
 	 */
 	static public function mask($message)
 	{
 		$masks = array(
-			'<SessionTicket>', 
-			'<ConnectionTicket>', 
-			'<CreditCardNumber>', 
-			'<CardSecurityCode>', 
-			'<AppID>', 
-			'<strPassword>', 
+			'<SessionTicket>',
+			'<ConnectionTicket>',
+			'<CreditCardNumber>',
+			'<CardSecurityCode>',
+			'<AppID>',
+			'<strPassword>',
 			);
-		
+
 		foreach ($masks as $key)
 		{
-			if ($key{0} == '<')
+			if ($key[0] == '<')
 			{
 				// It's an XML tag
 				$contents = QuickBooks_Utilities::_extractTagContents(trim($key, '<> '), $message);
-				
+
 				$masked = str_repeat('x', min(strlen($contents), 12)) . substr($contents, 12);
-				
+
 				$message = str_replace($key . $contents . '</' . trim($key, '<> ') . '>', $key . $masked . '</' . trim($key, '<> ') . '>', $message);
 			}
 		}
-		
+
 		return $message;
 	}
-	
+
 	/**
 	 * @deprecated		Use QuickBooks_XML::extractTagContents() instead
 	 */
@@ -109,10 +109,10 @@ class QuickBooks_Utilities
 		$tmp = QuickBooks_XML::extractTagContents($tag, $data);
 		return $tmp;
 	}
-	
+
 	/**
-	 * Write a message to the log (via the back-end driver) 
-	 * 
+	 * Write a message to the log (via the back-end driver)
+	 *
 	 * @param string $dsn		The DSN connection string to the logger
 	 * @param string $msg		The message to log
 	 * @param integer $lvl		The message log level
@@ -121,64 +121,64 @@ class QuickBooks_Utilities
 	static public function log($dsn, $msg, $lvl = QUICKBOOKS_LOG_NORMAL)
 	{
 		$Driver = QuickBooks_Utilities::driverFactory($dsn);
-		
+
 		// Mask important data
 		$msg = QuickBooks_Utilities::mask($msg);
-		
+
 		return $Driver->log($msg, null, $lvl);
 	}
-	
+
 	/**
-	 * 
+	 *
 	 *                1        2       3
 	 *               -3       -2      -1
 	 * domainParts('tools.consolibyte.com');
 	 *                0        1       2
-	 * 
+	 *
 	 */
 	/*static public function domainParts($domain, $part = null)
 	{
 		$tmp = explode('.', $domain);
-		
+
 		$part = (int) $part;
-		if ($part > 0 and 
+		if ($part > 0 and
 			isset($tmp[$part - 1]))
 		{
 			return $tmp[$part - 1];
 		}
-		else if ($part < 0 and 
+		else if ($part < 0 and
 			isset($tmp[count($tmp) + $part]))
 		{
 			return $tmp[count($tmp) + $part];
 		}
-		
+
 		return $tmp;
 	}*/
 
 	/**
 	 * Extract the requestID attribute from an XML stream
-	 * 
+	 *
 	 * @param string $xml	The XML stream to look for a requestID attribute in
 	 * @return mixed		The request ID
 	 */
 	static public function extractRequestID($xml)
 	{
 		$look = array(
-			
+
 			);
-		
-		if (false !== ($start = strpos($xml, ' requestID="')) and 
+
+		if (false !== ($start = strpos($xml, ' requestID="')) and
 			false !== ($end = strpos($xml, '"', $start + 12)))
 		{
 			return substr($xml, $start + 12, $end - $start - 12);
 		}
-		
+
 		return false;
 	}
-	
+
 	/**
 	 * Create a requestID string from action and ident parts
-	 * 
+	 *
 	 * @param string $action
 	 * @param mixed $ident
 	 * @return string
@@ -187,10 +187,10 @@ class QuickBooks_Utilities
 	{
 		return base64_encode($action . '|' . $ident);
 	}
-	
+
 	/**
 	 * Parse a requestID string into it's action and ident parts
-	 * 
+	 *
 	 * @param string $requestID
 	 * @param string $action
 	 * @param mixed $ident
@@ -199,42 +199,42 @@ class QuickBooks_Utilities
 	static public function parseRequestID($requestID, &$action, &$ident)
 	{
 		$tmp = explode('|', base64_decode($requestID));
-		
+
 		if (count($tmp) == 2)
 		{
 			$action = $tmp[0];
 			$ident = $tmp[1];
-			
+
 			return true;
 		}
-		
+
 		$action = null;
 		$ident = null;
-		
+
 		return false;
 	}
-	
+
 	/**
 	 * Create an instance of a driver class from a DSN connection string *or* a connection resource
-	 * 
+	 *
 	 * You can actually pass in *either* a DSN-style connection string OR an already connected database resource
 	 * 	- mysql://user:pass@localhost:port/database
 	 * 	- $var (Resource ID #XYZ, valid MySQL connection resource)
-	 * 
+	 *
 	 * @param mixed $dsn_or_conn	A DSN-style connection string or a PHP resource
 	 * @param array $config			An array of configuration options for the driver
 	 * @param array $hooks			An array mapping hooks to user-defined hook functions to call
-	 * @param integer $log_level	
+	 * @param integer $log_level
 	 * @return object				A class instance, a child class of QuickBooks_Driver
-	 */	
+	 */
 	static public function driverFactory($dsn_or_conn, $config = array(), $hooks = array(), $log_level = QUICKBOOKS_LOG_NORMAL)
 	{
 		return QuickBooks_Driver_Factory::create($dsn_or_conn, $config, $hooks, $log_level);
 	}
 
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 * @param string $module
 	 * @param string $key
 	 * @param mixed $value
@@ -248,13 +248,13 @@ class QuickBooks_Utilities
 		{
 			return $Driver->configWrite($user, $module, $key, $value, $type, $opts);
 		}
-		
+
 		return false;
 	}
-	
+
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 * @param string $module
 	 * @param string $key
 	 * @param string $type
@@ -267,13 +267,13 @@ class QuickBooks_Utilities
 		{
 			return $Driver->configRead($user, $module, $key, $type, $opts);
 		}
-		
+
 		return false;
 	}
-	
+
 	/**
 	 * Convert a time interval to a number of seconds (i.e.: "1 hour" => 600, "3 hours" => 1800, "2 minutes" => 120, etc.)
-	 * 
+	 *
 	 * @param mixed $interval
 	 * @return integer
 	 */
@@ -281,37 +281,37 @@ class QuickBooks_Utilities
 	{
 		if ( (string) (int) $interval === (string) $interval)
 		{
-			// It's already an integer... 
+			// It's already an integer...
 		}
 		else
 		{
 			$intervals = array(
-				'second' => 1, 
-				'minute' => 60, 
-				'hour' => 60 * 60, 
-				'day' => 60 * 60 * 24, 
-				'week' => 60 * 60 * 24 * 7, 
-				'month' => 60 * 60 * 24 * 30, 
+				'second' => 1,
+				'minute' => 60,
+				'hour' => 60 * 60,
+				'day' => 60 * 60 * 24,
+				'week' => 60 * 60 * 24 * 7,
+				'month' => 60 * 60 * 24 * 30,
 				'year' => 60 * 60 * 24 * 365,
 				);
-				
+
 			$interval = strtolower(trim($interval));
-				
+
 			$justletters = true;
 			$count = strlen($interval);
 			for ($i = 0; $i < $count; $i++)
 			{
-				if (ord($interval{$i}) < 97 or ord($interval{$i}) > 122)
+				if (ord($interval[$i]) < 97 or ord($interval[$i]) > 122)
 				{
 					$justletters = false;
 				}
 			}
-				
+
 			if ($justletters)
 			{
 				$interval = '1 ' . $interval;
 			}
-				
+
 			foreach ($intervals as $str => $multiplier)
 			{
 				if (false !== strpos($interval, ' ' . $str))
@@ -320,14 +320,14 @@ class QuickBooks_Utilities
 				}
 			}
 		}
-		
+
 		// If it's not an integer yet, cast it!
 		return (int) $interval;
 	}
-		
+
 	/**
 	 * Check if a given IP address lies within a CIDR range
-	 * 
+	 *
 	 * @param string $remoteaddr		The remote machine's IP address (example: 192.168.1.4)
 	 * @param string $CIDR				A CIDR network address (example: 192.168.0.0/24)
 	 * @return boolean
@@ -335,39 +335,39 @@ class QuickBooks_Utilities
 	static protected function _checkCIDR($remoteaddr, $CIDR)
 	{
 		$remoteaddr_long = ip2long($remoteaddr);
-		
+
 		list ($net, $mask) = split('/', $CIDR);
 		$ip_net = ip2long($net);
 		$ip_mask = ~((1 << (32 - $mask)) - 1);
-		
+
 		$remoteaddr_net = $remoteaddr_long & $ip_mask;
-		
+
 		return $remoteaddr_net == $ip_net;
 	}
 
 	/**
 	 * Check if a given remote address (IP address) is allowed based on allow and deny arrays
-	 * 
+	 *
 	 * @param string $remoteaddr
 	 * @param array $allow
 	 * @param array $deny
 	 * @return boolean
-	 */	
+	 */
 	static public function checkRemoteAddress($remoteaddr, $arr_allow, $arr_deny)
 	{
 		$allowed = true;
-		
+
 		if (count($arr_allow))
 		{
 			// only allow these addresses
 			$allowed = false;
-			
+
 			foreach ($arr_allow as $allow)
 			{
 				if (false !== strpos($allow, '/'))
 				{
 					// CIDR notation
-					
+
 					if (QuickBooks_Utilities::_checkCIDR($remoteaddr, $allow))
 					{
 						$allowed = true;
@@ -377,7 +377,7 @@ class QuickBooks_Utilities
 				else if (ereg('^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$', $allow))
 				{
 					// IPv4 address
-					
+
 					if ($remoteaddr == $allow)
 					{
 						$allowed = true;
@@ -385,13 +385,13 @@ class QuickBooks_Utilities
 					}
 				}
 			}
-			
+
 			if (!$allowed)
 			{
 				return false;
 			}
 		}
-		
+
 		if (count($arr_deny))
 		{
 			// do *not* allow these addresses
@@ -400,7 +400,7 @@ class QuickBooks_Utilities
 				if (false !== strpos($deny, '/'))
 				{
 					// CIDR notation
-					
+
 					if (QuickBooks_Utilities::_checkCIDR($remoteaddr, $deny))
 					{
 						return false;
@@ -409,7 +409,7 @@ class QuickBooks_Utilities
 				else if (ereg('^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$', $deny))
 				{
 					// IPv4 address
-					
+
 					if ($remoteaddr == $deny)
 					{
 						return false;
@@ -417,32 +417,32 @@ class QuickBooks_Utilities
 				}
 			}
 		}
-		
+
 		return $allowed;
 	}
-	
-	
+
+
 	/**
 	 * Create a user for the QuickBooks Web Connector SOAP server
-	 * 
+	 *
 	 * @param string $dsn		A DSN-style connection string for the back-end driver
 	 * @param string $username	The username for the new user
 	 * @param string $password	The password for the new user
-	 * @param string $company_file				
-	 * @param string $wait_before_next_update	
-	 * @param string $min_run_every_n_seconds	
-	 * @return boolean 			
+	 * @param string $company_file
+	 * @param string $wait_before_next_update
+	 * @param string $min_run_every_n_seconds
+	 * @return boolean
 	 */
 	static public function createUser($dsn, $username, $password, $company_file = null, $wait_before_next_update = null, $min_run_every_n_seconds = null)
 	{
 		$driver = QuickBooks_Utilities::driverFactory($dsn);
-		
+
 		return $driver->authCreate($username, $password, $company_file, $wait_before_next_update, $min_run_every_n_seconds);
 	}
-	
+
 	/**
 	 * Disable a user for the QuickBooks Web Connector SOAP server
-	 * 
+	 *
 	 * @param string $dsn		A DSN-style connection string
 	 * @param string $username	The username for the user to disable
 	 * @return boolean
@@ -450,13 +450,13 @@ class QuickBooks_Utilities
 	static public function disableUser($dsn, $username)
 	{
 		$driver = QuickBooks_Utilities::driverFactory($dsn);
-		
+
 		return $driver->authDisable($username);
 	}
-	
+
 	/**
 	 * Generate a unique hash from a bunch of variables
-	 * 
+	 *
 	 * @param mixed $mixed1
 	 * @param mixed $mixed2
 	 * @param mixed $mixed3
@@ -468,10 +468,10 @@ class QuickBooks_Utilities
 	{
 		return md5(serialize($mixed1) . serialize($mixed2) . serialize($mixed3) . serialize($mixed4) . serialize($mixed5));
 	}
-	
+
 	/**
 	 * Create a mapping between a QuickBooks object and an object in your own database/application
-	 * 
+	 *
 	 * @param string $dsn
 	 * @param string $user
 	 * @param string $object_type
@@ -482,13 +482,13 @@ class QuickBooks_Utilities
 	public static function createMapping($dsn, $user, $object_type, $TxnID_or_ListID, $app_ID, $editsequence = '')
 	{
 		$Driver = QuickBooks_Utilities::driverFactory($dsn);
-		
+
 		return $Driver->identMap($user, $object_type, $app_ID, $TxnID_or_ListID, $editsequence);
 	}
-	
+
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 * @param string $dsn
 	 * @param string $user
 	 * @param string $object_type
@@ -498,13 +498,13 @@ class QuickBooks_Utilities
 	public static function fetchApplicationID($dsn, $user, $object_type, $TxnID_or_ListID)
 	{
 		$Driver = QuickBooks_Utilities::driverFactory($dsn);
-		
+
 		$extra = null;
 		return $Driver->identToApplication($user, $object_type, $TxnID_or_ListID, $extra);
 	}
-	
+
 	/**
-	 * 
+	 *
 	 */
 	public static function hasApplicationID($dsn, $user, $object_type, $TxnID_or_ListID)
 	{
@@ -512,60 +512,60 @@ class QuickBooks_Utilities
 		{
 			return true;
 		}
-		
+
 		return false;
 	}
-	
+
 	/**
-	 * 
-	 * @param string $object_type	A QuickBooks object-type constant, i.e.: QUICKBOOKS_OBJECT_CUSTOMER, QUICKBOOKS_OBJECT_INVOICE, etc. 
+	 *
+	 * @param string $object_type	A QuickBooks object-type constant, i.e.: QUICKBOOKS_OBJECT_CUSTOMER, QUICKBOOKS_OBJECT_INVOICE, etc.
 	 * @param mixed $webapp_ID		The unique ID or PRIMARY KEY of the object within your application
 	 * @return string				A QuickBooks TxnID or ListID
 	 */
 	public static function fetchQuickbooksID($dsn, $user, $object_type, $webapp_ID)
 	{
 		$Driver = QuickBooks_Utilities::driverFactory($dsn);
-		
+
 		$editseq = null;
 		$extra = null;
 		return $Driver->identToQuickBooks($user, $object_type, $webapp_ID, $editseq, $extra);
 	}
-	
+
 	/**
-	 * 
-	 * 
-	 * 
+	 *
+	 *
+	 *
 	 */
 	public static function fetchQuickBooksEditSequence($dsn, $user, $object_type, $webapp_ID)
 	{
 		$Driver = QuickBooks_Utilities::driverFactory($dsn);
-		
+
 		$editseq = null;
 		$extra = null;
 		$Driver->identToQuickBooks($user, $object_type, $webapp_ID, $editseq, $extra);
 		return $editseq;
 	}
-	
+
 	/**
 	 * Fetches extra data stored along with the mapping of a QuickBooks ListID or TxnID to application primary key
-	 * 
-	 * @param string $dsn			The driver connection string 
+	 *
+	 * @param string $dsn			The driver connection string
 	 * @param string $user			The QuickBooks username
 	 * @param string $object_type	The object type (e.g. QUICKBOOKS_OBJECT_CUSTOMER, or QUICKBOOKS_OBJECT_INVOICE, etc.)
-	 * @param mixed $webapp_ID		The primary key for the record 
-	 * @return mixed 				Any extra data stored 
+	 * @param mixed $webapp_ID		The primary key for the record
+	 * @return mixed 				Any extra data stored
 	 */
 	public static function fetchQuickBooksExtra($dsn, $user, $object_type, $webapp_ID)
 	{
 		$Driver = QuickBooks_Utilities::driverFactory($dsn);
-		
+
 		$editseq = null;
 		$extra = null;
 		$Driver->identToQuickBooks($user, $object_type, $webapp_ID, $editseq, $extra);
-		
+
 		return $extra;
 	}
-	
+
 	/**
 	 * Alias of {@link QuickBooks_Utilities::fetchQuickBooksEditSequence()}
 	 */
@@ -573,18 +573,18 @@ class QuickBooks_Utilities
 	{
 		return QuickBooks_Utilities::fetchQuickBooksEditSequence($dsn, $user, $object_type, $webapp_ID);
 	}
-	
+
 	/**
 	 * Tell whether or not a given object has a ListID or TxnID associated with it
-	 * 
+	 *
 	 * * Note *
-	 * This function *does not* query QuickBooks, it only queries the internal 
-	 * mapping of QuickBooks IDs to PRIMARY KEYS. The mappings can be created 
-	 * with the {@link QuickBooks_Utilities::createMapping()} method and the API 
-	 * tries to automatically create the mapping when you add or update an 
-	 * object and provide a PRIMARY KEY when calling the ->add* or ->update* 
-	 * method.  
-	 * 
+	 * This function *does not* query QuickBooks, it only queries the internal
+	 * mapping of QuickBooks IDs to PRIMARY KEYS. The mappings can be created
+	 * with the {@link QuickBooks_Utilities::createMapping()} method and the API
+	 * tries to automatically create the mapping when you add or update an
+	 * object and provide a PRIMARY KEY when calling the ->add* or ->update*
+	 * method.
+	 *
 	 * @param string $object_type
 	 * @param mixed $app_ID
 	 * @return boolean
@@ -595,16 +595,16 @@ class QuickBooks_Utilities
 		{
 			return true;
 		}
-		
+
 		return false;
 	}
-	
+
 	/**
 	 * Initialize the backend driver
-	 * 
-	 * Initialization should only be done once, and is used to take care of 
+	 *
+	 * Initialization should only be done once, and is used to take care of
 	 * things like creating the database schema, etc.
-	 * 
+	 *
 	 * @param string $dsn				A DSN-style connection string
 	 * @param array $driver_options
 	 * @return boolean
@@ -612,13 +612,13 @@ class QuickBooks_Utilities
 	static public function initialize($dsn, $driver_options = array(), $init_options = array())
 	{
 		$Driver = QuickBooks_Utilities::driverFactory($dsn, $driver_options);
-		
+
 		return $Driver->initialize($init_options);
 	}
-	
+
 	/**
 	 * Tell whether or not a driver has been initialized
-	 * 
+	 *
 	 * @param string $dsn
 	 * @param array $driver_options
 	 * @return boolean
@@ -626,30 +626,30 @@ class QuickBooks_Utilities
 	static public function initialized($dsn, $driver_options = array())
 	{
 		$Driver = QuickBooks_Utilities::driverFactory($dsn, $driver_options);
-		
+
 		return $Driver->initialized();
 	}
-	
+
 	/**
-	 * 
-	 * 
+	 *
+	 *
 	 */
 	static public function date($date = null)
 	{
 		if ($date)
 		{
-			if (is_numeric($date) and 
+			if (is_numeric($date) and
 				strlen($date) > 6)
 			{
 				return date('Y-m-d', $date);
 			}
-			
+
 			return date('Y-m-d', strtotime($date));
 		}
-		
+
 		return date('Y-m-d');
 	}
-	
+
 	/**
 	 *
 	 *
@@ -659,21 +659,21 @@ class QuickBooks_Utilities
 	{
 		if ($datetime)
 		{
-			if (is_numeric($datetime) and 
+			if (is_numeric($datetime) and
 				strlen($datetime) > 6)
 			{
 				return date('Y-m-d', $datetime) . 'T' . date('H:i:s', $datetime);
 			}
-			
+
 			return date('Y-m-d', strtotime($datetime)) . 'T' . date('H:i:s', strtotime($datetime));
 		}
-		
+
 		return date('Y-m-d') . 'T' . date('H:i:s');
 	}
-		
+
 	/**
 	 * Tell if a pattern matches a string or not (Windows-compatible version of www.php.net/fnmatch)
-	 * 
+	 *
 	 * @param string $pattern
 	 * @param string $str
 	 * @return boolean
@@ -684,17 +684,17 @@ class QuickBooks_Utilities
 		{
 			return fnmatch($pattern, $str, FNM_CASEFOLD);
 		}
-		
+
 		$arr = array(
-			'\*' => '.*', 
+			'\*' => '.*',
 			'\?' => '.'
 			);
 		return preg_match('#^' . strtr(preg_quote($pattern, '#'), $arr) . '$#i', $str);
 	}
-	
+
 	/**
 	 * List all of the QuickBooks object types supported by the framework
-	 * 
+	 *
 	 * @param string $filter
 	 * @param boolean $return_keys
 	 * @param boolean $order_for_mapping
@@ -703,26 +703,26 @@ class QuickBooks_Utilities
 	static public function listObjects($filter = null, $return_keys = false, $order_for_mapping = false)
 	{
 		static $cache = array();
-		
+
 		$crunch = $filter . '[' . $return_keys . '[' . $order_for_mapping;
-		
+
 		if (isset($cache[$crunch]))
 		{
 			return $cache[$crunch];
 		}
-		
+
 		$constants = array();
-			
+
 		foreach (get_defined_constants() as $constant => $value)
 		{
-			if (substr($constant, 0, strlen('QUICKBOOKS_OBJECT_')) == 'QUICKBOOKS_OBJECT_' and 
+			if (substr($constant, 0, strlen('QUICKBOOKS_OBJECT_')) == 'QUICKBOOKS_OBJECT_' and
 				substr_count($constant, '_') == 2)
 			{
 				if (!$return_keys)
 				{
 					$constant = $value;
 				}
-				
+
 				if ($filter)
 				{
 					if (QuickBooks_Utilities::fnmatch($filter, $constant))
@@ -736,7 +736,7 @@ class QuickBooks_Utilities
 				}
 			}
 		}
-			
+
 		if ($order_for_mapping)
 		{
 			// Sort with the very longest values first, to the shortest values last
@@ -746,30 +746,30 @@ class QuickBooks_Utilities
 		{
 			sort($constants);
 		}
-			
+
 		$cache[$crunch] = $constants;
-			
+
 		return $constants;
 	}
-		
+
 	/**
 	 * Convert a QuickBooks action to a QuickBooks object type (i.e.: QUICKBOOKS_ADD_CUSTOMER gets converted to QUICKBOOKS_OBJECT_CUSTOMER)
-	 * 
+	 *
 	 * @param string $action
 	 * @return string
 	 */
 	static public function actionToObject($action)
 	{
 		static $cache = array();
-		
+
 		if (isset($cache[$action]))
 		{
 			//print('returning cached [' . $action . ']' . "\n");
 			return $cache[$action];
 		}
-		
+
 		$types = QuickBooks_Utilities::listObjects(null, false, true);
-		
+
 		foreach ($types as $type)
 		{
 			if (QuickBooks_Utilities::fnmatch('*' . $type . '*', $action))
@@ -779,34 +779,34 @@ class QuickBooks_Utilities
 				return $type;
 			}
 		}
-			
+
 		return null;
 	}
 
 	/**
 	 * Generate a GUID
-	 * 
+	 *
 	 * Note: This is used for tickets too, so it *must* be a RANDOM GUID!
-	 * 
+	 *
 	 * @param boolean $surround
 	 * @return string
 	 */
 	static public function GUID()
 	{
 		$guid = sprintf('%04x%04x-%04x-%03x4-%04x-%04x%04x%04x',
-			mt_rand(0, 65535), mt_rand(0, 65535), 
-			mt_rand(0, 65535), 
-			mt_rand(0, 4095),  
+			mt_rand(0, 65535), mt_rand(0, 65535),
+			mt_rand(0, 65535),
+			mt_rand(0, 4095),
 			bindec(substr_replace(sprintf('%016b', mt_rand(0, 65535)), '01', 6, 2)),
 			mt_rand(0, 65535), mt_rand(0, 65535), mt_rand(0, 65535)
-			);  	
-			
-		return $guid;	
-	}	
-		
+			);
+
+		return $guid;
+	}
+
 	/**
 	 * Try to guess the queueing priority for this action
-	 * 
+	 *
 	 * @param string $action		The action you're trying to guess for
 	 * @param string $dependency	If the action depends on another action (i.e. a DataExtAdd for a CustomerAdd) you can pass the dependency here
 	 * @return integer				A best guess at the proper priority
@@ -815,254 +815,254 @@ class QuickBooks_Utilities
 	{
 		// low priorities up here (*lots* of dependencies)
 		static $priorities = array(
-			QUICKBOOKS_DELETE_TRANSACTION, 
-			
-			QUICKBOOKS_VOID_TRANSACTION, 
-		
-			QUICKBOOKS_DEL_DATAEXT, 
+			QUICKBOOKS_DELETE_TRANSACTION,
+
+			QUICKBOOKS_VOID_TRANSACTION,
+
+			QUICKBOOKS_DEL_DATAEXT,
 			QUICKBOOKS_MOD_DATAEXT,
-			QUICKBOOKS_ADD_DATAEXT, 
-		
-			QUICKBOOKS_MOD_JOURNALENTRY, 
-			QUICKBOOKS_ADD_JOURNALENTRY, 
-		
-			QUICKBOOKS_MOD_RECEIVEPAYMENT, 
-			QUICKBOOKS_ADD_RECEIVEPAYMENT, 
-			
-			QUICKBOOKS_MOD_BILLPAYMENTCHECK, 
-			QUICKBOOKS_ADD_BILLPAYMENTCHECK, 
-			
-			//QUICKBOOKS_MOD_BILLPAYMENTCREDITCARD, 
-			QUICKBOOKS_ADD_BILLPAYMENTCREDITCARD, 
-			
-			QUICKBOOKS_MOD_BILL, 
-			QUICKBOOKS_ADD_BILL, 
-			
-			QUICKBOOKS_MOD_PURCHASEORDER, 
-			QUICKBOOKS_ADD_PURCHASEORDER, 
-			
+			QUICKBOOKS_ADD_DATAEXT,
+
+			QUICKBOOKS_MOD_JOURNALENTRY,
+			QUICKBOOKS_ADD_JOURNALENTRY,
+
+			QUICKBOOKS_MOD_RECEIVEPAYMENT,
+			QUICKBOOKS_ADD_RECEIVEPAYMENT,
+
+			QUICKBOOKS_MOD_BILLPAYMENTCHECK,
+			QUICKBOOKS_ADD_BILLPAYMENTCHECK,
+
+			//QUICKBOOKS_MOD_BILLPAYMENTCREDITCARD,
+			QUICKBOOKS_ADD_BILLPAYMENTCREDITCARD,
+
+			QUICKBOOKS_MOD_BILL,
+			QUICKBOOKS_ADD_BILL,
+
+			QUICKBOOKS_MOD_PURCHASEORDER,
+			QUICKBOOKS_ADD_PURCHASEORDER,
+
 			QUICKBOOKS_MOD_INVOICE,
 			QUICKBOOKS_ADD_INVOICE,
-			
-			QUICKBOOKS_MOD_SALESORDER, 
-			QUICKBOOKS_ADD_SALESORDER, 
-			
-			QUICKBOOKS_MOD_ESTIMATE, 
-			QUICKBOOKS_ADD_ESTIMATE, 
-			
-			QUICKBOOKS_ADD_INVENTORYADJUSTMENT, 
 
-			QUICKBOOKS_ADD_CREDITMEMO, 
-			QUICKBOOKS_MOD_CREDITMEMO, 
-			
+			QUICKBOOKS_MOD_SALESORDER,
+			QUICKBOOKS_ADD_SALESORDER,
+
+			QUICKBOOKS_MOD_ESTIMATE,
+			QUICKBOOKS_ADD_ESTIMATE,
+
+			QUICKBOOKS_ADD_INVENTORYADJUSTMENT,
+
+			QUICKBOOKS_ADD_CREDITMEMO,
+			QUICKBOOKS_MOD_CREDITMEMO,
+
 			QUICKBOOKS_ADD_ITEMRECEIPT,
 			QUICKBOOKS_MOD_ITEMRECEIPT,
 
-			QUICKBOOKS_MOD_SALESRECEIPT, 
-			QUICKBOOKS_ADD_SALESRECEIPT, 
+			QUICKBOOKS_MOD_SALESRECEIPT,
+			QUICKBOOKS_ADD_SALESRECEIPT,
 
-			QUICKBOOKS_ADD_SALESTAXITEM, 
-			QUICKBOOKS_MOD_SALESTAXITEM, 
-			
-			QUICKBOOKS_ADD_DISCOUNTITEM, 
-			QUICKBOOKS_MOD_DISCOUNTITEM, 
-			
-			QUICKBOOKS_ADD_OTHERCHARGEITEM, 
-			QUICKBOOKS_MOD_OTHERCHARGEITEM, 
-			
-			QUICKBOOKS_MOD_NONINVENTORYITEM, 
+			QUICKBOOKS_ADD_SALESTAXITEM,
+			QUICKBOOKS_MOD_SALESTAXITEM,
+
+			QUICKBOOKS_ADD_DISCOUNTITEM,
+			QUICKBOOKS_MOD_DISCOUNTITEM,
+
+			QUICKBOOKS_ADD_OTHERCHARGEITEM,
+			QUICKBOOKS_MOD_OTHERCHARGEITEM,
+
+			QUICKBOOKS_MOD_NONINVENTORYITEM,
 			QUICKBOOKS_ADD_NONINVENTORYITEM,
-			
-			QUICKBOOKS_MOD_INVENTORYITEM,  
-			QUICKBOOKS_ADD_INVENTORYITEM, 
-			
+
+			QUICKBOOKS_MOD_INVENTORYITEM,
+			QUICKBOOKS_ADD_INVENTORYITEM,
+
 			QUICKBOOKS_MOD_INVENTORYASSEMBLYITEM,
 			QUICKBOOKS_ADD_INVENTORYASSEMBLYITEM,
-			
-			QUICKBOOKS_MOD_SERVICEITEM, 
-			QUICKBOOKS_ADD_SERVICEITEM, 
-			
-			QUICKBOOKS_MOD_PAYMENTITEM, 
-			QUICKBOOKS_ADD_PAYMENTITEM, 
-			
-			QUICKBOOKS_MOD_SALESREP, 
-			QUICKBOOKS_ADD_SALESREP, 
-			
-			QUICKBOOKS_MOD_EMPLOYEE, 
-			QUICKBOOKS_ADD_EMPLOYEE, 
-			
+
+			QUICKBOOKS_MOD_SERVICEITEM,
+			QUICKBOOKS_ADD_SERVICEITEM,
+
+			QUICKBOOKS_MOD_PAYMENTITEM,
+			QUICKBOOKS_ADD_PAYMENTITEM,
+
+			QUICKBOOKS_MOD_SALESREP,
+			QUICKBOOKS_ADD_SALESREP,
+
+			QUICKBOOKS_MOD_EMPLOYEE,
+			QUICKBOOKS_ADD_EMPLOYEE,
+
 			//QUICKBOOKS_MOD_SALESTAXCODE, 		// The SDK doesn't support this
-			QUICKBOOKS_ADD_SALESTAXCODE, 
-			
-			QUICKBOOKS_MOD_VENDOR, 
-			QUICKBOOKS_ADD_VENDOR, 
-			
+			QUICKBOOKS_ADD_SALESTAXCODE,
+
+			QUICKBOOKS_MOD_VENDOR,
+			QUICKBOOKS_ADD_VENDOR,
+
 			QUICKBOOKS_MOD_JOB,
 			QUICKBOOKS_ADD_JOB,
-			
+
 			QUICKBOOKS_MOD_CUSTOMER,
 			QUICKBOOKS_ADD_CUSTOMER,
-			
-			QUICKBOOKS_MOD_ACCOUNT, 
-			QUICKBOOKS_ADD_ACCOUNT, 
-			
-			//QUICKBOOKS_MOD_CLASS,		(does not exist in qbXML API) 
-			QUICKBOOKS_ADD_CLASS, 
-			
-			QUICKBOOKS_ADD_PAYMENTMETHOD, 
-			QUICKBOOKS_ADD_SHIPMETHOD, 
-			
-			// Queries 
+
+			QUICKBOOKS_MOD_ACCOUNT,
+			QUICKBOOKS_ADD_ACCOUNT,
+
+			//QUICKBOOKS_MOD_CLASS,		(does not exist in qbXML API)
+			QUICKBOOKS_ADD_CLASS,
+
+			QUICKBOOKS_ADD_PAYMENTMETHOD,
+			QUICKBOOKS_ADD_SHIPMETHOD,
+
+			// Queries
 			QUICKBOOKS_QUERY_PURCHASEORDER,
 			QUICKBOOKS_QUERY_ITEMRECEIPT,
-			QUICKBOOKS_QUERY_SALESORDER, 
-			QUICKBOOKS_QUERY_SALESRECEIPT, 
+			QUICKBOOKS_QUERY_SALESORDER,
+			QUICKBOOKS_QUERY_SALESRECEIPT,
 			QUICKBOOKS_QUERY_INVOICE,
-			QUICKBOOKS_QUERY_ESTIMATE, 
-			QUICKBOOKS_QUERY_RECEIVEPAYMENT, 
-			QUICKBOOKS_QUERY_CREDITMEMO, 
-			
-			QUICKBOOKS_QUERY_BILLPAYMENTCHECK, 
-			QUICKBOOKS_QUERY_BILLPAYMENTCREDITCARD, 
-			QUICKBOOKS_QUERY_BILLTOPAY, 
-			QUICKBOOKS_QUERY_BILL, 
-			
-			QUICKBOOKS_QUERY_CREDITCARDCHARGE, 
-			QUICKBOOKS_QUERY_CREDITCARDCREDIT, 
-			QUICKBOOKS_QUERY_CHECK, 
+			QUICKBOOKS_QUERY_ESTIMATE,
+			QUICKBOOKS_QUERY_RECEIVEPAYMENT,
+			QUICKBOOKS_QUERY_CREDITMEMO,
+
+			QUICKBOOKS_QUERY_BILLPAYMENTCHECK,
+			QUICKBOOKS_QUERY_BILLPAYMENTCREDITCARD,
+			QUICKBOOKS_QUERY_BILLTOPAY,
+			QUICKBOOKS_QUERY_BILL,
+
+			QUICKBOOKS_QUERY_CREDITCARDCHARGE,
+			QUICKBOOKS_QUERY_CREDITCARDCREDIT,
+			QUICKBOOKS_QUERY_CHECK,
 			QUICKBOOKS_QUERY_CHARGE,
-			
+
 			QUICKBOOKS_QUERY_DELETEDLISTS,		// This gets all items deleted in the last 90 days
 			QUICKBOOKS_QUERY_DELETEDTXNS,		// This gets all transactions deleted in the last 90 days
-			
-			QUICKBOOKS_QUERY_TIMETRACKING, 
-			QUICKBOOKS_QUERY_VENDORCREDIT, 
-			
-			QUICKBOOKS_QUERY_INVENTORYADJUSTMENT, 
-			
-			QUICKBOOKS_QUERY_ITEM, 
-			QUICKBOOKS_QUERY_DISCOUNTITEM, 
-			QUICKBOOKS_QUERY_SALESTAXITEM, 
+
+			QUICKBOOKS_QUERY_TIMETRACKING,
+			QUICKBOOKS_QUERY_VENDORCREDIT,
+
+			QUICKBOOKS_QUERY_INVENTORYADJUSTMENT,
+
+			QUICKBOOKS_QUERY_ITEM,
+			QUICKBOOKS_QUERY_DISCOUNTITEM,
+			QUICKBOOKS_QUERY_SALESTAXITEM,
 			QUICKBOOKS_QUERY_SERVICEITEM,
-			QUICKBOOKS_QUERY_NONINVENTORYITEM, 
-			QUICKBOOKS_QUERY_INVENTORYITEM, 
+			QUICKBOOKS_QUERY_NONINVENTORYITEM,
+			QUICKBOOKS_QUERY_INVENTORYITEM,
 
-			QUICKBOOKS_QUERY_SALESREP, 
+			QUICKBOOKS_QUERY_SALESREP,
 
-			QUICKBOOKS_QUERY_VEHICLEMILEAGE, 
-			QUICKBOOKS_QUERY_VEHICLE, 
+			QUICKBOOKS_QUERY_VEHICLEMILEAGE,
+			QUICKBOOKS_QUERY_VEHICLE,
 
 			QUICKBOOKS_QUERY_CUSTOMER,
-			QUICKBOOKS_QUERY_VENDOR, 
-			QUICKBOOKS_QUERY_EMPLOYEE, 
+			QUICKBOOKS_QUERY_VENDOR,
+			QUICKBOOKS_QUERY_EMPLOYEE,
 			QUICKBOOKS_QUERY_JOB,
 
-			QUICKBOOKS_QUERY_WORKERSCOMPCODE, 
+			QUICKBOOKS_QUERY_WORKERSCOMPCODE,
 
 			QUICKBOOKS_QUERY_UNITOFMEASURESET,
-			
-			QUICKBOOKS_QUERY_JOURNALENTRY, 
-			QUICKBOOKS_QUERY_DEPOSIT,  
 
-			QUICKBOOKS_QUERY_SHIPMETHOD, 
-			QUICKBOOKS_QUERY_PAYMENTMETHOD, 
-			QUICKBOOKS_QUERY_PRICELEVEL, 
-			QUICKBOOKS_QUERY_DATEDRIVENTERMS, 
-			QUICKBOOKS_QUERY_BILLINGRATE, 
-			QUICKBOOKS_QUERY_CUSTOMERTYPE, 
-			QUICKBOOKS_QUERY_CUSTOMERMSG, 
-			QUICKBOOKS_QUERY_TERMS, 
-			QUICKBOOKS_QUERY_SALESTAXCODE, 
-			QUICKBOOKS_QUERY_ACCOUNT, 
-			QUICKBOOKS_QUERY_CLASS, 
-			QUICKBOOKS_QUERY_JOBTYPE, 
-			QUICKBOOKS_QUERY_VENDORTYPE, 
-			
-			QUICKBOOKS_QUERY_COMPANY, 
-			
-			
-			QUICKBOOKS_IMPORT_RECEIVEPAYMENT, 
-			
-			
+			QUICKBOOKS_QUERY_JOURNALENTRY,
+			QUICKBOOKS_QUERY_DEPOSIT,
+
+			QUICKBOOKS_QUERY_SHIPMETHOD,
+			QUICKBOOKS_QUERY_PAYMENTMETHOD,
+			QUICKBOOKS_QUERY_PRICELEVEL,
+			QUICKBOOKS_QUERY_DATEDRIVENTERMS,
+			QUICKBOOKS_QUERY_BILLINGRATE,
+			QUICKBOOKS_QUERY_CUSTOMERTYPE,
+			QUICKBOOKS_QUERY_CUSTOMERMSG,
+			QUICKBOOKS_QUERY_TERMS,
+			QUICKBOOKS_QUERY_SALESTAXCODE,
+			QUICKBOOKS_QUERY_ACCOUNT,
+			QUICKBOOKS_QUERY_CLASS,
+			QUICKBOOKS_QUERY_JOBTYPE,
+			QUICKBOOKS_QUERY_VENDORTYPE,
+
+			QUICKBOOKS_QUERY_COMPANY,
+
+
+			QUICKBOOKS_IMPORT_RECEIVEPAYMENT,
+
+
 			QUICKBOOKS_IMPORT_PURCHASEORDER,
 			QUICKBOOKS_IMPORT_ITEMRECEIPT,
-			QUICKBOOKS_IMPORT_SALESRECEIPT, 
-			
-			// The ESTIMATE, then INVOICE, then SALES ORDER order is important, 
-			//	because we might have events which depend on the estimate being present 
-			//	when the invoice is imported, or the sales order being present when 
-			//	then invoice is imported, etc. 
+			QUICKBOOKS_IMPORT_SALESRECEIPT,
+
+			// The ESTIMATE, then INVOICE, then SALES ORDER order is important,
+			//	because we might have events which depend on the estimate being present
+			//	when the invoice is imported, or the sales order being present when
+			//	then invoice is imported, etc.
 			QUICKBOOKS_IMPORT_INVOICE,
-			QUICKBOOKS_IMPORT_SALESORDER, 
-			QUICKBOOKS_IMPORT_ESTIMATE, 
-			
-			QUICKBOOKS_IMPORT_BILLPAYMENTCHECK, 
-			QUICKBOOKS_IMPORT_BILLPAYMENTCREDITCARD, 
-			QUICKBOOKS_IMPORT_BILLTOPAY, 
-			QUICKBOOKS_IMPORT_BILL, 
-			
-			QUICKBOOKS_IMPORT_CREDITCARDCHARGE, 
-			QUICKBOOKS_IMPORT_CREDITCARDCREDIT, 
-			QUICKBOOKS_IMPORT_CHECK, 
+			QUICKBOOKS_IMPORT_SALESORDER,
+			QUICKBOOKS_IMPORT_ESTIMATE,
+
+			QUICKBOOKS_IMPORT_BILLPAYMENTCHECK,
+			QUICKBOOKS_IMPORT_BILLPAYMENTCREDITCARD,
+			QUICKBOOKS_IMPORT_BILLTOPAY,
+			QUICKBOOKS_IMPORT_BILL,
+
+			QUICKBOOKS_IMPORT_CREDITCARDCHARGE,
+			QUICKBOOKS_IMPORT_CREDITCARDCREDIT,
+			QUICKBOOKS_IMPORT_CHECK,
 			QUICKBOOKS_IMPORT_CHARGE,
-			
+
 			QUICKBOOKS_IMPORT_DELETEDLISTS,    // This gets all items deleted in the last 90 days.
 			QUICKBOOKS_IMPORT_DELETEDTXNS,    // This gets all transactions deleted in the last 90 days.
-			
-			QUICKBOOKS_IMPORT_TIMETRACKING, 
-			QUICKBOOKS_IMPORT_VENDORCREDIT, 
-			
-			QUICKBOOKS_IMPORT_INVENTORYADJUSTMENT, 
-			
-			QUICKBOOKS_IMPORT_ITEM, 
-			QUICKBOOKS_IMPORT_DISCOUNTITEM, 
-			QUICKBOOKS_IMPORT_SALESTAXITEM, 
+
+			QUICKBOOKS_IMPORT_TIMETRACKING,
+			QUICKBOOKS_IMPORT_VENDORCREDIT,
+
+			QUICKBOOKS_IMPORT_INVENTORYADJUSTMENT,
+
+			QUICKBOOKS_IMPORT_ITEM,
+			QUICKBOOKS_IMPORT_DISCOUNTITEM,
+			QUICKBOOKS_IMPORT_SALESTAXITEM,
 			QUICKBOOKS_IMPORT_SERVICEITEM,
-			QUICKBOOKS_IMPORT_NONINVENTORYITEM, 
-			QUICKBOOKS_IMPORT_INVENTORYITEM, 
+			QUICKBOOKS_IMPORT_NONINVENTORYITEM,
+			QUICKBOOKS_IMPORT_INVENTORYITEM,
 			QUICKBOOKS_IMPORT_INVENTORYASSEMBLYITEM,
 
-			QUICKBOOKS_IMPORT_SALESREP, 
+			QUICKBOOKS_IMPORT_SALESREP,
 
-			QUICKBOOKS_IMPORT_VEHICLEMILEAGE, 
-			QUICKBOOKS_IMPORT_VEHICLE, 
+			QUICKBOOKS_IMPORT_VEHICLEMILEAGE,
+			QUICKBOOKS_IMPORT_VEHICLE,
 
 			QUICKBOOKS_IMPORT_CUSTOMER,
-			QUICKBOOKS_IMPORT_VENDOR, 
-			QUICKBOOKS_IMPORT_EMPLOYEE, 
+			QUICKBOOKS_IMPORT_VENDOR,
+			QUICKBOOKS_IMPORT_EMPLOYEE,
 			QUICKBOOKS_IMPORT_JOB,
 
-			QUICKBOOKS_IMPORT_WORKERSCOMPCODE, 
+			QUICKBOOKS_IMPORT_WORKERSCOMPCODE,
 
 			QUICKBOOKS_IMPORT_UNITOFMEASURESET,
-			
-			QUICKBOOKS_IMPORT_JOURNALENTRY, 
-			QUICKBOOKS_IMPORT_DEPOSIT,  
 
-			QUICKBOOKS_IMPORT_SHIPMETHOD, 
-			QUICKBOOKS_IMPORT_PAYMENTMETHOD, 
-			QUICKBOOKS_IMPORT_PRICELEVEL, 
-			QUICKBOOKS_IMPORT_DATEDRIVENTERMS, 
-			QUICKBOOKS_IMPORT_BILLINGRATE, 
-			QUICKBOOKS_IMPORT_CUSTOMERTYPE, 
-			QUICKBOOKS_IMPORT_CUSTOMERMSG, 
-			QUICKBOOKS_IMPORT_TERMS, 
-			QUICKBOOKS_IMPORT_SALESTAXCODE, 
-			QUICKBOOKS_IMPORT_ACCOUNT, 
-			QUICKBOOKS_IMPORT_CLASS, 
-			QUICKBOOKS_IMPORT_JOBTYPE, 
-			QUICKBOOKS_IMPORT_VENDORTYPE, 
-			
-			QUICKBOOKS_IMPORT_COMPANY, 
+			QUICKBOOKS_IMPORT_JOURNALENTRY,
+			QUICKBOOKS_IMPORT_DEPOSIT,
+
+			QUICKBOOKS_IMPORT_SHIPMETHOD,
+			QUICKBOOKS_IMPORT_PAYMENTMETHOD,
+			QUICKBOOKS_IMPORT_PRICELEVEL,
+			QUICKBOOKS_IMPORT_DATEDRIVENTERMS,
+			QUICKBOOKS_IMPORT_BILLINGRATE,
+			QUICKBOOKS_IMPORT_CUSTOMERTYPE,
+			QUICKBOOKS_IMPORT_CUSTOMERMSG,
+			QUICKBOOKS_IMPORT_TERMS,
+			QUICKBOOKS_IMPORT_SALESTAXCODE,
+			QUICKBOOKS_IMPORT_ACCOUNT,
+			QUICKBOOKS_IMPORT_CLASS,
+			QUICKBOOKS_IMPORT_JOBTYPE,
+			QUICKBOOKS_IMPORT_VENDORTYPE,
+
+			QUICKBOOKS_IMPORT_COMPANY,
 		);
 		// high priorities down here (no dependencies OR queries)
-		
-		// Now, let's space those priorities out a little bit, it gives us some 
-		//	wiggle room in case we need to add things inbetween the default 
+
+		// Now, let's space those priorities out a little bit, it gives us some
+		//	wiggle room in case we need to add things inbetween the default
 		//	priority values
 		static $wiggled = false;
 		$wiggle = 6;
-		
+
 		if (!$wiggled)
 		{
 			$count = count($priorities);
@@ -1070,67 +1070,67 @@ class QuickBooks_Utilities
 			{
 				$priorities[$i * $wiggle] = $priorities[$i];
 				unset($priorities[$i]);
-				
+
 				// with a wiggle multiplier of 2...
 				// 	priority 25 goes to 50
 				// 	priority 24 goes to 48
 				// 	priority 23 goes to 46
-				// 	etc. etc. etc. 
+				// 	etc. etc. etc.
 			}
-			
+
 			$wiggled = true;
-			
+
 			//print_r($priorities);
 		}
-		
+
 		if ($dependency)
 		{
-			// 
-			// This is a list of dependency modifications
-			//	For instance, normally, you'd want to send just any  old DataExtAdd 
-			//	with a really low priority, because whatever record it applies to 
-			//	must be in QuickBooks before you send the DataExtAdd/Mod request. 
-			// 
-			//	However, if we pass in the $dependency of QUICKBOOKS_ADD_CUSTOMER, 
-			//	then we know that this DataExt applies to a CustomerAdd, and can 
-			//	therefore be sent with a priority *just barely lower than* than a 
-			//	CustomerAdd request, which will ensure this gets run as soon as 
-			//	possible, but not sooner than the CustomerAdd.
-			// 
-			//	This is important because in some cases, this data will be 
-			//	automatically used by QuickBooks. For instance, a custom field that 
-			//	is placed on an Invoice *must already be populated for the 
-			//	Customer* before the invoice is created. 
 			//
-			// This is an example of a priority list without dependencies, and it's bad: 	
-			//	CustomerAdd, InvoiceAdd, DataExtAdd		
+			// This is a list of dependency modifications
+			//	For instance, normally, you'd want to send just any  old DataExtAdd
+			//	with a really low priority, because whatever record it applies to
+			//	must be in QuickBooks before you send the DataExtAdd/Mod request.
+			//
+			//	However, if we pass in the $dependency of QUICKBOOKS_ADD_CUSTOMER,
+			//	then we know that this DataExt applies to a CustomerAdd, and can
+			//	therefore be sent with a priority *just barely lower than* than a
+			//	CustomerAdd request, which will ensure this gets run as soon as
+			//	possible, but not sooner than the CustomerAdd.
+			//
+			//	This is important because in some cases, this data will be
+			//	automatically used by QuickBooks. For instance, a custom field that
+			//	is placed on an Invoice *must already be populated for the
+			//	Customer* before the invoice is created.
+			//
+			// This is an example of a priority list without dependencies, and it's bad:
+			//	CustomerAdd, InvoiceAdd, DataExtAdd
 			//	(the custom field for the customer doesn't get populated in the invoice)
 			//
-			// This is an example of a priority list with dependencies, and it's good: 
+			// This is an example of a priority list with dependencies, and it's good:
 			// 	CustomerAdd, DataExtAdd, InvoiceAdd
-			//	
+			//
 			$dependencies = array(
-				QUICKBOOKS_ADD_DATAEXT => array( 
-					QUICKBOOKS_ADD_CUSTOMER => QuickBooks_Utilities::priorityForAction(QUICKBOOKS_ADD_CUSTOMER) - 1, 
-					QUICKBOOKS_MOD_CUSTOMER => QuickBooks_Utilities::priorityForAction(QUICKBOOKS_MOD_CUSTOMER) - 1, 
+				QUICKBOOKS_ADD_DATAEXT => array(
+					QUICKBOOKS_ADD_CUSTOMER => QuickBooks_Utilities::priorityForAction(QUICKBOOKS_ADD_CUSTOMER) - 1,
+					QUICKBOOKS_MOD_CUSTOMER => QuickBooks_Utilities::priorityForAction(QUICKBOOKS_MOD_CUSTOMER) - 1,
 				),
 				QUICKBOOKS_MOD_DATAEXT => array(
-					QUICKBOOKS_ADD_CUSTOMER => QuickBooks_Utilities::priorityForAction(QUICKBOOKS_ADD_CUSTOMER) - 1, 
-					QUICKBOOKS_MOD_CUSTOMER => QuickBooks_Utilities::priorityForAction(QUICKBOOKS_MOD_CUSTOMER) - 1, 
+					QUICKBOOKS_ADD_CUSTOMER => QuickBooks_Utilities::priorityForAction(QUICKBOOKS_ADD_CUSTOMER) - 1,
+					QUICKBOOKS_MOD_CUSTOMER => QuickBooks_Utilities::priorityForAction(QUICKBOOKS_MOD_CUSTOMER) - 1,
 					),
-					
-				// A *Bill VOID* has a slightly higher priority than a PurchaseOrderMod so that we can IsManuallyClosed POs (we'll get an error if we try to close it and a bill is dependent on it)  
+
+				// A *Bill VOID* has a slightly higher priority than a PurchaseOrderMod so that we can IsManuallyClosed POs (we'll get an error if we try to close it and a bill is dependent on it)
 				QUICKBOOKS_VOID_TRANSACTION => array(
-					QUICKBOOKS_MOD_PURCHASEORDER => QuickBooks_Utilities::priorityForAction(QUICKBOOKS_MOD_PURCHASEORDER) + 1, 
-					), 
-				);			
+					QUICKBOOKS_MOD_PURCHASEORDER => QuickBooks_Utilities::priorityForAction(QUICKBOOKS_MOD_PURCHASEORDER) + 1,
+					),
+				);
 		}
-		
+
 		// Check for dependency priorities
-		if ($dependency and 
-			isset($dependencies[$action]) and 
+		if ($dependency and
+			isset($dependencies[$action]) and
 			isset($dependencies[$action][$dependency]))
-		{			
+		{
 			// Dependency modified priority
 			return $dependencies[$action][$dependency];
 		}
@@ -1139,14 +1139,14 @@ class QuickBooks_Utilities
 			// Regular priority
 			return $key;
 		}
-		
+
 		// Default priority
-		return 999;		
+		return 999;
 	}
-		
+
 	/**
 	 * List all of the QuickBooks actions the framework supports
-	 * 
+	 *
 	 * @param string $filter
 	 * @param boolean $return_keys
 	 * @return array
@@ -1154,16 +1154,16 @@ class QuickBooks_Utilities
 	static public function listActions($filter = null, $return_keys = false)
 	{
 		$startswith = array(
-			'QUICKBOOKS_IMPORT_', 
-			'QUICKBOOKS_QUERY_', 
-			'QUICKBOOKS_ADD_', 
-			'QUICKBOOKS_MOD_', 
-			'QUICKBOOKS_DEL_', 
-			'QUICKBOOKS_VOID_', 
+			'QUICKBOOKS_IMPORT_',
+			'QUICKBOOKS_QUERY_',
+			'QUICKBOOKS_ADD_',
+			'QUICKBOOKS_MOD_',
+			'QUICKBOOKS_DEL_',
+			'QUICKBOOKS_VOID_',
 			);
-			
+
 		$constants = array();
-		
+
 		//$inter_key = 'QUICKBOOKS_INTERACTIVE_MODE';
 		//$inter_val = QUICKBOOKS_INTERACTIVE_MODE;
 		/*
@@ -1189,7 +1189,7 @@ class QuickBooks_Utilities
 			$constants[] = $inter_val;
 		}
 		*/
-			
+
 		foreach (get_defined_constants() as $constant => $value)
 		{
 			foreach ($startswith as $start)
@@ -1200,7 +1200,7 @@ class QuickBooks_Utilities
 					{
 						$constant = $value;
 					}
-					
+
 					if (!is_null($filter))
 					{
 						if (QuickBooks_Utilities::fnmatch($filter, $constant))
@@ -1215,23 +1215,23 @@ class QuickBooks_Utilities
 				}
 			}
 		}
-			
+
 		sort($constants);
-			
+
 		return $constants;
 	}
-	
+
 	/**
 	 * Get the primary key within QuickBooks for this type of object (or this type of action)
-	 * 
+	 *
 	 * <code>
 	 * 	// This prints "ListID"
 	 * 	print(QuickBooks_Utilities::keyForObject(QUICKBOOKS_OBJECT_CUSTOMER));
-	 * 
+	 *
 	 * 	// This prints "TxnID"  (this method also works for actions)
 	 * 	print(QuickBooks_Utilities::keyForObject(QUICKBOOKS_ADD_INVOICE));
 	 * </code>
-	 * 
+	 *
 	 * @param string $object		An object or action type
 	 * @return string
 	 */
@@ -1239,7 +1239,7 @@ class QuickBooks_Utilities
 	{
 		// Make sure it's an object
 		$object = QuickBooks_Utilities::actionToObject($object);
-		
+
 		switch ($object)
 		{
 			case QUICKBOOKS_OBJECT_BILLPAYMENTCREDITCARD:
@@ -1272,7 +1272,7 @@ class QuickBooks_Utilities
 				return 'ListID';
 		}
 	}
-	
+
 	/**
 	 * Alias of QuickBooks_Utilities::keyForObject()
 	 */
@@ -1280,10 +1280,10 @@ class QuickBooks_Utilities
 	{
 		return QuickBooks_Utilities::keyForObject($action);
 	}
-			
+
 	/**
 	 * Converts an action to a request (example: "CustomerAdd" to "CustomerAddRq")
-	 * 
+	 *
 	 * @param string $action
 	 * @return string
 	 */
@@ -1291,10 +1291,10 @@ class QuickBooks_Utilities
 	{
 		return $action . 'Rq';
 	}
-		
+
 	/**
 	 * Converts an action to a response (example: "CustomerAdd" to "CustomerAddRs")
-	 * 
+	 *
 	 * @param string $action
 	 * @return string
 	 */
@@ -1302,10 +1302,10 @@ class QuickBooks_Utilities
 	{
 		return $action . 'Rs';
 	}
-		
+
 	/**
 	 * Converts a request to an action (example: "CustomerAddRq" to "CustomerAdd")
-	 * 
+	 *
 	 * @param string $request
 	 * @return string
 	 */
@@ -1313,10 +1313,10 @@ class QuickBooks_Utilities
 	{
 		return substr($request, 0, -2);
 	}
-		
+
 	/**
 	 * Converts an action to an XML Element (example: "CustomerAdd" to "CustomerRet")
-	 * 
+	 *
 	 * @param string $action
 	 * @return string
 	 */
@@ -1324,10 +1324,10 @@ class QuickBooks_Utilities
 	{
 		return $object . 'Ret';
 	}
-		
+
 	/**
 	 * Converts an action to an XML Element (example: "CustomerAdd" to "CustomerRet")
-	 * 
+	 *
 	 * @param string $action
 	 * @return string
 	 */
@@ -1335,10 +1335,10 @@ class QuickBooks_Utilities
 	{
 		return QuickBooks_Utilities::actionToObject($action) . 'Ret';
 	}
-		
+
 	/**
 	 * Converts an object type to the corresponding Query Action (example: "Customer" to "CustomerQuery")
-	 * 
+	 *
 	 * @param string $type
 	 * @return string
 	 */
@@ -1346,7 +1346,7 @@ class QuickBooks_Utilities
 	{
 		return QuickBooks_Utilities::actionToObject($type) . 'Query';
 	}
-		
+
 	/**
 	 * Converts an object type to the corresponding Mod Action
 	 * Ex: Customer to CustomerMod
@@ -1355,7 +1355,7 @@ class QuickBooks_Utilities
 	{
 		return QuickBooks_Utilities::actionToObject($type) . 'Mod';
 	}
-		
+
 	/**
 	 * Converts an object type to the corresponding Add Action
 	 * Ex: Customer to CustomerAdd
@@ -1364,8 +1364,8 @@ class QuickBooks_Utilities
 	{
 		return QuickBooks_Utilities::actionToObject($type) . 'Add';
 	}
-		
-		
+
+
 	/**
 	 * Converts an actrion to the corresponding Query Action
 	 * Ex: Customer to CustomerQuery
@@ -1374,7 +1374,7 @@ class QuickBooks_Utilities
 	{
 		return QuickBooks_Utilities::objectToQuery(QuickBooks_Utilities::actionToObject($action));
 	}
-		
+
 	/**
 	 * Converts an action to the corresponding Mod Action
 	 * Ex: Customer to CustomerQuery
@@ -1383,14 +1383,14 @@ class QuickBooks_Utilities
 	{
 		return QuickBooks_Utilities::objectToMod(QuickBooks_Utilities::actionToObject($action));
 	}
-		
+
 	/**
 	 * Converts a MySQL timestamp value to the timezone of the PHP server this script is running on.
-	 * 
+	 *
 	 * @deprecated This need to be removed and moved to a driver class!
-	 * 
+	 *
 	 * Expects $datetime in the formation of "YYYY-MM-DD HH:MM:SS"
-	 * 
+	 *
 	 * @TODO Double check that a lack of a Driver Instance properly returns false.
 	 * @TODO Investigate possible bug if within a few hours of daylight savings change.
 	 * @TODO This should *not* be in the QuickBooks_Utilties class, any database queries that arn't abstracted need to be in QuickBooks/Driver/Sql/your-sql-file-here.php
@@ -1398,63 +1398,63 @@ class QuickBooks_Utilities
 	/*static public function mysqlTZToPHPTZ($datetime)
 	{
 		$Driver = QuickBooks_Driver_Singleton::getInstance();
-			
+
 		$sql = " SELECT UTC_TIME() AS theUtcTime, CURTIME() AS theCurTime ";
 		$res = $Driver->query($sql, $errnum, $errmsg);
-			
+
 		if (!$res)
 		{
 			return false;
 		}
-			
+
 		if (!($arr = $Driver->fetch($res)))
 		{
 			return false;
 		}
-			
-		// get the time bits: 
-		$utcTime = explode(":", $arr['theUtcTime']); 
-		$curTime = explode(":", $arr['theCurTime']); 
-		
+
+		// get the time bits:
+		$utcTime = explode(":", $arr['theUtcTime']);
+		$curTime = explode(":", $arr['theCurTime']);
+
 		// create unix timestamps for each
-		// since we're calculating a relative time only: 
-		$utc_t = mktime($utcTime[0], $utcTime[1], $utcTime[2]); 
-		$cur_t = mktime($curTime[0], $curTime[1], $curTime[2]); 
-			
+		// since we're calculating a relative time only:
+		$utc_t = mktime($utcTime[0], $utcTime[1], $utcTime[2]);
+		$cur_t = mktime($curTime[0], $curTime[1], $curTime[2]);
+
 		$mysqlOffset = ($cur_t - $utc_t);
-			
+
 		$phpOffset = (int) date('Z');
-			
+
 		//mail("grgisme@gmail.com","Offsets","MysqlOffset: ".($mysqlOffset)."\n\n\nPHPOffset: ".$phpOffset);
-			
+
 		$timezoneDiff = $mysqlOffset - $phpOffset;
-			
+
 		$tempTime = explode(" ", $datetime);
-			
+
 		if (count($tempTime) != 2)//Improper input
 		{
 			return FALSE;
 		}
-			
+
 		$mysqlTime = explode(":", $tempTime[1]);
-			
+
 		$mysql_t = mktime($mysqlTime[0], $mysqlTime[1], $mysqlTime[2]);
-			
+
 		$newMysqlTime = $mysql_t - $timezoneDiff;
-			
+
 		//mail("grgisme@gmail.com","TimeZone Diff","TimeZone Diff: ".($timezoneDiff));
-			
+
 		return $tempTime[0]." ".date("H:i:s", $newMysqlTime);
-		
+
 	}*/
-	
+
 	/**
 	 * Compares a time reported from QuickBooks to a mysql datetime field
 	 * Ex: QB Time: 2009-01-23T08:33:56-05:00
 	 *     SQL Time: 2009-01-23 08:31:11
-	 * 
+	 *
 	 * @deprecated This needs to be moved to a driver class!
-	 * 
+	 *
 	 * Returns -1 if QB Time is Smaller
 	 * Returns 0 if Times are Equal
 	 * Returns 1 if QB Time is Greater
@@ -1463,16 +1463,16 @@ class QuickBooks_Utilities
 	/*static public function compareQBTimeToSQLTime($QBTime, $SQLTime)
 	{
 		$SQLTime = QuickBooks_Utilities::mysqlTZToPHPTZ($SQLTime);
-			
+
 		$tempTime = explode(" ", $SQLTime);
 		$mysqlTime = explode(":", $tempTime[1]);
 		$tempTime = explode("-", $tempTime[0]);
-			
+
 		$mysql_t = mktime($mysqlTime[0], $mysqlTime[1], $mysqlTime[2], $tempTime[1], $tempTime[2], $tempTime[0], 0);
 		$QBTime = strtotime($QBTime);
-			
+
 		//mail("grgisme@gmail.com","QBTime","QBTime: ".($QBTime)."\n\n\nSQLTime: ".$mysql_t."\n\n\n".$SQLTime."\n\n\nDaylight Savings?: ".date('I'));
-			
+
 		if ($QBTime < $mysql_t)
 			return -1;
 		elseif($QBTime > $mysql_t)

--- a/QuickBooks/XML.php
+++ b/QuickBooks/XML.php
@@ -2,13 +2,13 @@
 
 /**
  * XML constants (and backward compat. class)
- * 
+ *
  * Copyright (c) 2010-04-16 Keith Palmer / ConsoliBYTE, LLC.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.opensource.org/licenses/eclipse-1.0.php
- * 
+ *
  * @package QuickBooks
  * @subpackage XML
  */
@@ -48,58 +48,58 @@ class QuickBooks_XML
 	 * @var integer
 	 */
 	const ERROR_OK = 0;
-	
+
 	/**
 	 * Alias of QUICKBOOKS_XML_ERROR_OK
 	 */
 	const OK = 0;
-	
+
 	/**
 	 * Indicates a tag mismatch/bad tag order
 	 * @var integer
 	 */
 	const ERROR_MISMATCH = 1;
-	
+
 	/**
-	 * Indicates garbage somewhere in the XML stream 
+	 * Indicates garbage somewhere in the XML stream
 	 * @var integer
 	 */
 	const ERROR_GARBAGE = 2;
-	
+
 	/**
 	 * Indicates a bad XML entity
 	 * @var integer
 	 */
 	const ERROR_ENTITY = 3;
-	
+
 	/**
 	 * Indicates a dangling XML attribute after parsing
 	 * @var integer
 	 */
 	const ERROR_DANGLING = 4;
-	
+
 	/**
 	 * Internal XML parser error
 	 * @var integer
 	 */
 	const ERROR_INTERNAL = 5;
-	
+
 	/**
 	 * No content to parse error
 	 * @var integer
 	 */
 	const ERROR_CONTENT = 6;
-	
+
 	/**
-	 * 
+	 *
 	 */
 	const PARSER_BUILTIN = 'builtin';
-	
+
 	/**
-	 * 
+	 *
 	 */
 	const PARSER_SIMPLEXML = 'simplexml';
-	
+
 	/**
 	 * <code>
 	 * $xml = '
@@ -107,84 +107,84 @@ class QuickBooks_XML
 	 * 		<Name type="firstname">Keith</Name>
 	 * 	</Person>
 	 * ';
-	 * 
+	 *
 	 * $arr = array(
 	 * 	'Person' => array(
-	 * 		'Name' => 'Keith', 
-	 * 		), 
+	 * 		'Name' => 'Keith',
+	 * 		),
 	 * 	);
 	 * </code>
 	 */
 	const ARRAY_NOATTRIBUTES = 'no-attrs';
-	
+
 	/**
-	 * 
+	 *
 	 * <code>
 	 * $arr = array(
 	 * 	'Person' => array(
 	 * 		'Name' => 'Keith',
-	 * 		'Name_type' => 'firstname', 
-	 * 		), 
+	 * 		'Name_type' => 'firstname',
+	 * 		),
 	 * 	);
 	 * </code>
-	 * 
+	 *
 	 */
 	const ARRAY_EXPANDATTRIBUTES = 'child-attrs';
-	
+
 	/**
 	 * <code>
 	 * $arr = array(
 	 * 	0 => array(
-	 * 		'name' => 'Person', 
+	 * 		'name' => 'Person',
 	 * 		'attributes' => array( ),
 	 * 		'children' => array(
 	 * 			0 => array(
-	 * 				'name' => 'Name', 
-	 * 				'attributes' => array( 
-	 * 					'type' => 'firstname', 
-	 * 				), 
-	 * 				'children' => array(  ), 
-	 * 				'data' => 'Keith', 
-	 * 			),  
-	 * 		), 
-	 * 		'data' => null, 
-	 * 	), 	
+	 * 				'name' => 'Name',
+	 * 				'attributes' => array(
+	 * 					'type' => 'firstname',
+	 * 				),
+	 * 				'children' => array(  ),
+	 * 				'data' => 'Keith',
+	 * 			),
+	 * 		),
+	 * 		'data' => null,
+	 * 	),
 	 * );
 	 * </code>
 	 */
 	const ARRAY_BRANCHED = 'branched';
-	
+
 	/**
-	 * 
+	 *
 	 * <code>
 	 * $arr = array(
-	 * 	'Person Name' => 'Keith', 
+	 * 	'Person Name' => 'Keith',
 	 * 	);
 	 * </code>
-	 * 
+	 *
 	 */
 	const ARRAY_PATHS = 'paths';
-	
+
 	/**
 	 * Flag to compress empty XML elements
-	 * 
+	 *
 	 * <Customer>
 	 * 	<FirstName>Keith</FirstName>
 	 * 	<LastName />
 	 * </Customer>
-	 * 
+	 *
 	 * @note Defined as an integer for backwards compat.
-	 * @var integer 
+	 * @var integer
 	 */
 	const XML_COMPRESS = 1;
-	
+
 	/**
 	 * Flag to drop empty XML elements
-	 * 
+	 *
 	 * <Customer>
 	 * 	<FirstName>Keith</FirstName>
 	 * </Customer>
-	 * 
+	 *
 	 * @note Defined as an integer for backwards compat.
 	 * @var integer
 	 */
@@ -192,85 +192,85 @@ class QuickBooks_XML
 
 	/**
 	 * Flag to preserve empty elements
-	 * 
+	 *
 	 * <Customer>
 	 * 	<FirstName>Keith</FirstName>
 	 * 	<LastName></LastName>
 	 * </Customer>
-	 * 
+	 *
 	 * @note Defined as an integer for backwards compat.
 	 * @var integer
 	 */
 	const XML_PRESERVE = 0;
-	
+
 	/**
 	 * Extract the contents from a particular XML tag in an XML string
-	 * 
+	 *
 	 * <code>
 	 * $xml = '<document><stuff>bla bla</stuff><other>ble ble</other></document>';
 	 * $contents = QuickBooks_Utilities::_extractTagContents('stuff', $xml);
 	 * print($contents); 	// prints "bla bla"
 	 * </code>
-	 * 
-	 * @param string $tag		The XML tag to extract the contents from 
+	 *
+	 * @param string $tag		The XML tag to extract the contents from
 	 * @param string $data		The XML document
 	 * @return string			The contents of the tag
-	 */	
+	 */
 	static public function extractTagContents($tag, $data)
 	{
 		$tag = trim($tag, '<> ');
-		
-		if (false !== strpos($data, '<' . $tag . '>') and 
+
+		if (false !== strpos($data, '<' . $tag . '>') and
 			false !== strpos($data, '</' . $tag . '>'))
 		{
 			$data = strstr($data, '<' . $tag . '>');
 			$end = strpos($data, '</' . $tag . '>');
-			
+
 			return substr($data, strlen($tag) + 2, $end - (strlen($tag) + 2));
 		}
-		
+
 		return null;
-	}		
-	
+	}
+
 	// @todo Documentation
 	static public function extractTagAttribute($attribute, $tag_w_attrs, $which = 0)
 	{
 		/*
-		if (false !== ($start = strpos($tag_w_attrs, $attribute . '="')) and 
+		if (false !== ($start = strpos($tag_w_attrs, $attribute . '="')) and
 			false !== ($end = strpos($tag_w_attrs,  '"', $start + strlen($attribute) + 2)))
 		{
 			return substr($tag_w_attrs, $start + strlen($attribute) + 2, $end - $start - strlen($attribute) - 2);
 		}
-		
+
 		return null;
 		*/
-		
+
 		$attr = $attribute;
 		$data = $tag_w_attrs;
-		
+
 		if ($which == 1)
 		{
 			$spos = strpos($data, $attr . '="');
 			$data = substr($data, $spos + strlen($attr));
 		}
-		
-		if (false !== ($spos = strpos($data, $attr . '="')) and 
+
+		if (false !== ($spos = strpos($data, $attr . '="')) and
 			false !== ($epos = strpos($data, '"', $spos + strlen($attr) + 2)))
 		{
 			//print('start: ' . $spos . "\n");
 			//print('end: ' . $epos . "\n");
-			
+
 			return substr($data, $spos + strlen($attr) + 2, $epos - $spos - strlen($attr) - 2);
 		}
-		
+
 		return '';
 	}
-	
+
 	/**
 	 * Extract the attributes from a tag container
-	 * 
+	 *
 	 * @todo Holy confusing code Batman!
-	 * 
+	 *
 	 * @param string $tag_w_attributes
 	 * @param string $tag
 	 * @param array $attributes
@@ -280,79 +280,79 @@ class QuickBooks_XML
 	{
 		$tag = '';
 		$attributes = array();
-		
+
 		$tag_w_attrs = trim($tag_w_attrs);
-		
+
 		/*if (substr($tag_w_attrs, -1, 1) == '/')		// condensed empty tag
 		{
 			$tag = trim($tag_w_attrs, '/ ');
 			$attributes = array();
 		}
-		else*/ 
+		else*/
 		if (false !== strpos($tag_w_attrs, ' '))
 		{
 			$tmp = explode(' ', $tag_w_attrs);
 			//$tag = trim(array_shift($tmp), " \n\r\t<>");
 			$tag = trim(array_shift($tmp));
-			
+
 			$attributes = array();
-			
+
 			$attrs = trim(implode(' ', $tmp));
 			$length = strlen($attrs);
-			
+
 			$key = '';
 			$value = '';
 			$in_key = true;
 			$in_value = false;
 			$expect_key = false;
 			$expect_value = false;
-			
+
 			for ($i = 0; $i < $length; $i++)
 			{
-				if ($attrs{$i} == '=')
+				if ($attrs[$i] == '=')
 				{
 					$in_key = false;
 					$in_value = false;
 					$expect_value = true;
 				}
 				/*
-				else if ($attrs{$i} == '"' and $expect_value)
+				else if ($attrs[$i] == '"' and $expect_value)
 				{
 					$in_value = true;
 					$expect_value = false;
 				}
 				*/
-				/*else if ($attrs{$i} == '"' and $in_value)*/
-				else if (($attrs{$i} == '"' or $attrs{$i} == '\'') and $expect_value)
+				/*else if ($attrs[$i] == '"' and $in_value)*/
+				else if (($attrs[$i] == '"' or $attrs[$i] == '\'') and $expect_value)
 				{
 					$in_value = true;
 					$expect_value = false;
 				}
-				else if (($attrs{$i} == '"' or $attrs{$i} == '\'') and $in_value)
+				else if (($attrs[$i] == '"' or $attrs[$i] == '\'') and $in_value)
 				{
 					$attributes[trim($key)] = $value;
-					
+
 					$key = '';
 					$value = '';
-					
+
 					$in_value = false;
 					$expect_key = true;
 				}
-				else if ($attrs{$i} == ' ' and $expect_key)
+				else if ($attrs[$i] == ' ' and $expect_key)
 				{
 					$expect_key = false;
 					$in_key = true;
 				}
 				else if ($in_key)
 				{
-					$key .= $attrs{$i};
+					$key .= $attrs[$i];
 				}
 				else if ($in_value)
 				{
-					$value .= $attrs{$i};
+					$value .= $attrs[$i];
 				}
 			}
-			
+
 			/*
 			foreach ($tmp as $attribute)
 			{
@@ -360,7 +360,7 @@ class QuickBooks_XML
 				{
 					$key = trim(substr($attribute, 0, $pos));
 					$value = trim(substr($attribute, $pos + 1), '"');
-					
+
 					$attributes[$key] = $value;
 				}
 			}*/
@@ -370,37 +370,37 @@ class QuickBooks_XML
 			$tag = $tag_w_attrs;
 			$attributes = array();
 		}
-		
+
 		// This returns the actual tag without attributes as the first key of the array
 		if ($return_tag_first)
 		{
 			array_unshift($attributes, $tag);
 		}
-		
+
 		return $attributes;
 	}
-	
+
 	/**
 	 * Encode a string for use within an XML document
 	 *
 	 * @todo Investigate QuickBooks qbXML encoding and implement solution
-	 * 
+	 *
 	 * @param string $str				The string to encode
-	 * @param boolean $for_qbxml		
+	 * @param boolean $for_qbxml
 	 * @return string
 	 */
 	static public function encode($str, $for_qbxml = true, $double_encode = true)
 	{
 		$transform = array(
-			'&' => '&amp;', 
-			'<' => '&lt;', 
-			'>' => '&gt;', 
-			//'\'' => '&apos;', 
-			'"' => '&quot;', 
+			'&' => '&amp;',
+			'<' => '&lt;',
+			'>' => '&gt;',
+			//'\'' => '&apos;',
+			'"' => '&quot;',
 			);
-		
+
 		$str = str_replace(array_keys($transform), array_values($transform), $str);
-		
+
 		if (!$double_encode)
 		{
 			$fix = array();
@@ -408,33 +408,33 @@ class QuickBooks_XML
 			{
 				$fix[str_replace('&', '&amp;', $encoded)] = $encoded;
 			}
-			
+
 			$str = str_replace(array_keys($fix), array_values($fix), $str);
 		}
-		
+
 		return $str;
 	}
-	
+
 	/**
 	 * Decode a string for use within an XML document
 	 *
 	 * @todo Investigate QuickBooks qbXML encoding and implement solution
-	 * 
+	 *
 	 * @param string $str				The string to encode
-	 * @param boolean $for_qbxml		
+	 * @param boolean $for_qbxml
 	 * @return string
 	 */
 	static public function decode($str, $for_qbxml = true)
 	{
 		$transform = array(
-			'&lt;' => '<', 
-			'&gt;' => '>', 
-			'&apos;' => '\'', 
-			'&quot;' => '"', 
+			'&lt;' => '<',
+			'&gt;' => '>',
+			'&apos;' => '\'',
+			'&quot;' => '"',
 			'&amp;' => '&', 		// Make sure that this is *the last* transformation to run, otherwise we end up double-un-encoding things
 			);
-			
-		return str_replace(array_keys($transform), array_values($transform), $str);		
+
+		return str_replace(array_keys($transform), array_values($transform), $str);
 	}
 }
 


### PR DESCRIPTION
php 7.4 and php 8 have removed the ability to use curly braces to select a single character from a string. 

Error is: Array and string offset access syntax with curly braces is deprecated at ....

The fix is to use square brackets. https://www.php.net/manual/en/migration74.deprecated.php#migration74.deprecated.core.array-string-access-curly-brace

Searched for \w\{ with regex and replaced all instances manually, there's two instances that aren't applicable.

My commit includes a lot of whitespace changes due to my IDE settings so easier to review by adding ?w=1 to the URL to hide the whitespace changes.