### PR TITLE
Prevent fatal error when QuickBooks Online is offline

### DIFF
--- a/QuickBooks/IPP/Parser.php
+++ b/QuickBooks/IPP/Parser.php
@@ -350,32 +350,37 @@ class QuickBooks_IPP_Parser
 
 					$list = array();
 
-					$List = $Root->getChildAt('IntuitResponse QueryResponse');
-
-					$attrs = $List->attributes();
-
-					if (!array_key_exists('startPosition', $attrs) and
-						array_key_exists('totalCount', $attrs))
+					if ($List = $Root->getChildAt('IntuitResponse QueryResponse'))
 					{
-						return $attrs['totalCount'];
+						$attrs = $List->attributes();
+
+						if (!array_key_exists('startPosition', $attrs) and
+							array_key_exists('totalCount', $attrs))
+						{
+							return $attrs['totalCount'];
+						}
+						else
+						{
+
+							foreach ($List->children() as $Child)
+							{
+								$class = 'QuickBooks_IPP_Object_' . $Child->name();
+								$Object = new $class();
+
+								foreach ($Child->children() as $Data)
+								{
+									$this->_push($Data, $Object);
+								}
+
+								$list[] = $Object;
+							}
+
+							return $list;
+						}
 					}
 					else
 					{
-
-						foreach ($List->children() as $Child)
-						{
-							$class = 'QuickBooks_IPP_Object_' . $Child->name();
-							$Object = new $class();
-
-							foreach ($Child->children() as $Data)
-							{
-								$this->_push($Data, $Object);
-							}
-
-							$list[] = $Object;
-						}
-
-						return $list;
+						return false;
 					}
 			}
 		}


### PR DESCRIPTION
This diff looks much bloodier than it is. All I did was wrap the call to $List = $Root->getChildAt('IntuitResponse QueryResponse') in an IF, and return false in the ELSE.

Prevents a fatal error when QuickBooks Online is offline, and the call to $List = $Root->getChildAt('IntuitResponse QueryResponse') returns FALSE, so $List->attributes() throws an error.