### PR TITLE
Cleanup asQBXML() & some undefined constants.

### DIFF
--- a/QuickBooks/QBXML/Object.php
+++ b/QuickBooks/QBXML/Object.php
@@ -572,11 +572,9 @@ abstract class QuickBooks_QBXML_Object
 	 *   @todo Support for qbXML versions
 	 * @param $locale
 	 *   Restrict it to a specific qbXML locale?
-	 * @param $root
-	 *   Unused - @todo: remove this.
 	 * @return string
 	 */
-	public function asQBXML($request, $version = null, $locale = null, $root = null)
+	public function asQBXML($request, $version = null, $locale = null)
 	{
 		$todo_for_empty_elements = QuickBooks_XML::XML_DROP;
 		$indent = "\t";

--- a/QuickBooks/QBXML/Object.php
+++ b/QuickBooks/QBXML/Object.php
@@ -565,15 +565,17 @@ abstract class QuickBooks_QBXML_Object
 	
 	/**
 	 * Convert this object to a valid qbXML request/response
-	 * 
-	 * @todo Support for qbXML versions
-	 * 
-	 * @param boolean $compress_empty_elements
-	 * @param string $indent
-	 * @param string $root
+	 *
+	 * @param $request
+	 *   The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
+	 * @param $version
+	 *   @todo Support for qbXML versions
+	 * @param $locale
+	 *   Restrict it to a specific qbXML locale?
+	 * @param $root
+	 *   Unused - @todo: remove this.
 	 * @return string
 	 */
-	//public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_XML_XML_DROP, $indent = "\t", $root = null)
 	public function asQBXML($request, $version = null, $locale = null, $root = null)
 	{
 		$todo_for_empty_elements = QuickBooks_XML::XML_DROP;

--- a/QuickBooks/QBXML/Object/Account.php
+++ b/QuickBooks/QBXML/Object/Account.php
@@ -280,22 +280,6 @@ class QuickBooks_QBXML_Object_Account extends QuickBooks_QBXML_Object
 	}
 	
 	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
 	 * Tell what type of object this is 
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/Bill/ItemLine.php
+++ b/QuickBooks/QBXML/Object/Bill/ItemLine.php
@@ -453,20 +453,6 @@ class QuickBooks_QBXML_Object_Bill_ItemLine extends QuickBooks_QBXML_Object
 		return parent::asArray($request, $nest);
 	}
 	
-	/**
-	 * 
-	 * 
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
 	public function object()
 	{
 		return 'ItemLine';

--- a/QuickBooks/QBXML/Object/BillPaymentCheck.php
+++ b/QuickBooks/QBXML/Object/BillPaymentCheck.php
@@ -407,24 +407,6 @@ class QuickBooks_QBXML_Object_BillPaymentCheck extends QuickBooks_QBXML_Object
 	}
 	
 	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	/*
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	*/
-	
-	/**
 	 * Tell what type of object this is 
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/BillPaymentCheck/AppliedToTxn.php
+++ b/QuickBooks/QBXML/Object/BillPaymentCheck/AppliedToTxn.php
@@ -131,21 +131,6 @@ class QuickBooks_QBXML_Object_BillPaymentCheck_AppliedToTxn extends QuickBooks_Q
 	}
 	
 	/**
-	 * 
-	 * 
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
 	 * Tell the type of object this is
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/Check.php
+++ b/QuickBooks/QBXML/Object/Check.php
@@ -506,20 +506,6 @@ class QuickBooks_QBXML_Object_Check extends QuickBooks_QBXML_Object
 	}
 	
 	/**
-	 * 
-	 * 
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QuickBooks_QBXML_Object::XML_DROP, $indent = "\t", $root = null, $parent = null)
-	{
-		$this->_cleanup();
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
 	 *
 	 */
 	protected function _cleanup()

--- a/QuickBooks/QBXML/Object/Check/ItemLine.php
+++ b/QuickBooks/QBXML/Object/Check/ItemLine.php
@@ -533,20 +533,6 @@ class QuickBooks_QBXML_Object_Check_ItemLine extends QuickBooks_QBXML_Object
 		return parent::asArray($request, $nest);
 	}
 	
