### PR TITLE
Add error code threshold

### DIFF
--- a/QuickBooks/WebConnector/Handlers.php
+++ b/QuickBooks/WebConnector/Handlers.php
@@ -320,6 +320,8 @@ class QuickBooks_WebConnector_Handlers
 			'deny_reallyfast_timeout' => 600,
 
 			'masking' => true,
+
+      'status_error_threshold' => 500, // the lowest status code considered an error
 			);
 
 		$config = array_merge($defaults, $config);
@@ -346,6 +348,8 @@ class QuickBooks_WebConnector_Handlers
 
 		$config['deny_reallyfast_logins'] = (boolean) $config['deny_reallyfast_logins'];
 		$config['deny_reallyfast_timeout'] = (int) max(1, $config['deny_reallyfast_timeout']);
+
+    $config['status_error_threshold'] = (int) max(1, $config['status_error_threshold']);
 
 		return $config;
 	}
@@ -1288,7 +1292,8 @@ class QuickBooks_WebConnector_Handlers
 
 			// Check if we got a error message...
 			if (strlen($obj->message) or
-				$this->_extractStatusCode($obj->response)) // or an error code
+          $this->_extractStatusCode($obj->response)
+          >= $this->_config['status_error_threshold']) // or an error code
 			{
 				//$this->_log('Extracted code[' . $this->_extractStatusCode($obj->response) . ']', $obj->ticket, QUICKBOOKS_LOG_DEBUG);
 


### PR DESCRIPTION
By spec all actual API errors have a status code 500 or greater, and only these should be handled as a process error. Other codes should keep the connection open, at least by default.