-	/**
-	 * 
-	 * 
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
 	public function object()
 	{
 		return 'ItemLine';

--- a/QuickBooks/QBXML/Object/Class.php
+++ b/QuickBooks/QBXML/Object/Class.php
@@ -170,22 +170,6 @@ class QuickBooks_QBXML_Object_Class extends QuickBooks_QBXML_Object
 	}
 	
 	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $version = null, $locale = null, $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $version, $locale, $root);
-	}
-	
-	/**
 	 * Tell what type of object this is 
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/CreditCardRefund.php
+++ b/QuickBooks/QBXML/Object/CreditCardRefund.php
@@ -370,22 +370,6 @@ QuickBooks_Loader::load('/QuickBooks/QBXML/Object.php');
 		$this->_cleanup();
 		return parent::asArray($request, $nest);
 	}
-	
-	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request						The type of request to convert this to (ARRefundCreditCardAddRq, or ARRefundCreditCardQuery)
-	 * @param boolean $todo_for_empty_elements		A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = NULL, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
 
 	public function object()
 	{

--- a/QuickBooks/QBXML/Object/CreditMemo.php
+++ b/QuickBooks/QBXML/Object/CreditMemo.php
@@ -274,21 +274,6 @@ class Quickbooks_QBXML_Object_CreditMemo extends QuickBooks_QBXML_Object
 		return parent::asArray($request, $nest);
 	}
 
-	/**
-	 * 
-	 * 
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QuickBooks_QBXML_Object::XML_DROP, $indent = "\t", $root = null, $parent = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-
 	public function object() {
 		return QUICKBOOKS_OBJECT_CREDITMEMO;
 	}

--- a/QuickBooks/QBXML/Object/CreditMemo/CreditMemoLine.php
+++ b/QuickBooks/QBXML/Object/CreditMemo/CreditMemoLine.php
@@ -140,19 +140,6 @@ class QuickBooks_QBXML_Object_CreditMemo_CreditMemoLine extends QuickBooks_QBXML
 		
 		return parent::asXML($root, $parent, $object);
 	}
-
-	/**
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
 	
 	/**
 	 * Tell the type of object this is

--- a/QuickBooks/QBXML/Object/Customer.php
+++ b/QuickBooks/QBXML/Object/Customer.php
@@ -805,22 +805,6 @@ class QuickBooks_QBXML_Object_Customer extends QuickBooks_QBXML_Object
 	}
 	
 	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $version = null, $locale = null, $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $version, $locale, $root);
-	}
-	
-	/**
 	 * Tell what type of object this is 
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/CustomerType.php
+++ b/QuickBooks/QBXML/Object/CustomerType.php
@@ -180,22 +180,6 @@ class QuickBooks_QBXML_Object_CustomerType extends QuickBooks_QBXML_Object
 	}
 	
 	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
 	 * Tell what type of object this is 
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/DataExt.php
+++ b/QuickBooks/QBXML/Object/DataExt.php
@@ -186,22 +186,6 @@ class QuickBooks_QBXML_Object_DataExt extends QuickBooks_QBXML_Object
 	}
 	
 	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $version = null, $locale = null, $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $version, $locale, $root);
-	}
-	
-	/**
 	 * Tell what type of object this is 
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/Department.php
+++ b/QuickBooks/QBXML/Object/Department.php
@@ -155,22 +155,6 @@ class QuickBooks_QBXML_Object_Department extends QuickBooks_QBXML_Object
 		// @TODO implement parent::asArray
 		return array();
 	}
-
-	/**
-	 * Convert this object to a valid qbXML request
-	 *
-	 * @param string $request The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param string $version
-	 * @param string $locale
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $version = null, $locale = null, $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $version, $locale, $root);
-	}
 	
 	/**
 	 * Tell what type of object this is 

--- a/QuickBooks/QBXML/Object/Deposit.php
+++ b/QuickBooks/QBXML/Object/Deposit.php
@@ -228,20 +228,6 @@ class QuickBooks_QBXML_Object_Deposit extends QuickBooks_QBXML_Object
 	}
 	
 	/**
-	 * 
-	 * 
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null, $parent = null)
-	{
-		$this->_cleanup();
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
 	 *
 	 */
 	protected function _cleanup()

--- a/QuickBooks/QBXML/Object/Deposit/DepositLine.php
+++ b/QuickBooks/QBXML/Object/Deposit/DepositLine.php
@@ -212,20 +212,6 @@ class QuickBooks_QBXML_Object_Deposit_DepositLine extends QuickBooks_QBXML_Objec
 		return parent::asArray($request, $nest);
 	}
 	
-	/**
-	 * 
-	 * 
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
 	public function object()
 	{
 		return 'DepositLine';

--- a/QuickBooks/QBXML/Object/DiscountItem.php
+++ b/QuickBooks/QBXML/Object/DiscountItem.php
@@ -210,22 +210,6 @@ class QuickBooks_QBXML_Object_DiscountItem extends QuickBooks_QBXML_Object
 	}
 	
 	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
 	 * Tell what type of object this is 
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/Employee.php
+++ b/QuickBooks/QBXML/Object/Employee.php
@@ -368,22 +368,6 @@ class QuickBooks_QBXML_Object_Employee extends QuickBooks_QBXML_Object
 	}
 	
 	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request						The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements		A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
 	 * Tell what type of object this is 
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/Estimate.php
+++ b/QuickBooks/QBXML/Object/Estimate.php
@@ -645,21 +645,6 @@ class QuickBooks_QBXML_Object_Estimate extends QuickBooks_QBXML_Object
 	}
 	
 	/**
-	 * 
-	 * 
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null, $parent = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
 	 * Tell the type of object this is
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/Estimate/EstimateLine.php
+++ b/QuickBooks/QBXML/Object/Estimate/EstimateLine.php
@@ -326,21 +326,6 @@ class QuickBooks_QBXML_Object_Estimate_EstimateLine extends QuickBooks_QBXML_Obj
 	}
 	
 	/**
-	 * 
-	 * 
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
 	 * Tell the type of object this is
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/FixedAssetItem.php
+++ b/QuickBooks/QBXML/Object/FixedAssetItem.php
@@ -285,22 +285,6 @@ class QuickBooks_QBXML_Object_FixedAssetItem extends QuickBooks_QBXML_Object
 	}
 	
 	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
 	 * Tell what type of object this is 
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/Generic.php
+++ b/QuickBooks/QBXML/Object/Generic.php
@@ -65,22 +65,6 @@ class QuickBooks_QBXML_Object_Generic extends QuickBooks_QBXML_Object
 	}
 	
 	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
 	 * Tell what type of object this is 
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/GroupItem.php
+++ b/QuickBooks/QBXML/Object/GroupItem.php
@@ -285,22 +285,6 @@ class QuickBooks_QBXML_Object_GroupItem extends QuickBooks_QBXML_Object
 	}
 	
 	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
 	 * Tell what type of object this is 
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/InventoryAdjustment.php
+++ b/QuickBooks/QBXML/Object/InventoryAdjustment.php
@@ -561,21 +561,6 @@ class QuickBooks_QBXML_Object_InventoryAdjustment extends QuickBooks_QBXML_Objec
 
 		return parent::asXML($root, $parent, $object);
 	}
-	/**
-	 * Convert this object to a valid qbXML request
-	 *
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
 
 	/**
 	 * Tell what type of object this is

--- a/QuickBooks/QBXML/Object/InventoryAdjustment/InventoryAdjustmentLine.php
+++ b/QuickBooks/QBXML/Object/InventoryAdjustment/InventoryAdjustmentLine.php
@@ -136,22 +136,6 @@ class QuickBooks_QBXML_Object_InventoryAdjustment_InventoryAdjustmentLine extend
 	}
 
 	/**
-	 * Convert this object to a valid qbXML request
-	 *
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-
-	/**
 	 * Tell what type of object this is
 	 *
 	 * @return string

--- a/QuickBooks/QBXML/Object/InventoryAssemblyItem.php
+++ b/QuickBooks/QBXML/Object/InventoryAssemblyItem.php
@@ -295,22 +295,6 @@ class QuickBooks_QBXML_Object_InventoryAssemblyItem extends QuickBooks_QBXML_Obj
 	}
 	
 	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
 	 * Tell what type of object this is 
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/InventoryItem.php
+++ b/QuickBooks/QBXML/Object/InventoryItem.php
@@ -361,22 +361,6 @@ class QuickBooks_QBXML_Object_InventoryItem extends QuickBooks_QBXML_Object
 	}
 	
 	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $version = null, $locale = null, $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $version, $locale, $root);
-	}
-	
-	/**
 	 * Tell what type of object this is 
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/Invoice.php
+++ b/QuickBooks/QBXML/Object/Invoice.php
@@ -1050,21 +1050,6 @@ class QuickBooks_QBXML_Object_Invoice extends QuickBooks_QBXML_Object
 	}
 	
 	/**
-	 * 
-	 * 
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QuickBooks_QBXML_Object::XML_DROP, $indent = "\t", $root = null, $parent = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
 	 * Tell the type of object this is
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/Invoice/DiscountLine.php
+++ b/QuickBooks/QBXML/Object/Invoice/DiscountLine.php
@@ -98,23 +98,6 @@ class QuickBooks_QBXML_Object_Invoice_DiscountLine extends QuickBooks_QBXML_Obje
 	}
 	
 	/**
-	 * 
-	 * 
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
 	 * Tell the type of object this is
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/Invoice/InvoiceLine.php
+++ b/QuickBooks/QBXML/Object/Invoice/InvoiceLine.php
@@ -399,21 +399,6 @@ class QuickBooks_QBXML_Object_Invoice_InvoiceLine extends QuickBooks_QBXML_Objec
 	}
 	
 	/**
-	 * 
-	 * 
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
 	 * Tell the type of object this is
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/Invoice/SalesTaxLine.php
+++ b/QuickBooks/QBXML/Object/Invoice/SalesTaxLine.php
@@ -95,23 +95,6 @@ class QuickBooks_QBXML_Object_Invoice_SalesTaxLine extends QuickBooks_QBXML_Obje
 	}
 	
 	/**
-	 * 
-	 * 
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
 	 * Tell the type of object this is
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/Invoice/ShippingLine.php
+++ b/QuickBooks/QBXML/Object/Invoice/ShippingLine.php
@@ -90,23 +90,6 @@ class QuickBooks_QBXML_Object_Invoice_ShippingLine extends QuickBooks_QBXML_Obje
 	}
 	
 	/**
-	 * 
-	 * 
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
 	 * Tell the type of object this is
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/Item.php
+++ b/QuickBooks/QBXML/Object/Item.php
@@ -221,22 +221,6 @@ class QuickBooks_QBXML_Object_Item extends QuickBooks_QBXML_Object
 	}
 	
 	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $version = null, $locale = null, $root = null)
-  {
-    $this->_cleanup();
-    
-    return parent::asQBXML($request, $version, $locale, $root);
-  }
-	
-	/**
 	 * Tell what type of object this is 
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/ItemReceipt.php
+++ b/QuickBooks/QBXML/Object/ItemReceipt.php
@@ -446,21 +446,6 @@ class QuickBooks_QBXML_Object_ItemReceipt extends QuickBooks_QBXML_Object
 
 		return parent::asXML($root, $parent, $object);
 	}
-	/**
-	 * Convert this object to a valid qbXML request
-	 *
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
 
 	/**
 	 * Tell what type of object this is

--- a/QuickBooks/QBXML/Object/ItemReceipt/ExpenseLine.php
+++ b/QuickBooks/QBXML/Object/ItemReceipt/ExpenseLine.php
@@ -170,22 +170,6 @@ class QuickBooks_QBXML_Object_ItemReceipt_ExpenseLine extends QuickBooks_QBXML_O
 	}
 
 	/**
-	 * Convert this object to a valid qbXML request
-	 *
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-
-	/**
 	 * Tell what type of object this is
 	 *
 	 * @return string

--- a/QuickBooks/QBXML/Object/ItemReceipt/ItemGroupLine.php
+++ b/QuickBooks/QBXML/Object/ItemReceipt/ItemGroupLine.php
@@ -117,22 +117,6 @@ class QuickBooks_QBXML_Object_ItemReceipt_ItemGroupLine extends QuickBooks_QBXML
 	}
 
 	/**
-	 * Convert this object to a valid qbXML request
-	 *
-	 * @param string $request The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-
-	/**
 	 * Tell what type of object this is
 	 *
 	 * @return string

--- a/QuickBooks/QBXML/Object/ItemReceipt/ItemLine.php
+++ b/QuickBooks/QBXML/Object/ItemReceipt/ItemLine.php
@@ -267,22 +267,6 @@ class QuickBooks_QBXML_Object_ItemReceipt_ItemLine extends QuickBooks_QBXML_Obje
 	}
 
 	/**
-	 * Convert this object to a valid qbXML request
-	 *
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-
-	/**
 	 * Tell what type of object this is
 	 *
 	 * @return string

--- a/QuickBooks/QBXML/Object/NonInventoryItem.php
+++ b/QuickBooks/QBXML/Object/NonInventoryItem.php
@@ -405,22 +405,6 @@ class QuickBooks_QBXML_Object_NonInventoryItem extends QuickBooks_QBXML_Object
 	}
 	
 	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $version = null, $locale = null, $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $version, $locale, $root);
-	}
-	
-	/**
 	 * Tell what type of object this is 
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/OtherChargeItem.php
+++ b/QuickBooks/QBXML/Object/OtherChargeItem.php
@@ -481,22 +481,6 @@ class QuickBooks_QBXML_Object_OtherChargeItem extends QuickBooks_QBXML_Object
 	}
 	
 	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
 	 * Tell what type of object this is 
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/PaymentItem.php
+++ b/QuickBooks/QBXML/Object/PaymentItem.php
@@ -483,22 +483,6 @@ class QuickBooks_QBXML_Object_PaymentItem extends QuickBooks_QBXML_Object
 	}
 	
 	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
 	 * Tell what type of object this is 
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/PaymentMethod.php
+++ b/QuickBooks/QBXML/Object/PaymentMethod.php
@@ -123,22 +123,6 @@ class QuickBooks_QBXML_Object_PaymentMethod extends QuickBooks_QBXML_Object
 	}
 	
 	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
 	 * Tell what type of object this is 
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/ReceivePayment.php
+++ b/QuickBooks/QBXML/Object/ReceivePayment.php
@@ -519,24 +519,6 @@ class QuickBooks_QBXML_Object_ReceivePayment extends QuickBooks_QBXML_Object
 	}
 	
 	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	/*
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	*/
-	
-	/**
 	 * Tell what type of object this is 
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/ReceivePayment/AppliedToTxn.php
+++ b/QuickBooks/QBXML/Object/ReceivePayment/AppliedToTxn.php
@@ -126,21 +126,6 @@ class QuickBooks_QBXML_Object_ReceivePayment_AppliedToTxn extends QuickBooks_QBX
 	}
 	
 	/**
-	 * 
-	 * 
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
 	 * Tell the type of object this is
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/SalesOrder.php
+++ b/QuickBooks/QBXML/Object/SalesOrder.php
@@ -774,23 +774,6 @@ class QuickBooks_QBXML_Object_SalesOrder extends QuickBooks_QBXML_Object
 		
 		return parent::asArray($request, $nest);
 	}
-
-	/**
-	 *
-	 *
-	 * @param        $request
-	 * @param null   $version
-	 * @param null   $locale
-	 * @param string $root
-	 *
-	 * @return string
-	 */
-	public function asQBXML($request, $version = null, $locale = null, $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $version, $locale, $root);
-	}
 	
 	/**
 	 * Tell the type of object this is

--- a/QuickBooks/QBXML/Object/SalesOrder/SalesOrderLine.php
+++ b/QuickBooks/QBXML/Object/SalesOrder/SalesOrderLine.php
@@ -300,21 +300,6 @@ class QuickBooks_QBXML_Object_SalesOrder_SalesOrderLine extends QuickBooks_QBXML
 	}
 	
 	/**
-	 * 
-	 * 
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
 	 * Tell the type of object this is
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/SalesReceipt.php
+++ b/QuickBooks/QBXML/Object/SalesReceipt.php
@@ -830,21 +830,6 @@ class QuickBooks_QBXML_Object_SalesReceipt extends QuickBooks_QBXML_Object
 	}
 	
 	/**
-	 * 
-	 * 
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $version = null, $locale = null, $root = null, $parent = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $version, $locale, $root);
-	}
-	
-	/**
 	 * Tell the type of object this is
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/SalesReceipt/DiscountLine.php
+++ b/QuickBooks/QBXML/Object/SalesReceipt/DiscountLine.php
@@ -95,23 +95,6 @@ class QuickBooks_QBXML_Object_SalesReceipt_DiscountLine extends QuickBooks_QBXML
 	}
 	
 	/**
-	 * 
-	 * 
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
 	 * Tell the type of object this is
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/SalesReceipt/SalesReceiptLine.php
+++ b/QuickBooks/QBXML/Object/SalesReceipt/SalesReceiptLine.php
@@ -217,23 +217,6 @@ class QuickBooks_QBXML_Object_SalesReceipt_SalesReceiptLine extends QuickBooks_Q
 	}
 	
 	/**
-	 * 
-	 * 
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	/*public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}*/
-	
-	/**
 	 * Tell the type of object this is
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/SalesReceipt/SalesTaxLine.php
+++ b/QuickBooks/QBXML/Object/SalesReceipt/SalesTaxLine.php
@@ -92,23 +92,6 @@ class QuickBooks_QBXML_Object_SalesReceipt_SalesTaxLine extends QuickBooks_QBXML
 	}
 	
 	/**
-	 * 
-	 * 
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
 	 * Tell the type of object this is
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/SalesReceipt/ShippingLine.php
+++ b/QuickBooks/QBXML/Object/SalesReceipt/ShippingLine.php
@@ -85,24 +85,7 @@ class QuickBooks_QBXML_Object_SalesReceipt_ShippingLine extends QuickBooks_QBXML
 		
 		return parent::asXML($root, $parent, $object);
 	}
-	
-	/**
-	 * 
-	 * 
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
+
 	/**
 	 * Tell the type of object this is
 	 * 

--- a/QuickBooks/QBXML/Object/SalesRep.php
+++ b/QuickBooks/QBXML/Object/SalesRep.php
@@ -102,22 +102,6 @@ class QuickBooks_QBXML_Object_SalesRep extends QuickBooks_QBXML_Object
 	}
 	
 	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $version = null, $locale = null, $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $version = null, $locale = null, $root);
-	}
-	
-	/**
 	 * Tell what type of object this is 
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/SalesTaxGroupItem.php
+++ b/QuickBooks/QBXML/Object/SalesTaxGroupItem.php
@@ -129,20 +129,6 @@ class QuickBooks_QBXML_Object_SalesTaxGroupItem extends QuickBooks_QBXML_Object
 	}
 	
 	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $version = null, $locale = null, $root = null)
-	{
-		return parent::asQBXML($request, $version, $locale, $root);
-	}
-	
-	/**
 	 * Tell what type of object this is 
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/SalesTaxItem.php
+++ b/QuickBooks/QBXML/Object/SalesTaxItem.php
@@ -166,22 +166,6 @@ class QuickBooks_QBXML_Object_SalesTaxItem extends QuickBooks_QBXML_Object
 	}
 	
 	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
 	 * Tell what type of object this is 
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/ServiceItem.php
+++ b/QuickBooks/QBXML/Object/ServiceItem.php
@@ -530,22 +530,6 @@ class QuickBooks_QBXML_Object_ServiceItem extends QuickBooks_QBXML_Object
 	}
 	
 	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $version = null, $locale = null, $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $version, $locale, $root);
-	}
-	
-	/**
 	 * Tell what type of object this is 
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/ShipMethod.php
+++ b/QuickBooks/QBXML/Object/ShipMethod.php
@@ -151,22 +151,6 @@ class QuickBooks_QBXML_Object_ShipMethod extends QuickBooks_QBXML_Object
 	}
 	
 	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $version = null, $locale = null, $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $version = null, $locale = null, $root);
-	}
-	
-	/**
 	 * Tell what type of object this is 
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/StandardTerms.php
+++ b/QuickBooks/QBXML/Object/StandardTerms.php
@@ -198,22 +198,6 @@ class QuickBooks_QBXML_Object_StandardTerms extends QuickBooks_QBXML_Object
 	}
 	
 	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
 	 * Tell what type of object this is 
 	 * 
 	 * @return string

--- a/QuickBooks/QBXML/Object/Vendor.php
+++ b/QuickBooks/QBXML/Object/Vendor.php
@@ -375,22 +375,6 @@ class QuickBooks_QBXML_Object_Vendor extends QuickBooks_QBXML_Object
 	}
 	
 	/**
-	 * Convert this object to a valid qbXML request
-	 * 
-	 * @param string $request					The type of request to convert this to (examples: CustomerAddRq, CustomerModRq, CustomerQueryRq)
-	 * @param boolean $todo_for_empty_elements	A constant, one of: QUICKBOOKS_XML_XML_COMPRESS, QUICKBOOKS_XML_XML_DROP, QUICKBOOKS_XML_XML_PRESERVE
-	 * @param string $indent
-	 * @param string $root
-	 * @return string
-	 */
-	public function asQBXML($request, $todo_for_empty_elements = QUICKBOOKS_OBJECT_XML_DROP, $indent = "\t", $root = null)
-	{
-		$this->_cleanup();
-		
-		return parent::asQBXML($request, $todo_for_empty_elements, $indent, $root);
-	}
-	
-	/**
 	 * Tell what type of object this is 
 	 * 
 	 * @return string


### PR DESCRIPTION
Overview:

- Fix QuickBooks_QBXML_Object::asQBXML() doc block to reference correct arguments
- Drop unused $root argument.
- Remove redundant (and incorrect) asQBXML() implementations from subclasses (more explanation below)

Note: This is a simplified and more focused version of #194.
My version stays focused on the asQBXML() method for now, and I've kept the commits clean and hopefully easy to follow.
However, @cmancone is correct that _cleanup() and asArray() have similar issues.


**Why are the subclassed implementations Redundant?**
These copies all simply invoke the _cleanup() method and delegate back to the central QuickBooks_QBXML_Object::asQBXML() which already calls the _cleanup() method.
_Also note: in most cases _cleanup() is an empty function anyway._


**Many of these methods are also using incorrect function arguments and undefined constants.**
$todo_for_empty_elements was passed into the $version argument of the parent method.
The default value QUICKBOOKS_OBJECT_XML_DROP is undefined and PHP interprets this as the string literal 'QUICKBOOKS_OBJECT_XML_DROP'.
This hasn't caused issues because that argument is effectively unused by the parent method. (There is an if block that checks it, but it does nothing)

$indent was being passed into $locale in the parent method.
The default value "\t" is technically one character and the parent method ignores anything that isn't exactly 2 characters.


**Effect of dropping the method overrides:**
- The base implementation will be called instead.
- _cleanup() will only be called once.
- $version will default to null instead of 'QUICKBOOKS_OBJECT_XML_DROP'  (it is ignored anyway, so no change)
- $locale will default to null instead of "\t" (no change in outcome)
- If any caller passes other values, they would still pass through the same with no change in outcome.


**Related:**
There are several other issues and pull requests related undefined constants.
This pull request would at least partially address many of them.

Here's a few:
#15 
#126 
#127
#185
#194 
#260 





